### PR TITLE
fix(SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001): belt/capacity gauges now count what a worker can actually auto-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Table of Contents
 
+- [2026-08-15](#2026-08-15)
+  - [Infrastructure](#infrastructure)
 - [2026-08-14](#2026-08-14)
   - [Bugfix](#bugfix)
 - [2026-08-12](#2026-08-12)
@@ -113,6 +115,14 @@
   - [Housekeeping & CI](#housekeeping-ci)
   - [EHG_Engineering](#ehg_engineering)
   - [EHG (Venture App)](#ehg-venture-app)
+
+## 2026-08-15
+
+### Infrastructure
+- **Belt/capacity gauges counted 173 "claimable" quick-fixes while a worker could actually auto-start 0 of them** - PR #7040 (SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001)
+  - **What was broken**: the worker `/checkin` self-claim path (`isAutoStartableQF` in `scripts/worker-checkin.cjs`) decides which `quick_fixes` a worker can auto-claim via a strict predicate (excludes stale/factory-lane/chairman-gated/risk-keyword/fixture rows). The belt-depth and capacity-forecast gauges (`lib/fleet/belt-depth.cjs`, `scripts/lib/capacity-inputs.mjs`) answered the same question with a much looser predicate (`lib/coordinator/qf-supply-predicate.cjs`'s `applyClaimableQfFilter`: unclaimed + `status='open'` only) — a single-representation violation between two "can a worker take this" answers. Measured live: the gauge reported 173, the worker predicate would start 0.
+  - **Fixed**: extracted the worker's predicate into a new shared module, `lib/fleet/qf-auto-start.cjs` (decision-logic-identical move, verified against the full pre-existing QF behavior-pinning suite plus a character-by-character diff). Added `countAutoStartableQuickFixes` to `lib/fleet/belt-depth.cjs`, reusing that predicate with a fail-loud contract (an unreadable table throws, never resolves to a healthy-looking 0 — including the degenerate PostgREST `{data:null,error:null}` missing-relation shape) and the same `factory_lane`-42703 staged-migration fallback the worker path already carries. `countBeltDepth` and `scripts/lib/capacity-inputs.mjs` now both source their QF term from it. `countClaimableQuickFixes`, `lib/coordinator/qf-supply-predicate.cjs`, and `lib/governance/qf-mint-gate.mjs` are all deliberately untouched — different consumers, different contracts (verified zero diff on the latter two).
+  - **Verification**: live re-measured post-fix — `countClaimableQuickFixes` (old, still used by the mint gate) reads 173 against the same table `countAutoStartableQuickFixes` (new) reads 0 on; `node scripts/coordinator-capacity-forecast.mjs` now reports the belt as `17 SD + 0 QF` instead of folding 173 phantom QFs in. Full pre-existing QF test suite passes with zero modification; new/updated tests pin the divergence between the two predicates as a deliberate, enforced requirement rather than a fixture-table accident.
 
 ## 2026-08-14
 

--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -23,6 +23,12 @@ const { classifyDispatchIneligibility, draftDepsSatisfied, parentLeadPending } =
 // The QF claimability predicate is OWNED by the coordinator's supply module. Imported, never
 // restated — see countClaimableQuickFixes below for why a local copy would be a gate failure.
 const { applyClaimableQfFilter } = require('../coordinator/qf-supply-predicate.cjs');
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-3): the WORKER auto-start predicate —
+// deliberately narrower than applyClaimableQfFilter (which is also fixture-blind by omission
+// for a DIFFERENT consumer, detectThunderingHerd — see qf-supply-predicate.cjs's own docblock
+// for why the two must stay independent). Imported, never restated, for the same reason as
+// applyClaimableQfFilter above: a local copy is how two consumers drift.
+const { isAutoStartableQF } = require('./qf-auto-start.cjs');
 
 // The columns classifyDispatchIneligibility's axes actually read. Kept explicit (not select('*'))
 // so a schema change that drops one fails loudly here rather than silently un-gating a row.
@@ -233,6 +239,64 @@ async function countClaimableQuickFixes(supabase, scope) {
   return count;
 }
 
+// Columns isAutoStartableQF's row-level checks read, mirroring scripts/worker-checkin.cjs's
+// QF_CANDIDATE_COLUMNS (selfClaimQuickFix) minus `severity` (only isCriticalQfJumpEligible
+// reads that, which is a priority-ordering concern, not part of the auto-start predicate).
+const AUTO_START_CANDIDATE_COLUMNS = 'id, status, pr_url, commit_sha, created_at, routing_tier, title, description, not_before, factory_lane, owner, release_condition, target_application';
+const AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE = AUTO_START_CANDIDATE_COLUMNS.replace(', factory_lane', '');
+
+/**
+ * Fetch the raw candidate rows countAutoStartableQuickFixes filters in memory. Split out so the
+ * factory_lane probe stays a single LIMIT-1 round trip regardless of how many pages the real
+ * fetch needs — factory_lane's existence doesn't vary per row, so probing once and reusing the
+ * confirmed column list for the full paginated fetch is correct, not just cheaper.
+ */
+async function fetchAutoStartCandidateRows(supabase, scope) {
+  const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');
+  const applyFilters = (q) => {
+    let out = q.eq('status', 'open').is('pr_url', null).is('commit_sha', null);
+    if (scope !== undefined && scope !== null) out = out.eq('target_application', scope);
+    return out;
+  };
+  // factory_lane is a staged, not-yet-applied column (database/migrations/
+  // 20260713_quick_fixes_factory_lane.sql) — same condition scripts/worker-checkin.cjs's
+  // selfClaimQuickFix already retries around (QF-20260720-763). fetchAllPaginated throws on any
+  // page error, wrapping it as a plain Error (losing .code), so the retry-on-42703 decision has
+  // to be made BEFORE handing a queryFactory to it — hence this cheap LIMIT-1 probe on the raw
+  // client, where the real PostgREST error.code is still available. A non-42703 probe error is a
+  // genuine failure and propagates (fail-loud, matching fetchAllPaginated's own contract).
+  const probe = await applyFilters(supabase.from('quick_fixes').select(AUTO_START_CANDIDATE_COLUMNS)).limit(1);
+  if (probe.error && probe.error.code !== '42703') throw probe.error;
+  const columns = probe.error ? AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE : AUTO_START_CANDIDATE_COLUMNS;
+  return fetchAllPaginated(() => applyFilters(supabase.from('quick_fixes').select(columns)));
+}
+
+/**
+ * QF-side depth, WORKER-AUTO-START definition: quick_fixes a worker's /checkin self-claim path
+ * would actually pick up right now. NOT interchangeable with countClaimableQuickFixes — that
+ * reading is deliberately looser (unclaimed + open-ish status only; see
+ * lib/coordinator/qf-supply-predicate.cjs's docblock for why detectThunderingHerd needs the wider
+ * count). This is the same isAutoStartableQF predicate worker-checkin.cjs's self-claim loop runs,
+ * so a "belt depth" that includes stale/factory-lane/chairman-gated/risk-flagged rows a worker
+ * would never actually reach stops happening. SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001.
+ *
+ * FAIL-LOUD, same contract as countClaimableQuickFixes and countDispatchableBacklog: an unreadable
+ * belt must never present as an empty one. fetchAutoStartCandidateRows propagates any real query
+ * error; this function does the JS-side filtering only after that succeeds.
+ *
+ * @param {object} supabase
+ * @returns {Promise<number>} count of quick_fixes rows isAutoStartableQF admits right now
+ */
+async function countAutoStartableQuickFixes(supabase, scope) {
+  if (scope !== undefined && scope !== null) {
+    requireResolvableLane(scope);
+    await assertLaneUnambiguous(supabase, 'quick_fixes', scope);
+  }
+  const rows = await fetchAutoStartCandidateRows(supabase, scope);
+  const nowMs = Date.now();
+  return (rows || []).filter((row) => isAutoStartableQF(row, nowMs)).length;
+}
+
 /**
  * Both readings together, for a caller that legitimately wants claimable WORK rather than claimable
  * SDs. `total` is the sum and is NOT interchangeable with sdDepth — a consumer that swaps one for
@@ -243,8 +307,16 @@ async function countClaimableQuickFixes(supabase, scope) {
  */
 async function countBeltDepth(supabase, scope) {
   const sd = await countDispatchableBacklog(supabase, scope);
-  const qfDepth = await countClaimableQuickFixes(supabase, scope);
+  // SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-3): was countClaimableQuickFixes (the
+  // looser "unclaimed + open-ish" reading). Belt depth is supposed to answer "how much work is
+  // actually there for a worker to pick up" — countAutoStartableQuickFixes is the reading that
+  // matches what a worker's self-claim loop would really take. countClaimableQuickFixes itself is
+  // untouched: lib/governance/qf-mint-gate.mjs still calls it directly for its own contract (a
+  // mint-floor supply gauge, not a belt-depth reading). scripts/lib/capacity-inputs.mjs's OWN
+  // QF term was ALSO switched to countAutoStartableQuickFixes (FR-4) — it has no remaining call
+  // to countClaimableQuickFixes at all.
+  const qfDepth = await countAutoStartableQuickFixes(supabase, scope);
   return { sdDepth: sd.dispatchable, qfDepth, total: sd.dispatchable + qfDepth, raw: sd.raw, ineligible: sd.ineligible };
 }
 
-module.exports = { countDispatchableBacklog, countClaimableQuickFixes, countBeltDepth, ELIGIBILITY_COLUMNS };
+module.exports = { countDispatchableBacklog, countClaimableQuickFixes, countAutoStartableQuickFixes, countBeltDepth, ELIGIBILITY_COLUMNS };

--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -267,6 +267,17 @@ async function fetchAutoStartCandidateRows(supabase, scope) {
   // genuine failure and propagates (fail-loud, matching fetchAllPaginated's own contract).
   const probe = await applyFilters(supabase.from('quick_fixes').select(AUTO_START_CANDIDATE_COLUMNS)).limit(1);
   if (probe.error && probe.error.code !== '42703') throw probe.error;
+  // TR-1: countClaimableQuickFixes's SEC-GSB-1 contract exists because a missing relation can come
+  // back as {count:null, error:null} under head:true — a non-array/null successful-looking response
+  // with no error at all. fetchAllPaginated's own defensive `Array.isArray(data) ? data : []`
+  // coercion (lib/db/fetch-all-paginated.mjs:40) shows the same shape is a live enough concern for a
+  // plain row-select that its own author guarded it — silently, in the fail-open direction. This
+  // probe is the one place that shape is still checkable (fetchAllPaginated discards it inside its
+  // own loop), so it is checked HERE: no error but data isn't an array is treated as a failed
+  // measurement, not an empty table.
+  if (!probe.error && !Array.isArray(probe.data)) {
+    throw new Error(`countAutoStartableQuickFixes: probe returned data=${JSON.stringify(probe.data)} with no error — refusing to treat an unreadable quick_fixes table as empty`);
+  }
   const columns = probe.error ? AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE : AUTO_START_CANDIDATE_COLUMNS;
   return fetchAllPaginated(() => applyFilters(supabase.from('quick_fixes').select(columns)));
 }

--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -253,8 +253,22 @@ const AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE = AUTO_START_CANDIDATE_COLUMN
  */
 async function fetchAutoStartCandidateRows(supabase, scope) {
   const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');
+  // Adversarial-review finding (deep-tier /ship gate, PR #7040): isAutoStartableQF does not
+  // inspect claiming_session_id (it mirrors scripts/worker-checkin.cjs's selfClaimQuickFix
+  // candidate query, which relies on claim_sd flipping status to 'in_progress' atomically with
+  // the claimant) -- safe for the WORKER, whose downstream claim_sd RPC call is the real
+  // arbiter and simply skips a row it can't claim. This gauge has no such downstream arbiter; a
+  // status='open'-but-claimed row (a reachable state -- lib/checkin/steps/resume.cjs handles it
+  // explicitly, lib/fleet/best-effort-release.mjs writes status/claimant separately) would be
+  // over-counted. countClaimableQuickFixes (this function's predecessor here) already applied
+  // this filter via applyClaimableQfFilter -- dropping it silently reopens the exact defect
+  // class SD-LEO-INFRA-GATE-SIDE-BELT-001 fixed ("IGNORED claiming_session_id ... over-reporting
+  // by 3", quoted in capacity-inputs.mjs next to this gauge's own call site). Filtering it can
+  // only REDUCE the count -- the safe direction for a gauge answering "how much is really
+  // there" -- so it is added at the query level even though the worker's own candidate query
+  // does not carry it.
   const applyFilters = (q) => {
-    let out = q.eq('status', 'open').is('pr_url', null).is('commit_sha', null);
+    let out = q.eq('status', 'open').is('pr_url', null).is('commit_sha', null).is('claiming_session_id', null);
     if (scope !== undefined && scope !== null) out = out.eq('target_application', scope);
     return out;
   };
@@ -267,18 +281,38 @@ async function fetchAutoStartCandidateRows(supabase, scope) {
   // genuine failure and propagates (fail-loud, matching fetchAllPaginated's own contract).
   const probe = await applyFilters(supabase.from('quick_fixes').select(AUTO_START_CANDIDATE_COLUMNS)).limit(1);
   if (probe.error && probe.error.code !== '42703') throw probe.error;
+  // Adversarial-review finding (deep-tier /ship gate, PR #7040), CRITICAL: the first cut of this
+  // guard only ran in the `!probe.error` branch below -- but on LIVE PRODUCTION the probe ALWAYS
+  // hits 42703 (factory_lane genuinely does not exist yet), so probe.error is truthy on every
+  // real call and that guard never fired. The column list that actually gets used
+  // (AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE) was never itself probed -- it went straight
+  // into fetchAllPaginated, whose own `Array.isArray(data) ? data : []` coercion
+  // (lib/db/fetch-all-paginated.mjs:40) would have silently turned a genuine {data:null,
+  // error:null} failure into a healthy-looking 0, exactly the fail-open direction TR-1 exists to
+  // close. Fix: re-probe with the CONFIRMED column list before trusting it, so the shape check
+  // below always covers the query fetchAllPaginated is about to run, not a discarded first
+  // attempt.
+  let columns = AUTO_START_CANDIDATE_COLUMNS;
+  let confirmedProbeData = probe.data;
+  if (probe.error) {
+    columns = AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE;
+    const retryProbe = await applyFilters(supabase.from('quick_fixes').select(columns)).limit(1);
+    // A second failure here is never the expected 42703 (factory_lane is already excluded) --
+    // always a genuine, unanticipated failure. Fail loud.
+    if (retryProbe.error) throw retryProbe.error;
+    confirmedProbeData = retryProbe.data;
+  }
   // TR-1: countClaimableQuickFixes's SEC-GSB-1 contract exists because a missing relation can come
   // back as {count:null, error:null} under head:true — a non-array/null successful-looking response
   // with no error at all. fetchAllPaginated's own defensive `Array.isArray(data) ? data : []`
   // coercion (lib/db/fetch-all-paginated.mjs:40) shows the same shape is a live enough concern for a
   // plain row-select that its own author guarded it — silently, in the fail-open direction. This
   // probe is the one place that shape is still checkable (fetchAllPaginated discards it inside its
-  // own loop), so it is checked HERE: no error but data isn't an array is treated as a failed
-  // measurement, not an empty table.
-  if (!probe.error && !Array.isArray(probe.data)) {
-    throw new Error(`countAutoStartableQuickFixes: probe returned data=${JSON.stringify(probe.data)} with no error — refusing to treat an unreadable quick_fixes table as empty`);
+  // own loop), so it is checked HERE, against the CONFIRMED column list: no error but data isn't an
+  // array is treated as a failed measurement, not an empty table.
+  if (!Array.isArray(confirmedProbeData)) {
+    throw new Error(`countAutoStartableQuickFixes: probe returned data=${JSON.stringify(confirmedProbeData)} with no error — refusing to treat an unreadable quick_fixes table as empty`);
   }
-  const columns = probe.error ? AUTO_START_CANDIDATE_COLUMNS_NO_FACTORY_LANE : AUTO_START_CANDIDATE_COLUMNS;
   return fetchAllPaginated(() => applyFilters(supabase.from('quick_fixes').select(columns)));
 }
 

--- a/lib/fleet/qf-auto-start.cjs
+++ b/lib/fleet/qf-auto-start.cjs
@@ -1,0 +1,118 @@
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-1): extracted from
+// scripts/worker-checkin.cjs so belt-depth accounting (lib/fleet/belt-depth.cjs) can share
+// the SAME predicate the worker claim path uses, instead of the looser
+// lib/coordinator/qf-supply-predicate.cjs (which deliberately excludes only fixture rows —
+// not staleness/tier/factory-lane/chairman-gate — for a different consumer,
+// detectThunderingHerd). Moved verbatim; behavior is byte-identical to the pre-extraction
+// inline version. worker-checkin.cjs now imports isAutoStartableQF from here (FR-2).
+//
+/**
+ * Pure predicate: is this quick_fixes row safe to AUTO-start via the worker
+ * self-claim path? Mirrors (inverts) the verify-first gate in
+ * scripts/modules/sd-next/display/quick-fixes.js. Re-implemented INLINE because
+ * this predicate is CommonJS and that module is ESM (package.json type:module),
+ * so it cannot be require()d there. SD-LEO-INFRA-MAKE-OPEN-QFS-001.
+ *
+ * *** CORRECTION (SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001). THE REASON ABOVE IS FALSE, AND
+ * BELIEVING IT COST FOUR INCOMPLETE FIXES. *** CJS can require ESM: it has been stable
+ * since Node 22.12 and this fleet runs 24. It was tested, not assumed — requiring the ESM
+ * parseAsUTC from a .cjs returns a working function. The retained text above is left
+ * visible rather than deleted because it is the primary evidence for WHY the timezone bug
+ * class survived four separate fixes without ever reaching this file: each pass read this
+ * docblock, believed reuse was impossible here, and stopped.
+ *
+ * The one real limit is narrower: require() fails with ERR_REQUIRE_ASYNC_MODULE against a
+ * module carrying a TOP-LEVEL AWAIT. That is why the canonical normalizer lives at
+ * lib/time/pg-timestamp.cjs — a CJS home carries no such constraint, and ESM can import
+ * CJS unconditionally.
+ *
+ * THE DUPLICATION ITSELF IS STILL REAL and is NOT resolved by this SD: this predicate and
+ * scripts/modules/sd-next/display/quick-fixes.js:275 remain independent implementations
+ * that both carried the identical timezone defect. Consolidating them is follow-on work.
+ */
+
+// SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: quick_fixes.created_at is `timestamp without time zone`,
+// so PostgREST returns it with no designator and Date.parse reads it as LOCAL — shifting every
+// age below by the host's UTC offset. Canonical normalizer, deliberately CJS so this file can
+// require it directly.
+const { pgTimestampMs } = require('../time/pg-timestamp.cjs');
+// SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: canonical chairman-gated-hold predicate (shared
+// with sd-next data-loaders + the coordinator dashboard so the sites can never drift).
+const { isChairmanGatedQF } = require('./qf-gated-hold.cjs');
+
+// TR-3: this is a shared home for the WORKER's copy only, NOT a full consolidation.
+// scripts/modules/sd-next/display/quick-fixes.js:36 independently re-reads the same
+// SD_NEXT_QF_STALE_DAYS env var into its own STALE_QF_DAYS constant (ESM, that module cannot
+// require() this CJS file without becoming this SD's third cross-module-type merge). Two live
+// representations of the same threshold, not one — a future reader should not assume moving the
+// worker-checkin.cjs copy here unified all copies.
+const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
+
+// Tier-3 risk keywords (CLAUDE.md Work Item Routing). Auto-self-claim is for small,
+// low-risk QFs only. The sd-next display path excludes _escalate via a LIVE re-triage
+// (runTriageGate, ESM); a .cjs can't run that pipeline, so we approximate parity with the
+// PERSISTED routing_tier PLUS this keyword scan — holding risk-bearing QFs for the
+// triage/human path. SD-LEO-INFRA-MAKE-OPEN-QFS-001 (SECURITY re-triage-parity advisory).
+const TIER3_RISK_RE = /\b(auth|authentication|authorization|rls|payments?|credentials?|migration|schema|alter\s+table|create\s+table|drop\s+table)\b/i;
+
+function isAutoStartableQF(qf, nowMs) {
+  if (!qf || qf.status !== 'open') return false;
+  // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-C FR-1: fixture rows are never self-claimable.
+  //
+  // THIS IS THE CONSEQUENTIAL SITE IN THE WHOLE SD. Everywhere else an unfiltered fixture row makes
+  // a number wrong; HERE it is handed to a REAL WORKER, who then builds against a row that was never
+  // real work. The other converted surfaces protect gauges — this one protects a person's afternoon.
+  //
+  // The defect was INCONSISTENCY, not absence: five surfaces already filter quick_fixes with this
+  // exact predicate (recursion-governor.js:128, adam-github-assessment.mjs:136,
+  // adam-self-adherence-review.mjs:105, fleet-dashboard.cjs:476 and sd-next/data-loaders.js:473 —
+  // the dispatch queue itself) while the CLAIM PATH did not. Five consumers agreed on a convention
+  // and the door that hands out work was left out of it.
+  //
+  // ADDED, never substituted: every exclusion below is a different concern and all of them still run.
+  // Degrade-safe like the surrounding predicate, but LOUDLY — an unreported fallback here is
+  // indistinguishable from a working filter, and this is the last gate before a worker is dispatched.
+  try {
+    const { isFixtureQf } = require('../governance/fixture-exclusion.mjs');
+    if (isFixtureQf(qf)) return false;
+  } catch (e) {
+    console.error(`[qf-auto-start] fixture predicate unavailable — self-claim UNFILTERED: ${e?.message || e}`);
+  }
+  if (qf.pr_url || qf.commit_sha) return false;        // already in PR/commit (verify-first / merge-race guard)
+  // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: quick_fixes.factory_lane is the structured
+  // "coordinator-dispatch only, not worker-self-claimable" marker (replaces the pre-fix free-text
+  // "FACTORY-LANE:" convention buried in description, which this predicate could not see -- live
+  // incident: QF-20260712-481 self-claimed despite being factory-lane). Fail-closed: any truthy
+  // value excludes; only exactly false (the column default) allows self-claim.
+  if (qf.factory_lane) return false;
+  if (qf.routing_tier != null && Number(qf.routing_tier) >= 3) return false;  // persisted Tier-3 -> full SD, not auto-QF
+  // QF-20260725-244: scan TITLE **and** DESCRIPTION. Title-only let QF-20260725-096 through --
+  // an auth/security QF whose implied fix ("thread the internal API key into the fetch headers")
+  // would publish an app-wide admin-bypass secret to an UNAUTHENTICATED page. Its title reads
+  // "internal-API-key", which has no word-boundary `auth`, while its description is saturated
+  // with auth / authorization / credential. Verified by executing this exact regex against that
+  // row: title=false, description=true. scripts/classify-quick-fix.js already gates on
+  // DESCRIPTION and FAILS that QF, so description is the correct surface -- reading the title
+  // alone is what let the two surfaces disagree. `description` is already in
+  // QF_CANDIDATE_COLUMNS, so this needs no query change.
+  if (TIER3_RISK_RE.test(`${qf.title || ''} ${qf.description || ''}`)) return false; // risk-keyword drift -> hold for triage/human
+  // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: durable time-gated defer -- a QF genuinely not ready
+  // yet (e.g. needs a clean 24h observation window) stays status='open' but is ineligible
+  // for claim until not_before passes. Prevents the same worker re-claiming it every cycle.
+  if (qf.not_before) {
+    const notBefore = Date.parse(qf.not_before);
+    if (Number.isFinite(notBefore) && notBefore > nowMs) return false;
+  }
+  // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: chairman-gated hold (owner='chairman' +
+  // release_condition) -- the QF-508/QF-970 class whose APPLY awaits a chairman condition.
+  // Stays status='open' but is false open work for a worker: exclude until released via
+  // scripts/release-chairman-gated-qf.js. Visible on the coordinator surface, never lost.
+  if (isChairmanGatedQF(qf)) return false;
+  // SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: naive created_at, see the require at the top of this file.
+  const created = qf.created_at ? pgTimestampMs(qf.created_at) : NaN;
+  if (!Number.isFinite(created)) return false;
+  const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
+  return ageDays < STALE_QF_DAYS;                       // exclude stale/verify-first QFs
+}
+
+module.exports = { isAutoStartableQF, TIER3_RISK_RE, STALE_QF_DAYS };

--- a/scripts/lib/capacity-inputs.mjs
+++ b/scripts/lib/capacity-inputs.mjs
@@ -48,7 +48,14 @@
 import { fetchAllPaginated, renderCount } from '../../lib/db/fetch-all-paginated.mjs';
 import { isBareShell } from '../../lib/coordinator/sd-exclusion.mjs';
 import { parentLeadPendingVerdict } from '../../lib/fleet/claim-eligibility.cjs';
-import { countClaimableQuickFixes } from '../../lib/fleet/belt-depth.cjs';
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-4): was countClaimableQuickFixes. This
+// forecaster answers "how much belt is there for a worker to pick up" — countAutoStartableQuickFixes
+// is the reading that matches what a worker's /checkin self-claim loop would actually take (same
+// isAutoStartableQF predicate), so the forecast no longer counts stale/factory-lane/chairman-gated/
+// risk-flagged QFs no worker could reach. lib/governance/qf-mint-gate.mjs's demand gauge still calls
+// countClaimableQuickFixes directly — a different contract (mint-floor supply, not forecast belt) —
+// and is untouched by this SD.
+import { countAutoStartableQuickFixes } from '../../lib/fleet/belt-depth.cjs';
 // SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: reuse the ranker's PURE leaf predicates from the
 // client-free SSOT so the forecaster belt spans the DISPATCHABLE-leaf extent (what the ranker
 // counts as "1 claimable leaf"), not the raw-unclaimed extent. Applied IN-MEMORY on the rows this
@@ -220,16 +227,21 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
     //
     // SD-LEO-INFRA-GATE-SIDE-BELT-001: this was a local head-count on `status='open'` that IGNORED
     // claiming_session_id, while the SD term ~20 lines below skips claimed rows — one surface, two
-    // claimability rules, over-reporting by 3 (148 counted, 145 actually claimable). It now shares
-    // the coordinator's QF supply predicate through lib/fleet/belt-depth.cjs, so this number and the
-    // coordinator's own supply reads cannot disagree again.
+    // claimability rules, over-reporting by 3 (148 counted, 145 actually claimable). It then shared
+    // the coordinator's QF supply predicate through lib/fleet/belt-depth.cjs.
     //
-    // FAIL-OPEN IS PRESERVED DELIBERATELY, AND SAID OUT LOUD. countClaimableQuickFixes is fail-LOUD
-    // by contract, because a gauge that reports 0 when it cannot read is indistinguishable from an
-    // empty belt. THIS surface has always fallen back to a 0 QF contribution rather than aborting the
-    // whole forecast, so the catch keeps that behaviour at the call site where a reader can see it,
-    // instead of weakening the shared gauge for every other consumer.
-    countClaimableQuickFixes(sb).catch(() => null),
+    // SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-4): now countAutoStartableQuickFixes, the
+    // worker-auto-start reading (isAutoStartableQF) rather than the looser coordinator-supply reading
+    // — a QF held by staleness/factory-lane/chairman-gate/risk-keyword was still counted as forecast
+    // belt before this, over-reporting capacity a worker could never actually claim.
+    //
+    // FAIL-OPEN IS PRESERVED DELIBERATELY, AND SAID OUT LOUD. countAutoStartableQuickFixes is
+    // fail-LOUD by contract, same as countClaimableQuickFixes was, because a gauge that reports 0
+    // when it cannot read is indistinguishable from an empty belt. THIS surface has always fallen
+    // back to a 0 QF contribution rather than aborting the whole forecast, so the catch keeps that
+    // behaviour at the call site where a reader can see it, instead of weakening the shared gauge for
+    // every other consumer.
+    countAutoStartableQuickFixes(sb).catch(() => null),
   ]);
   const openQfCountRendered = renderCount(openQfCountRaw);
   const openQfCount = typeof openQfCountRendered === 'number' ? openQfCountRendered : 0; // fail-open: unreadable → 0 belt contribution, unchanged from the prior fallback

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -61,9 +61,11 @@ const { fetchOutstandingSignals, formatOutstandingWarning } = require('../lib/fl
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, liveClaimWriteFenceReason } = require('../lib/fleet/claim-eligibility.cjs');
-// SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: canonical chairman-gated-hold predicate (shared
-// with sd-next data-loaders + the coordinator dashboard so the sites can never drift).
-const { isChairmanGatedQF } = require('../lib/fleet/qf-gated-hold.cjs');
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-1/FR-2): the auto-start predicate moved
+// to lib/fleet/qf-auto-start.cjs so belt-depth.cjs can share it (previously duplicated by
+// nothing — belt-depth used the looser qf-supply-predicate.cjs instead). Imported here in
+// place of the local definitions that used to follow this line; behavior is byte-identical.
+const { isAutoStartableQF, STALE_QF_DAYS } = require('../lib/fleet/qf-auto-start.cjs');
 // SD-ARCH-HOTSPOT-SD-START-001 FR-2: the CONVERGED dependency gate shared with scripts/sd-start.js
 // (one resolution truth — deps array shapes + blocked_on_sd fold + sd_key-OR-id lookup). This
 // consumer applies its native FAIL-CLOSED polarity via depsSatisfiedFromVerdict: skip on
@@ -212,7 +214,6 @@ function isCriticalQfJumpEligible(qf, nowMs) {
   return (nowMs - created) >= CRITICAL_QF_JUMP_GRACE_MS;
 }
 
-const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
 // SD-LEO-FEAT-WORKER-CHECKIN-SELF-001 (FR-2): gap before confirmRowGone's confirming read so it lands
 // genuinely later than the first (defends a momentary stale-replica null). Env-overridable; tests set 0.
 const CONFIRM_DELETE_GAP_MS = process.env.CHECKIN_CONFIRM_GAP_MS != null ? Number(process.env.CHECKIN_CONFIRM_GAP_MS) : 250;
@@ -299,13 +300,6 @@ async function isGlobalStandDownActive(sb) {
     return false;
   }
 }
-// Tier-3 risk keywords (CLAUDE.md Work Item Routing). Auto-self-claim is for small,
-// low-risk QFs only. The sd-next display path excludes _escalate via a LIVE re-triage
-// (runTriageGate, ESM); a .cjs can't run that pipeline, so we approximate parity with the
-// PERSISTED routing_tier PLUS this keyword scan — holding risk-bearing QFs for the
-// triage/human path. SD-LEO-INFRA-MAKE-OPEN-QFS-001 (SECURITY re-triage-parity advisory).
-const TIER3_RISK_RE = /\b(auth|authentication|authorization|rls|payments?|credentials?|migration|schema|alter\s+table|create\s+table|drop\s+table)\b/i;
-
 const SD_KEY_RE = /SD-[A-Z0-9]+(?:-[A-Z0-9]+)+/;
 
 /**
@@ -613,90 +607,6 @@ async function rehydrateCallsign(sb, sessionId, currentMeta) {
  * id so it is unit-testable without env/network. Returns the resolution object
  * (the same object printed as JSON by the CLI). NEVER throws, NEVER reads stdin.
  */
-/**
- * Pure predicate: is this quick_fixes row safe to AUTO-start via the worker
- * self-claim path? Mirrors (inverts) the verify-first gate in
- * scripts/modules/sd-next/display/quick-fixes.js. Re-implemented INLINE because
- * worker-checkin.cjs is CommonJS and that module is ESM (package.json
- * type:module), so it cannot be require()d here. SD-LEO-INFRA-MAKE-OPEN-QFS-001.
- *
- * *** CORRECTION (SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001). THE REASON ABOVE IS FALSE, AND
- * BELIEVING IT COST FOUR INCOMPLETE FIXES. *** CJS can require ESM: it has been stable
- * since Node 22.12 and this fleet runs 24. It was tested, not assumed — requiring the ESM
- * parseAsUTC from a .cjs returns a working function. The retained text above is left
- * visible rather than deleted because it is the primary evidence for WHY the timezone bug
- * class survived four separate fixes without ever reaching this file: each pass read this
- * docblock, believed reuse was impossible here, and stopped.
- *
- * The one real limit is narrower: require() fails with ERR_REQUIRE_ASYNC_MODULE against a
- * module carrying a TOP-LEVEL AWAIT. That is why the canonical normalizer now lives at
- * lib/time/pg-timestamp.cjs — a CJS home carries no such constraint, and ESM can import
- * CJS unconditionally.
- *
- * THE DUPLICATION ITSELF IS STILL REAL and is NOT resolved by this SD: this predicate and
- * scripts/modules/sd-next/display/quick-fixes.js:275 remain independent implementations
- * that both carried the identical timezone defect. Consolidating them is follow-on work.
- */
-function isAutoStartableQF(qf, nowMs) {
-  if (!qf || qf.status !== 'open') return false;
-  // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-C FR-1: fixture rows are never self-claimable.
-  //
-  // THIS IS THE CONSEQUENTIAL SITE IN THE WHOLE SD. Everywhere else an unfiltered fixture row makes
-  // a number wrong; HERE it is handed to a REAL WORKER, who then builds against a row that was never
-  // real work. The other converted surfaces protect gauges — this one protects a person's afternoon.
-  //
-  // The defect was INCONSISTENCY, not absence: five surfaces already filter quick_fixes with this
-  // exact predicate (recursion-governor.js:128, adam-github-assessment.mjs:136,
-  // adam-self-adherence-review.mjs:105, fleet-dashboard.cjs:476 and sd-next/data-loaders.js:473 —
-  // the dispatch queue itself) while the CLAIM PATH did not. Five consumers agreed on a convention
-  // and the door that hands out work was left out of it.
-  //
-  // ADDED, never substituted: every exclusion below is a different concern and all of them still run.
-  // Degrade-safe like the surrounding predicate, but LOUDLY — an unreported fallback here is
-  // indistinguishable from a working filter, and this is the last gate before a worker is dispatched.
-  try {
-    const { isFixtureQf } = require('../lib/governance/fixture-exclusion.mjs');
-    if (isFixtureQf(qf)) return false;
-  } catch (e) {
-    console.error(`[worker-checkin] fixture predicate unavailable — self-claim UNFILTERED: ${e?.message || e}`);
-  }
-  if (qf.pr_url || qf.commit_sha) return false;        // already in PR/commit (verify-first / merge-race guard)
-  // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: quick_fixes.factory_lane is the structured
-  // "coordinator-dispatch only, not worker-self-claimable" marker (replaces the pre-fix free-text
-  // "FACTORY-LANE:" convention buried in description, which this predicate could not see -- live
-  // incident: QF-20260712-481 self-claimed despite being factory-lane). Fail-closed: any truthy
-  // value excludes; only exactly false (the column default) allows self-claim.
-  if (qf.factory_lane) return false;
-  if (qf.routing_tier != null && Number(qf.routing_tier) >= 3) return false;  // persisted Tier-3 -> full SD, not auto-QF
-  // QF-20260725-244: scan TITLE **and** DESCRIPTION. Title-only let QF-20260725-096 through --
-  // an auth/security QF whose implied fix ("thread the internal API key into the fetch headers")
-  // would publish an app-wide admin-bypass secret to an UNAUTHENTICATED page. Its title reads
-  // "internal-API-key", which has no word-boundary `auth`, while its description is saturated
-  // with auth / authorization / credential. Verified by executing this exact regex against that
-  // row: title=false, description=true. scripts/classify-quick-fix.js already gates on
-  // DESCRIPTION and FAILS that QF, so description is the correct surface -- reading the title
-  // alone is what let the two surfaces disagree. `description` is already in
-  // QF_CANDIDATE_COLUMNS, so this needs no query change.
-  if (TIER3_RISK_RE.test(`${qf.title || ''} ${qf.description || ''}`)) return false; // risk-keyword drift -> hold for triage/human
-  // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: durable time-gated defer -- a QF genuinely not ready
-  // yet (e.g. needs a clean 24h observation window) stays status='open' but is ineligible
-  // for claim until not_before passes. Prevents the same worker re-claiming it every cycle.
-  if (qf.not_before) {
-    const notBefore = Date.parse(qf.not_before);
-    if (Number.isFinite(notBefore) && notBefore > nowMs) return false;
-  }
-  // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: chairman-gated hold (owner='chairman' +
-  // release_condition) -- the QF-508/QF-970 class whose APPLY awaits a chairman condition.
-  // Stays status='open' but is false open work for a worker: exclude until released via
-  // scripts/release-chairman-gated-qf.js. Visible on the coordinator surface, never lost.
-  if (isChairmanGatedQF(qf)) return false;
-  // SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: naive created_at, see the require at the top of this file.
-  const created = qf.created_at ? pgTimestampMs(qf.created_at) : NaN;
-  if (!Number.isFinite(created)) return false;
-  const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
-  return ageDays < STALE_QF_DAYS;                       // exclude stale/verify-first QFs
-}
-
 /**
  * Self-claim tier for open quick_fixes — sourced ONLY here because
  * v_sd_next_candidates is SD-only. Sits strictly BELOW the SD self-claim loop

--- a/tests/unit/capacity-forecaster-belt-extent.test.js
+++ b/tests/unit/capacity-forecaster-belt-extent.test.js
@@ -15,7 +15,15 @@ import { computeBeltVerdict } from '../../lib/drive-loop/belt-verdict.js';
 import { claimableDbFreeReason, blockerKeysFor } from '../../scripts/lib/claimable-leaves.mjs';
 import { isBareShell } from '../../lib/coordinator/sd-exclusion.mjs';
 
-/** Fake supabase mirroring capacity-inputs.test.js, plus a from()-call counter for the read-count assertion. */
+/**
+ * Fake supabase mirroring capacity-inputs.test.js, plus a from()-call counter for the read-count
+ * assertion. SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-4): the QF term now comes from
+ * countAutoStartableQuickFixes, which fetches ROWS (isAutoStartableQF runs in JS), not a bare
+ * head-count — quick_fixes now uses the same row-capable `table()` builder as the other tables,
+ * fed by real, isAutoStartableQF-eligible rows generated from qfCount (a missing created_at reads
+ * as unparseable age and excludes the row, matching the fixture-fidelity gap already found and
+ * fixed in tests/unit/capacity-inputs.test.js's sibling fakeClient).
+ */
 function fakeClient({ sessions = [], sds = [], qfCount = 0, counter } = {}) {
   const table = (rows) => {
     const b = {
@@ -27,19 +35,27 @@ function fakeClient({ sessions = [], sds = [], qfCount = 0, counter } = {}) {
     };
     return b;
   };
+  const qfs = Array.from({ length: qfCount }, (_, i) => ({
+    id: `qf-fake-${i}`,
+    status: 'open',
+    claiming_session_id: null,
+    pr_url: null,
+    commit_sha: null,
+    created_at: new Date().toISOString(),
+    routing_tier: null,
+    title: 'Fix a typo in a comment',
+    description: 'No behavioral change.',
+    not_before: null,
+    factory_lane: false,
+    owner: null,
+    release_condition: null,
+  }));
   return {
     from(name) {
       if (counter) counter[name] = (counter[name] || 0) + 1;
       if (name === 'claude_sessions') return table(sessions);
       if (name === 'strategic_directives_v2') return table(sds);
-      if (name === 'quick_fixes') {
-        const b = {
-          select() { return b; }, eq() { return b; }, in() { return b; }, is() { return b; },
-          not() { return b; }, order() { return b; },
-          then(res) { return Promise.resolve({ count: qfCount, error: null }).then(res); },
-        };
-        return b;
-      }
+      if (name === 'quick_fixes') return table(qfs);
       return table([]);
     },
   };

--- a/tests/unit/capacity-inputs.test.js
+++ b/tests/unit/capacity-inputs.test.js
@@ -26,7 +26,11 @@ import { computeBeltVerdict } from '../../lib/drive-loop/belt-verdict.js';
 
 /**
  * A fake Supabase whose builders satisfy fetchAllPaginated (fresh builder per page, .range applied
- * by the caller) and the head-count path countClaimableQuickFixes uses.
+ * by the caller) and the row-fetch path countAutoStartableQuickFixes uses (SD-LEO-INFRA-QF-SUPPLY-
+ * PREDICATE-AUTO-START-001 FR-4: was the head-count path countClaimableQuickFixes used — that
+ * builder only ever needed to answer a bare {count}, never a row; countAutoStartableQuickFixes
+ * fetches rows and runs isAutoStartableQF over them in JS, so quick_fixes now needs the SAME
+ * row-capable builder claude_sessions/strategic_directives_v2 already use, not a narrower one).
  */
 function fakeClient({ sessions = [], sds = [], qfCount = 0 } = {}) {
   const table = (rows) => {
@@ -39,28 +43,36 @@ function fakeClient({ sessions = [], sds = [], qfCount = 0 } = {}) {
       not() { return b; },
       gte() { return b; },
       order() { return b; },
-      limit() { return b; },
+      limit(n) { return Promise.resolve({ data: b._rows.slice(0, n), error: null }); },
       range(from, to) { return Promise.resolve({ data: b._rows.slice(from, to + 1), error: null }); },
       then(res) { return Promise.resolve({ data: b._rows, error: null }).then(res); },
     };
     return b;
   };
+  // Fresh, open, unambiguously isAutoStartableQF-eligible rows — qfCount stays the test-facing
+  // knob ("N open QFs on the belt"), it just now has to carry the fields the row-level predicate
+  // reads (created_at above all: a missing one reads as unparseable age and excludes the row).
+  const qfs = Array.from({ length: qfCount }, (_, i) => ({
+    id: `qf-fake-${i}`,
+    status: 'open',
+    pr_url: null,
+    commit_sha: null,
+    created_at: new Date().toISOString(),
+    routing_tier: null,
+    title: 'Fix a typo in a comment',
+    // Deliberately free of TIER3_RISK_RE's keywords (auth/schema/migration/etc.) — a description
+    // merely ASSERTING their absence would itself contain the words and self-exclude the row.
+    description: 'No behavioral change.',
+    not_before: null,
+    factory_lane: false,
+    owner: null,
+    release_condition: null,
+  }));
   return {
     from(name) {
       if (name === 'claude_sessions') return table(sessions);
       if (name === 'strategic_directives_v2') return table(sds);
-      if (name === 'quick_fixes') {
-        const b = {
-          select() { return b; },
-          eq() { return b; },
-          in() { return b; },
-          is() { return b; },
-          not() { return b; },
-          order() { return b; },
-          then(res) { return Promise.resolve({ count: qfCount, error: null }).then(res); },
-        };
-        return b;
-      }
+      if (name === 'quick_fixes') return table(qfs);
       return table([]);
     },
   };

--- a/tests/unit/coordinator/qf-supply-gauge-agreement.test.js
+++ b/tests/unit/coordinator/qf-supply-gauge-agreement.test.js
@@ -23,6 +23,7 @@ import { createRequire } from 'node:module';
 const require_ = createRequire(import.meta.url);
 const { isClaimableQfSupply, CLAIMABLE_QF_STATUSES } = require_('../../../lib/coordinator/qf-supply-predicate.cjs');
 const { isAutoStartableQF } = require_('../../../scripts/worker-checkin.cjs');
+const { STALE_QF_DAYS } = require_('../../../lib/fleet/qf-auto-start.cjs');
 
 const base = (over) => ({
   id: 'QF-T',
@@ -144,5 +145,54 @@ describe('FR-4: gauge and chokepoint agree on the axis where they used to disagr
     // fails. That direction would let workers claim held or attestation-pending rows.
     expect(CLAIMABLE_QF_STATUSES).toEqual(['open']);
     expect(isAutoStartableQF(base({ status: 'in_progress' }), Date.now())).toBe(false);
+  });
+});
+
+/**
+ * SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-5) — the axes where the two predicates are
+ * SUPPOSED to disagree, pinned rather than left implicit.
+ *
+ * A SEPARATE describe block, over its OWN fixture population — deliberately not added to
+ * `fixtures` above. isClaimableQfSupply's docblock (lib/coordinator/qf-supply-predicate.cjs:62-65,
+ * 82-85) already states it does NOT apply staleness/tier/factory-lane/chairman-gate, only
+ * "unclaimed + open-ish status" — different question, different consumer (detectThunderingHerd).
+ * Every row below is FREE (claiming_session_id: null) and status='open', so the existing free-row
+ * biconditional up above (`isClaimableQfSupply === isAutoStartableQF`, guarded on
+ * `claiming_session_id === null`) would break the moment any of these joined `fixtures` — that
+ * collision is exactly why this is its own block, not an extension of the other one.
+ *
+ * The property under test is the INVERSE of FR-4's: for a FREE row on one of these axes,
+ * isClaimableQfSupply (loose: coordinator supply) and isAutoStartableQF (strict: worker
+ * auto-start) MUST diverge — true and false respectively. If a future change makes them agree
+ * here, either the coordinator gauge quietly grew the strict checks (and needs its own FR-4-style
+ * re-verification against the chokepoints) or isAutoStartableQF quietly lost one — both are
+ * regressions this block exists to catch.
+ */
+describe('FR-5: axes where isClaimableQfSupply and isAutoStartableQF are DELIBERATELY different', () => {
+  const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  const staleCreatedAt = new Date(Date.now() - (STALE_QF_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+
+  const divergent = [
+    { name: 'stale — older than STALE_QF_DAYS', row: base({ created_at: staleCreatedAt }) },
+    { name: 'factory_lane — coordinator-dispatch only', row: base({ factory_lane: true }) },
+    { name: 'chairman-gated hold', row: base({ owner: 'chairman', release_condition: 'EU-send-planned' }) },
+    { name: 'TIER3_RISK_RE keyword in title', row: base({ title: 'rotate auth credentials' }) },
+    { name: 'TIER3_RISK_RE keyword in description', row: base({ description: 'apply the pending schema migration' }) },
+    { name: 'not_before in the future', row: base({ not_before: FUTURE }) },
+  ];
+
+  for (const f of divergent) {
+    it(`diverges for: ${f.name} (supply says yes, auto-start says no)`, () => {
+      expect(f.row.claiming_session_id, 'this axis only means something for a FREE row').toBeNull();
+      expect(isClaimableQfSupply(f.row)).toBe(true);
+      expect(isAutoStartableQF(f.row, Date.now())).toBe(false);
+    });
+  }
+
+  it('CONTROL: the same base() row (no divergence override) agrees on both sides', () => {
+    // Without this, "diverges" above could be true trivially because base() itself never agrees —
+    // this proves the axis-specific override, not the fixture shape, is what causes each divergence.
+    expect(isClaimableQfSupply(base())).toBe(true);
+    expect(isAutoStartableQF(base(), Date.now())).toBe(true);
   });
 });

--- a/tests/unit/fleet/belt-depth-qf.test.js
+++ b/tests/unit/fleet/belt-depth-qf.test.js
@@ -136,6 +136,26 @@ describe('SEC-GSB-1 — a NON-NUMERIC count is a failed measurement, not an empt
   });
 });
 
+// Adversarial-review finding (deep-tier /ship gate, PR #7040), WARNING, reproduced here:
+// isAutoStartableQF itself never inspects claiming_session_id (it mirrors the worker's real
+// candidate query, which relies on claim_sd flipping status atomically with the claimant) — safe
+// for the worker, whose downstream claim_sd RPC call is the real arbiter, but this gauge has no
+// such arbiter. Without a query-level filter, a status='open'-but-claimed row (a reachable state
+// — see lib/checkin/steps/resume.cjs, lib/fleet/best-effort-release.mjs) would be over-counted,
+// reopening the exact defect class SD-LEO-INFRA-GATE-SIDE-BELT-001 fixed.
+describe('countAutoStartableQuickFixes — claiming_session_id exclusion (adversarial-review fix)', () => {
+  it('does not count a row that is status=open but already claimed by another session', async () => {
+    const client = fakeClient({ qfs: [...openUnclaimed(4), ...openClaimed(3)] });
+    await expect(countAutoStartableQuickFixes(client)).resolves.toBe(4);
+  });
+
+  it('countBeltDepth inherits the same exclusion via its qfDepth reading', async () => {
+    const client = fakeClient({ qfs: [...openUnclaimed(4), ...openClaimed(3)] });
+    const depth = await countBeltDepth(client);
+    expect(depth.qfDepth).toBe(4);
+  });
+});
+
 // SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-3, TS-2 scope clause): a scoped call must
 // not silently fall back to fleet-wide counting on the new row-fetch path — both the factory_lane
 // probe and the paginated fetch have to carry the SAME .eq('target_application', scope) filter
@@ -205,6 +225,33 @@ describe('countAutoStartableQuickFixes — factory_lane 42703 fallback (TR-2/TS-
   it('a non-42703 error on the probe still propagates (fail-loud is not weakened by the retry)', async () => {
     const client = { from: () => ({ select: () => ({ eq() { return this; }, is() { return this; }, limit: () => Promise.resolve({ data: null, error: { code: 'PGRST205', message: 'relation not found' } }) }) }) };
     await expect(countAutoStartableQuickFixes(client)).rejects.toBeTruthy();
+  });
+
+  // Adversarial-review finding (deep-tier /ship gate, PR #7040), CRITICAL, reproduced here: on
+  // LIVE PRODUCTION the FIRST probe (with factory_lane) always hits 42703 -- the prior version of
+  // this guard only checked the shape of THAT discarded first attempt, never the retry probe that
+  // uses the column list actually fed to the real fetch. This is the scenario that matters: probe
+  // #1 -> 42703 (expected, triggers the fallback), probe #2 (retry, no factory_lane) -> the
+  // degenerate {data:null, error:null} shape. Must still throw, not resolve to 0.
+  it('a probe that hits 42703, then a RETRY probe that resolves data=null/error=null, still THROWS', async () => {
+    const client = {
+      from: () => ({
+        select: (cols) => {
+          const includesFactoryLane = /(^|,)\s*factory_lane\s*(,|$)/.test(cols);
+          const b = {
+            eq() { return b; },
+            is() { return b; },
+            limit: () => Promise.resolve(
+              includesFactoryLane
+                ? { data: null, error: { code: '42703', message: 'column quick_fixes.factory_lane does not exist' } }
+                : { data: null, error: null }
+            ),
+          };
+          return b;
+        },
+      }),
+    };
+    await expect(countAutoStartableQuickFixes(client)).rejects.toThrow(/refusing to treat an unreadable quick_fixes table as empty/);
   });
 
   // TR-1 / SEC-GSB-1 parity: PostgREST's documented missing-relation signature is {count:null,

--- a/tests/unit/fleet/belt-depth-qf.test.js
+++ b/tests/unit/fleet/belt-depth-qf.test.js
@@ -1,9 +1,17 @@
 // GSB-A — the QF-side reading and the invariant that keeps the SD reading unchanged.
 // SD-LEO-INFRA-GATE-SIDE-BELT-001, TS-1/TS-2/TS-3.
+//
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-3): countBeltDepth's qfDepth now comes
+// from countAutoStartableQuickFixes (isAutoStartableQF), not countClaimableQuickFixes — so TS-2
+// exercises a row-filtering predicate with staleness/fixture/risk checks, not a head-count. The
+// fake client needed .limit() (the factory_lane-probe step) and the openUnclaimed/openClaimed
+// fixtures needed a created_at, or every row reads as unparseable-age and isAutoStartableQF
+// excludes all of them — countClaimableQuickFixes (still exercised directly in TS-3) never
+// looked at created_at at all, so this gap was invisible before FR-3 existed.
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { countDispatchableBacklog, countClaimableQuickFixes, countBeltDepth } = require('../../../lib/fleet/belt-depth.cjs');
+const { countDispatchableBacklog, countClaimableQuickFixes, countAutoStartableQuickFixes, countBeltDepth } = require('../../../lib/fleet/belt-depth.cjs');
 const { CLAIMABLE_QF_STATUSES } = require('../../../lib/coordinator/qf-supply-predicate.cjs');
 
 /**
@@ -30,6 +38,7 @@ function fakeClient({ sds = [], qfs = [] } = {}) {
       in(col, vals) { qfFilters.push(`in:${col}`); filtered = filtered.filter((r) => vals.includes(r[col])); return builder; },
       not() { return builder; },
       order() { return builder; },
+      limit(n) { filtered = filtered.slice(0, n); return builder; },
       range(from, to) { filtered = filtered.slice(from, to + 1); return builder; },
       then(resolve, reject) {
         return Promise.resolve({ data: builder._head ? null : filtered, count: filtered.length, error: null })
@@ -45,8 +54,11 @@ function fakeClient({ sds = [], qfs = [] } = {}) {
   };
 }
 
-const openUnclaimed = (n) => Array.from({ length: n }, (_, i) => ({ id: `qf-open-${i}`, status: CLAIMABLE_QF_STATUSES[0], claiming_session_id: null }));
-const openClaimed = (n) => Array.from({ length: n }, (_, i) => ({ id: `qf-claimed-${i}`, status: CLAIMABLE_QF_STATUSES[0], claiming_session_id: `sess-${i}` }));
+// created_at must be present and fresh: isAutoStartableQF treats a missing/unparseable
+// created_at as a failed age check and excludes the row (see the FR-3 note above the imports).
+const FRESH_CREATED_AT = new Date().toISOString();
+const openUnclaimed = (n) => Array.from({ length: n }, (_, i) => ({ id: `qf-open-${i}`, status: CLAIMABLE_QF_STATUSES[0], claiming_session_id: null, created_at: FRESH_CREATED_AT }));
+const openClaimed = (n) => Array.from({ length: n }, (_, i) => ({ id: `qf-claimed-${i}`, status: CLAIMABLE_QF_STATUSES[0], claiming_session_id: `sess-${i}`, created_at: FRESH_CREATED_AT }));
 
 describe('TS-1 — countDispatchableBacklog never reads quick_fixes', () => {
   // BEHAVIOURAL, NOT A PINNED COUNT. The first draft of this asserted dispatchable===23; it had
@@ -121,5 +133,77 @@ describe('SEC-GSB-1 — a NON-NUMERIC count is a failed measurement, not an empt
     // Both arms in one describe: a version that throws unconditionally fails here, and a version
     // that coerces unconditionally fails above. Neither constant survives.
     await expect(countClaimableQuickFixes(emptyBelt)).resolves.toBe(0);
+  });
+});
+
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-3, TS-2 scope clause): a scoped call must
+// not silently fall back to fleet-wide counting on the new row-fetch path — both the factory_lane
+// probe and the paginated fetch have to carry the SAME .eq('target_application', scope) filter
+// countClaimableQuickFixes already applies for its own (head-count) query.
+describe('countAutoStartableQuickFixes — lane scoping', () => {
+  it('counts only rows in the requested lane, not the fleet total', async () => {
+    const engRow = { id: 'qf-eng', status: 'open', claiming_session_id: null, created_at: FRESH_CREATED_AT, target_application: 'EHG_Engineer' };
+    const otherRow = { id: 'qf-other', status: 'open', claiming_session_id: null, created_at: FRESH_CREATED_AT, target_application: 'EHG' };
+    const client = fakeClient({ qfs: [engRow, otherRow] });
+    await expect(countAutoStartableQuickFixes(client, 'EHG_Engineer')).resolves.toBe(1);
+    await expect(countAutoStartableQuickFixes(client, 'EHG')).resolves.toBe(1);
+  });
+
+  it('an unresolvable scope throws rather than silently counting the fleet total', async () => {
+    const client = fakeClient({ qfs: openUnclaimed(3) });
+    await expect(countAutoStartableQuickFixes(client, '')).rejects.toThrow(/unresolvable lane scope/);
+  });
+
+  it('an unscoped call (scope omitted) counts across all lanes, unchanged from before scoping existed', async () => {
+    const engRow = { id: 'qf-eng', status: 'open', claiming_session_id: null, created_at: FRESH_CREATED_AT, target_application: 'EHG_Engineer' };
+    const otherRow = { id: 'qf-other', status: 'open', claiming_session_id: null, created_at: FRESH_CREATED_AT, target_application: 'EHG' };
+    const client = fakeClient({ qfs: [engRow, otherRow] });
+    await expect(countAutoStartableQuickFixes(client)).resolves.toBe(2);
+  });
+});
+
+// SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (TR-2/TS-4): factory_lane is a staged,
+// unapplied migration (database/migrations/20260713_quick_fixes_factory_lane.sql) — selecting it
+// throws Postgres 42703 in live production today. The 42703 fallback lives INSIDE
+// fetchAutoStartCandidateRows (belt-depth.cjs), not left as a per-caller responsibility, mirroring
+// scripts/worker-checkin.cjs's selfClaimQuickFix retry (lines ~712-747) for the SAME condition.
+describe('countAutoStartableQuickFixes — factory_lane 42703 fallback (TR-2/TS-4)', () => {
+  // A column-list-sensitive stub: the probe (which selects factory_lane) hits 42703; the retried
+  // probe/fetch (without factory_lane) succeeds. Distinct from the generic fakeClient() above
+  // because this needs to inspect WHICH columns were requested, not just filter rows.
+  function factoryLaneMissingClient(rows) {
+    const make = (cols) => {
+      const includesFactoryLane = /(^|,)\s*factory_lane\s*(,|$)/.test(cols);
+      const b = {
+        _cols: cols,
+        eq() { return b; },
+        is() { return b; },
+        limit(n) {
+          if (includesFactoryLane) {
+            return Promise.resolve({ data: null, error: { code: '42703', message: 'column quick_fixes.factory_lane does not exist' } });
+          }
+          return Promise.resolve({ data: rows.slice(0, n), error: null });
+        },
+        range(from, to) {
+          if (includesFactoryLane) {
+            return Promise.resolve({ data: null, error: { code: '42703', message: 'column quick_fixes.factory_lane does not exist' } });
+          }
+          return Promise.resolve({ data: rows.slice(from, to + 1), error: null });
+        },
+      };
+      return b;
+    };
+    return { from: () => ({ select: (cols) => make(cols) }) };
+  }
+
+  it('retries without factory_lane on 42703 and still counts the eligible rows', async () => {
+    const rows = openUnclaimed(4); // factory_lane absent on every row -> falsy -> isAutoStartableQF admits them
+    const client = factoryLaneMissingClient(rows);
+    await expect(countAutoStartableQuickFixes(client)).resolves.toBe(4);
+  });
+
+  it('a non-42703 error on the probe still propagates (fail-loud is not weakened by the retry)', async () => {
+    const client = { from: () => ({ select: () => ({ eq() { return this; }, is() { return this; }, limit: () => Promise.resolve({ data: null, error: { code: 'PGRST205', message: 'relation not found' } }) }) }) };
+    await expect(countAutoStartableQuickFixes(client)).rejects.toBeTruthy();
   });
 });

--- a/tests/unit/fleet/belt-depth-qf.test.js
+++ b/tests/unit/fleet/belt-depth-qf.test.js
@@ -206,4 +206,22 @@ describe('countAutoStartableQuickFixes — factory_lane 42703 fallback (TR-2/TS-
     const client = { from: () => ({ select: () => ({ eq() { return this; }, is() { return this; }, limit: () => Promise.resolve({ data: null, error: { code: 'PGRST205', message: 'relation not found' } }) }) }) };
     await expect(countAutoStartableQuickFixes(client)).rejects.toBeTruthy();
   });
+
+  // TR-1 / SEC-GSB-1 parity: PostgREST's documented missing-relation signature is {count:null,
+  // error:null} under head:true (lib/db/fetch-all-paginated.mjs's renderCount docblock). Its own
+  // fetchAllPaginated defends the analogous {data:null, error:null} shape for a plain select by
+  // silently coercing to [] — the exact fail-open direction this SD's whole premise is against.
+  // The probe is the one place that shape is still checkable before it disappears into
+  // fetchAllPaginated's loop.
+  it('a probe that resolves with data=null and error=null THROWS rather than reporting 0', async () => {
+    const client = { from: () => ({ select: () => ({ eq() { return this; }, is() { return this; }, limit: () => Promise.resolve({ data: null, error: null }) }) }) };
+    await expect(countAutoStartableQuickFixes(client)).rejects.toThrow(/refusing to treat an unreadable quick_fixes table as empty/);
+  });
+
+  it('a probe that resolves with data=[] (genuinely empty, not null) does NOT throw', async () => {
+    // Control for the control above: an empty ARRAY is a valid, distinguishable "really has zero
+    // rows" signal. Only a non-array data with no error is treated as a failed measurement.
+    const client = fakeClient({ qfs: [] });
+    await expect(countAutoStartableQuickFixes(client)).resolves.toBe(0);
+  });
 });

--- a/tests/unit/fleet/qf-auto-start.test.js
+++ b/tests/unit/fleet/qf-auto-start.test.js
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the extracted auto-start predicate module.
+ * SD: SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-1)
+ *
+ * isAutoStartableQF/TIER3_RISK_RE/STALE_QF_DAYS moved out of scripts/worker-checkin.cjs
+ * into lib/fleet/qf-auto-start.cjs so lib/fleet/belt-depth.cjs (FR-3) can share the exact
+ * predicate the worker claim path uses, rather than the deliberately looser
+ * lib/coordinator/qf-supply-predicate.cjs (a different consumer's contract — see
+ * tests/unit/coordinator/qf-supply-gauge-agreement.test.js for why the two must diverge).
+ *
+ * This file tests the module DIRECTLY at its new import path — one representative case per
+ * exclusion branch, not an exhaustive matrix. The exhaustive edge-case scenarios (factory_lane,
+ * not_before, TIER3_RISK_RE title-vs-description) already live in
+ * tests/unit/worker-checkin-qf-{factory-lane,not-before,tier3-risk-description}.test.js and
+ * continue to pin the SAME code via worker-checkin.cjs's re-export (FR-2) — duplicating them
+ * here would just be two places that can silently drift apart.
+ */
+import { describe, test, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { isAutoStartableQF, TIER3_RISK_RE, STALE_QF_DAYS } = require('../../../lib/fleet/qf-auto-start.cjs');
+
+const NOW = Date.parse('2026-08-15T12:00:00Z');
+
+function qf(overrides = {}) {
+  return {
+    id: 'QF-20260815-001',
+    status: 'open',
+    pr_url: null,
+    commit_sha: null,
+    created_at: '2026-08-15T00:00:00Z',
+    routing_tier: null,
+    title: 'Fix a benign typo',
+    description: 'No behavioral change.',
+    severity: 'medium',
+    not_before: null,
+    factory_lane: false,
+    owner: null,
+    release_condition: null,
+    ...overrides,
+  };
+}
+
+describe('lib/fleet/qf-auto-start.cjs — module surface', () => {
+  test('exports isAutoStartableQF, TIER3_RISK_RE, STALE_QF_DAYS from the new location', () => {
+    expect(typeof isAutoStartableQF).toBe('function');
+    expect(TIER3_RISK_RE).toBeInstanceOf(RegExp);
+    expect(typeof STALE_QF_DAYS).toBe('number');
+    expect(STALE_QF_DAYS).toBeGreaterThan(0);
+  });
+});
+
+describe('isAutoStartableQF — one representative case per exclusion branch', () => {
+  test('admits a fully-eligible open, fresh, low-risk QF (happy path)', () => {
+    expect(isAutoStartableQF(qf(), NOW)).toBe(true);
+  });
+
+  test('excludes a null/undefined row and a non-open status', () => {
+    expect(isAutoStartableQF(null, NOW)).toBe(false);
+    expect(isAutoStartableQF(undefined, NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ status: 'in_progress' }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ status: 'completed' }), NOW)).toBe(false);
+  });
+
+  test('excludes a fixture row (QF-TEST-* id marker)', () => {
+    expect(isAutoStartableQF(qf({ id: 'QF-TEST-001' }), NOW)).toBe(false);
+  });
+
+  test('excludes a row already in flight (pr_url or commit_sha set)', () => {
+    expect(isAutoStartableQF(qf({ pr_url: 'https://github.com/x/y/pull/1' }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ commit_sha: 'abc123' }), NOW)).toBe(false);
+  });
+
+  test('excludes factory_lane=true, admits factory_lane=false/undefined', () => {
+    expect(isAutoStartableQF(qf({ factory_lane: true }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ factory_lane: false }), NOW)).toBe(true);
+    const noColumn = qf();
+    delete noColumn.factory_lane;
+    expect(isAutoStartableQF(noColumn, NOW)).toBe(true);
+  });
+
+  test('excludes a persisted Tier-3 routing_tier, admits Tier 1/2', () => {
+    expect(isAutoStartableQF(qf({ routing_tier: 3 }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ routing_tier: 1 }), NOW)).toBe(true);
+    expect(isAutoStartableQF(qf({ routing_tier: 2 }), NOW)).toBe(true);
+  });
+
+  test('excludes a TIER3_RISK_RE keyword match in title or description', () => {
+    expect(isAutoStartableQF(qf({ title: 'rotate auth credentials' }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ description: 'apply the pending schema migration' }), NOW)).toBe(false);
+  });
+
+  test('excludes a not_before still in the future, admits one already past', () => {
+    expect(isAutoStartableQF(qf({ not_before: '2026-08-16T00:00:00Z' }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ not_before: '2026-08-01T00:00:00Z' }), NOW)).toBe(true);
+  });
+
+  test('excludes a chairman-gated hold (owner=chairman + non-empty release_condition)', () => {
+    expect(isAutoStartableQF(qf({ owner: 'chairman', release_condition: 'EU-send-planned' }), NOW)).toBe(false);
+    // fail-open: owner alone, or condition alone, is not a gate
+    expect(isAutoStartableQF(qf({ owner: 'chairman', release_condition: null }), NOW)).toBe(true);
+  });
+
+  test('excludes a stale QF (age >= STALE_QF_DAYS), admits one just inside the window', () => {
+    const staleCreated = new Date(NOW - (STALE_QF_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+    const freshCreated = new Date(NOW - (STALE_QF_DAYS - 1) * 24 * 60 * 60 * 1000).toISOString();
+    expect(isAutoStartableQF(qf({ created_at: staleCreated }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ created_at: freshCreated }), NOW)).toBe(true);
+  });
+
+  test('excludes an unparseable created_at rather than throwing', () => {
+    expect(isAutoStartableQF(qf({ created_at: 'not-a-date' }), NOW)).toBe(false);
+    expect(isAutoStartableQF(qf({ created_at: null }), NOW)).toBe(false);
+  });
+});

--- a/tests/unit/governance/belt-gauge-contract-freeze.test.js
+++ b/tests/unit/governance/belt-gauge-contract-freeze.test.js
@@ -45,6 +45,11 @@ function wideStub({ count = 0, rows = [] } = {}) {
     not() { return chain; },
     or() { return chain; },
     order() { return chain; },
+    // SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 (FR-3): countAutoStartableQuickFixes's
+    // factory_lane probe calls .limit(1) before the real fetch — infrastructure widening, same
+    // spirit as the rest of this stub being "wider than the ones already in the suite" (see the
+    // docblock above). No assertion below changes.
+    limit() { return Promise.resolve({ data: rows.slice(0, 1), count, error: null }); },
     range() { return Promise.resolve({ data: rows, count, error: null }); },
     then(res) { return Promise.resolve({ data: rows, count, error: null }).then(res); },
   };


### PR DESCRIPTION
## Summary

The worker `/checkin` self-claim path (`isAutoStartableQF` in `scripts/worker-checkin.cjs`) decides which `quick_fixes` a worker can auto-claim via a strict predicate (status=open, not fixture, not already in PR/commit, not `factory_lane`, not persisted Tier-3, no `TIER3_RISK_RE` keyword match, `not_before` not in the future, not chairman-gated, not stale). The belt-depth/capacity-forecast gauges used a much looser predicate (`lib/coordinator/qf-supply-predicate.cjs`'s `applyClaimableQfFilter`: unclaimed + `status='open'` only) — a single-representation violation between two "can a worker take this" answers.

**Measured live 2026-08-15**: the loose gauge reported **173** "claimable" QFs while the worker's real predicate would only actually start **0** of them.

- Extracted `isAutoStartableQF`/`TIER3_RISK_RE`/`STALE_QF_DAYS` into a new shared module, `lib/fleet/qf-auto-start.cjs` (decision-logic-identical move — verified against the full pre-existing QF behavior-pinning test suite, zero modifications, plus a character-by-character diff comparison). `scripts/worker-checkin.cjs` now imports from it instead of defining it locally.
- Added `countAutoStartableQuickFixes` to `lib/fleet/belt-depth.cjs`, reusing the same predicate, with a fail-loud contract (an unreadable table throws, never resolves to a healthy-looking 0 — including the degenerate `{data:null,error:null}` PostgREST missing-relation shape) and the same `factory_lane`-42703 staged-migration fallback `worker-checkin.cjs` already carries. `countBeltDepth`'s QF-side reading now uses it. `countClaimableQuickFixes` itself is untouched — `lib/governance/qf-mint-gate.mjs` is its sole remaining consumer, on a deliberately different contract.
- Switched `scripts/lib/capacity-inputs.mjs`'s QF term to the new function, so the capacity forecaster reports the belt a worker can actually reach.
- Pinned the axes where the coordinator-supply predicate and the worker auto-start predicate are *deliberately* different (staleness, `factory_lane`, chairman-gate, risk-keyword, `not_before`), in a new test block that doesn't touch the pre-existing agreement suite.
- Updated 3 tests' fake-client stubs (row-fetch/`.limit()` support) to match the new query shape — zero assertions changed in any of them.

`lib/coordinator/qf-supply-predicate.cjs` and `lib/governance/qf-mint-gate.mjs` are untouched by design (different consumers, different contracts — verified zero diff).

## Live verification

```
countClaimableQuickFixes (old/loose, still used by qf-mint-gate): 173
countAutoStartableQuickFixes (new/strict, now used by belt-depth+capacity): 0
```

`node scripts/coordinator-capacity-forecast.mjs` now reports `BELT: 17 claimable ... (17 SD + 0 QF)` instead of folding 173 phantom QFs into the belt.

## Why one PR, not several

The extraction, its new belt-depth consumer, the capacity-forecaster switch, and the test-fidelity fixes required to keep pre-existing tests accurate are mutually interdependent — any subset ships either dead code or a broken intermediate state.

## Test plan
- [x] `npx vitest run tests/unit/fleet/qf-auto-start.test.js tests/unit/fleet/belt-depth-qf.test.js tests/unit/governance/belt-gauge-contract-freeze.test.js tests/unit/coordinator/qf-supply-gauge-agreement.test.js tests/unit/governance/qf-mint-gate.test.js tests/unit/capacity-inputs.test.js` — all pass
- [x] Full pre-existing QF behavior-pinning suite (`worker-checkin-qf-*`, `fleet/qf-gated-hold`, `fleet/qf-clear-and-reopen`, `governance/fixture-exclusion-per-table`, `sd-next/quick-fix-*-gate`, `defer-quick-fix-deliberate-release-fr2`) — zero diff, all pass (44+ tests)
- [x] `git diff --stat` confirms zero diff on `lib/coordinator/qf-supply-predicate.cjs` and `lib/governance/qf-mint-gate.mjs`
- [x] `grep -rn 'function isAutoStartableQF'` returns exactly one definition site
- [x] Live-verified against production data: old gauge 173, new gauge 0, forecaster output confirmed
- [x] DOCMON sub-agent: CONCERNS → all findings addressed (stale comment fixed) or explicitly deferred (operator-facing doc update flagged for follow-up, requires a DB-generated protocol-doc edit outside this SD's scope)
- [x] REGRESSION sub-agent: PASS, 129/129 tests, no regression on either the byte-identical extraction or the bounded gauge behavior change
- [x] 3 pre-existing, unrelated test timeouts (`worker-checkin-{newest,ranked,fleet-critical}-window.test.js`) independently confirmed against clean `origin/main` with this branch's changes stashed out — identical failure, logged as harness bug (feedback `4d53aa7d`), not attributable to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)