### PR TITLE
fix(SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001): stage a matchable notification on every decision-SMS send

### DIFF
--- a/lib/chairman/sms-bridge.js
+++ b/lib/chairman/sms-bridge.js
@@ -258,7 +258,7 @@ async function insertChairmanSmsNotification(supabase, {
   decisionId, chairmanUserId, chairmanEmail, chairmanPhone,
   status = 'queued', providerMessageId = null, sentAt = null, errorMessage = null,
 }) {
-  const { error } = await supabase.from('chairman_notifications').insert({
+  const { data, error } = await supabase.from('chairman_notifications').insert({
     chairman_user_id: chairmanUserId,
     recipient_email: chairmanEmail,
     recipient_phone: chairmanPhone,
@@ -269,10 +269,11 @@ async function insertChairmanSmsNotification(supabase, {
     provider_message_id: providerMessageId,
     error_message: errorMessage,
     sent_at: sentAt,
-  });
+  }).select('id');
   if (error) {
     throw new Error(`insertChairmanSmsNotification: chairman_notifications insert failed for decision ${decisionId}: ${error.message}`);
   }
+  return Array.isArray(data) && data[0] ? data[0].id : null;
 }
 
 /**
@@ -332,23 +333,63 @@ async function updateChairmanDecisionSmsFields(supabase, { decisionId, token, ex
  * Both writes must succeed. This is the composed "insert THEN update, unconditionally" shape —
  * sendChairmanSmsQuestion's fallback-inline-send branch calls the two pieces directly instead,
  * because it must SKIP the chairman_decisions update when the provider send itself failed
- * (a message that never sent should not receive a live reply token).
+ * (a message that never sent should not receive a live reply token). A caller whose OWN send is
+ * synchronous and outcome-known only AFTER this call returns (the Adam-outbound gate — its
+ * sender dispatches inline and verifies delivery before returning, per QF-20260725-738) MUST
+ * call invalidateDecisionSmsStaging below on a confirmed send failure — staging here happens
+ * before that outcome is known, by design (FR-3 requires failing the send closed on a STAGING
+ * error), so a later TRANSPORT failure is a distinct case this function cannot itself detect.
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {{decisionId: string, chairmanUserId: string, chairmanEmail: string, chairmanPhone: string,
  *   options?: string[], token: string, expiresAt: string, status?: string,
  *   providerMessageId?: string|null, sentAt?: string|null, errorMessage?: string|null,
  *   consequenceLevel?: string}} args
+ * @returns {Promise<{notificationId: string|null}>}
  */
 export async function stageDecisionSmsNotification(supabase, {
   decisionId, chairmanUserId, chairmanEmail, chairmanPhone, options = [],
   token, expiresAt, status = 'queued', providerMessageId = null, sentAt = null, errorMessage = null,
   consequenceLevel,
 } = {}) {
-  await insertChairmanSmsNotification(supabase, {
+  const notificationId = await insertChairmanSmsNotification(supabase, {
     decisionId, chairmanUserId, chairmanEmail, chairmanPhone, status, providerMessageId, sentAt, errorMessage,
   });
   await updateChairmanDecisionSmsFields(supabase, { decisionId, token, expiresAt, options, consequenceLevel });
+  return { notificationId };
+}
+
+/**
+ * Undo a stageDecisionSmsNotification call after the caller learns — AFTER staging already ran —
+ * that the send itself did not actually reach the chairman. Adversarial-review finding
+ * (SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001, deep-tier review): the Adam-outbound gate's
+ * sender dispatches synchronously and reports a definitive outcome, so a staged-but-undelivered
+ * decision would otherwise sit live and matchable for the full token TTL — the exact "enqueue is
+ * not delivery" class this module was hardened against twice before (QF-20260719-509,
+ * QF-20260725-738), reopened through this new staging path. Clears the token (scoped to the
+ * EXACT token just set, so a concurrent successful re-stage of the same decision is never
+ * clobbered) so handleInboundSmsReply's eligibility filter can no longer match this decision, and
+ * marks the notification row failed for audit accuracy. Best-effort / fail-soft: never throws —
+ * the caller's own honest {sent:false} return is the real safety net; this is hardening on top.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{decisionId: string, token: string, notificationId?: string|null, reason?: string}} args
+ */
+export async function invalidateDecisionSmsStaging(supabase, { decisionId, token, notificationId = null, reason = 'transport_failed' }) {
+  try {
+    await supabase
+      .from('chairman_decisions')
+      .update({ sms_reply_token: null, sms_reply_token_expires_at: null })
+      .eq('id', decisionId)
+      .eq('sms_reply_token', token);
+    if (notificationId) {
+      await supabase
+        .from('chairman_notifications')
+        .update({ status: 'failed', error_message: reason })
+        .eq('id', notificationId);
+    }
+  } catch {
+    // Best-effort — see docstring. The caller's {sent:false} return already reports the truth.
+  }
 }
 
 /**

--- a/lib/chairman/sms-bridge.js
+++ b/lib/chairman/sms-bridge.js
@@ -245,6 +245,113 @@ export async function enqueueChairmanSms(supabase, { recipientPhone, kind, body,
 }
 
 /**
+ * Insert a chairman_notifications row for a decision-SMS send. The SOLE insert site for this
+ * table across both decision-SMS send paths (sendChairmanSmsQuestion + the Adam-outbound gate) —
+ * SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-1. Error-checked: throws rather than swallowing,
+ * unlike the pre-SD inline call sites this replaces.
+ * @private
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{decisionId: string, chairmanUserId: string, chairmanEmail: string, chairmanPhone: string,
+ *   status?: string, providerMessageId?: string|null, sentAt?: string|null, errorMessage?: string|null}} args
+ */
+async function insertChairmanSmsNotification(supabase, {
+  decisionId, chairmanUserId, chairmanEmail, chairmanPhone,
+  status = 'queued', providerMessageId = null, sentAt = null, errorMessage = null,
+}) {
+  const { error } = await supabase.from('chairman_notifications').insert({
+    chairman_user_id: chairmanUserId,
+    recipient_email: chairmanEmail,
+    recipient_phone: chairmanPhone,
+    notification_type: 'immediate',
+    channel: 'sms',
+    decision_id: decisionId,
+    status,
+    provider_message_id: providerMessageId,
+    error_message: errorMessage,
+    sent_at: sentAt,
+  });
+  if (error) {
+    throw new Error(`insertChairmanSmsNotification: chairman_notifications insert failed for decision ${decisionId}: ${error.message}`);
+  }
+}
+
+/**
+ * Patch chairman_decisions with the reply token/expiry (and brief_data.sms_options when the
+ * decision presented enumerated options) so handleInboundSmsReply's eligibility filter
+ * (status='pending' + live sms_reply_token_expires_at + !sms_reply_used_at) can actually resolve
+ * a reply — the candidate lookup (chairman_notifications) alone is necessary but not sufficient.
+ * The SOLE update site for these fields — SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-1/TR-2.
+ *
+ * Error-checked including a zero-rows-matched decisionId, which is Supabase's classic
+ * update-affecting-zero-rows-looks-like-success trap: only an explicit empty ARRAY from a
+ * `.select()`-chained update is treated as "row not found" (real supabase-js always returns an
+ * array — possibly empty — when `.select()` is chained and there is no error). A `data === null`
+ * result (no error) is treated as "unverifiable, not a failure" rather than a false-positive
+ * throw, so this stays compatible with older test doubles that don't model `.select()`-after-
+ * `.update()` readback.
+ * @private
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{decisionId: string, token: string, expiresAt: string, options?: string[], consequenceLevel?: string}} args
+ */
+async function updateChairmanDecisionSmsFields(supabase, { decisionId, token, expiresAt, options = [], consequenceLevel }) {
+  const normalizedOptions = Array.isArray(options) ? options : [];
+  let briefDataPatch = null;
+  if (normalizedOptions.length > 0) {
+    const { data: existingDecision } = await supabase
+      .from('chairman_decisions')
+      .select('brief_data')
+      .eq('id', decisionId)
+      .maybeSingle();
+    briefDataPatch = { ...((existingDecision && existingDecision.brief_data) || {}), sms_options: normalizedOptions };
+  }
+  const decisionUpdate = { sms_reply_token: token, sms_reply_token_expires_at: expiresAt };
+  if (briefDataPatch) decisionUpdate.brief_data = briefDataPatch;
+  if (consequenceLevel !== undefined) decisionUpdate.consequence_level = consequenceLevel;
+
+  const { data, error } = await supabase
+    .from('chairman_decisions')
+    .update(decisionUpdate)
+    .eq('id', decisionId)
+    .select('id');
+  if (error) {
+    throw new Error(`updateChairmanDecisionSmsFields: chairman_decisions update failed for decision ${decisionId}: ${error.message}`);
+  }
+  if (Array.isArray(data) && data.length === 0) {
+    throw new Error(`updateChairmanDecisionSmsFields: decision_not_found: no chairman_decisions row for id ${decisionId}`);
+  }
+}
+
+/**
+ * Stage a decision-SMS: insert the matchable chairman_notifications row AND patch
+ * chairman_decisions (token/expiry/options) so a later inbound reply can resolve it. Composes
+ * insertChairmanSmsNotification + updateChairmanDecisionSmsFields — the shared, error-checked
+ * TWO-WRITE staging helper extracted from sendChairmanSmsQuestion's obligation-enqueue branch
+ * and reused by the Adam-outbound gate (lib/comms/adam-outbound/chairman-sms-gate/index.js).
+ * SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-1/FR-3.
+ *
+ * Both writes must succeed. This is the composed "insert THEN update, unconditionally" shape —
+ * sendChairmanSmsQuestion's fallback-inline-send branch calls the two pieces directly instead,
+ * because it must SKIP the chairman_decisions update when the provider send itself failed
+ * (a message that never sent should not receive a live reply token).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{decisionId: string, chairmanUserId: string, chairmanEmail: string, chairmanPhone: string,
+ *   options?: string[], token: string, expiresAt: string, status?: string,
+ *   providerMessageId?: string|null, sentAt?: string|null, errorMessage?: string|null,
+ *   consequenceLevel?: string}} args
+ */
+export async function stageDecisionSmsNotification(supabase, {
+  decisionId, chairmanUserId, chairmanEmail, chairmanPhone, options = [],
+  token, expiresAt, status = 'queued', providerMessageId = null, sentAt = null, errorMessage = null,
+  consequenceLevel,
+} = {}) {
+  await insertChairmanSmsNotification(supabase, {
+    decisionId, chairmanUserId, chairmanEmail, chairmanPhone, status, providerMessageId, sentAt, errorMessage,
+  });
+  await updateChairmanDecisionSmsFields(supabase, { decisionId, token, expiresAt, options, consequenceLevel });
+}
+
+/**
  * Send a chairman a LOW/MEDIUM-consequence question over SMS. Never sends HIGH-consequence
  * questions regardless of caller intent (fail-closed — FR-3/FR-4).
  *
@@ -294,23 +401,6 @@ export async function sendChairmanSmsQuestion(supabase, opts, provider = twilioP
   const options = normalizeSmsOptions(opts.options);
   const message = composeMessage(title, options);
 
-  // Persist the presented options on the decision so handleInboundSmsReply can enforce the
-  // multiple-choice match. Stored under brief_data.sms_options (NOT sms_reply) — this is presented-
-  // QUESTION metadata, never the reply, so it is outside the free-text-untrusted seam and the
-  // anti-direct-read AST rule (which guards sms_reply only). Read+merge so existing brief_data keys
-  // are preserved; only touched when options are actually presented (legacy path unchanged).
-  let briefDataPatch = null;
-  if (options.length > 0) {
-    const { data: existingDecision } = await supabase
-      .from('chairman_decisions')
-      .select('brief_data')
-      .eq('id', decisionId)
-      .maybeSingle();
-    briefDataPatch = { ...((existingDecision && existingDecision.brief_data) || {}), sms_options: options };
-  }
-  const decisionUpdate = { sms_reply_token: token, sms_reply_token_expires_at: expiresAt, consequence_level: consequence };
-  if (briefDataPatch) decisionUpdate.brief_data = briefDataPatch;
-
   // SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-B FR-1: when the durable owed-state table is live,
   // ENQUEUE an owed obligation row instead of sending inline (the 201-as-success F1 defect). The
   // claim-serialized worker (reconcileOutboundSms) performs the actual send and stamps
@@ -320,23 +410,13 @@ export async function sendChairmanSmsQuestion(supabase, opts, provider = twilioP
   // false and we fall through to the unchanged pre-existing inline-send path below — so nothing in
   // the live send path regresses pre-apply.
   if (await smsOutboundObligationsLive(supabase)) {
-    await supabase.from('chairman_notifications').insert({
-      chairman_user_id: chairmanUserId,
-      recipient_email: chairmanEmail,
-      recipient_phone: chairmanPhone,
-      notification_type: 'immediate',
-      channel: 'sms',
-      decision_id: decisionId,
-      status: 'queued', // not yet accepted by the provider — the worker sends it
-      provider_message_id: null,
-      error_message: null,
-      sent_at: null,
+    // SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-1/FR-2: both writes, unconditionally — this
+    // branch defers the actual send to the async worker, so there is no failure to gate on yet.
+    await stageDecisionSmsNotification(supabase, {
+      decisionId, chairmanUserId, chairmanEmail, chairmanPhone, options, token, expiresAt,
+      status: 'queued', providerMessageId: null, sentAt: null, errorMessage: null,
+      consequenceLevel: consequence,
     });
-
-    await supabase
-      .from('chairman_decisions')
-      .update(decisionUpdate)
-      .eq('id', decisionId);
 
     // FR-6: this decision is being ASKED over SMS — stamp channel='sms' (fail-soft; no-op pre-apply).
     await stampSmsChannel(supabase, decisionId);
@@ -355,27 +435,21 @@ export async function sendChairmanSmsQuestion(supabase, opts, provider = twilioP
   const result = await provider.send({ to: chairmanPhone, body: message });
   const notifStatus = result.status === 'failed' ? 'failed' : result.status;
 
-  await supabase.from('chairman_notifications').insert({
-    chairman_user_id: chairmanUserId,
-    recipient_email: chairmanEmail,
-    recipient_phone: chairmanPhone,
-    notification_type: 'immediate',
-    channel: 'sms',
-    decision_id: decisionId,
-    status: notifStatus,
-    provider_message_id: result.provider_message_id || null,
-    error_message: result.reason || null,
-    sent_at: notifStatus === 'failed' ? null : new Date().toISOString(),
+  // SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-1/FR-2: the notification insert always runs
+  // (audit trail for a failed send too), but the chairman_decisions token/options patch must be
+  // SKIPPED on failure — a message that never sent must not receive a live reply token.
+  await insertChairmanSmsNotification(supabase, {
+    decisionId, chairmanUserId, chairmanEmail, chairmanPhone,
+    status: notifStatus, providerMessageId: result.provider_message_id || null,
+    sentAt: notifStatus === 'failed' ? null : new Date().toISOString(),
+    errorMessage: result.reason || null,
   });
 
   if (notifStatus === 'failed') {
     return { sent: false, reason: result.reason || 'provider_failed', consequence };
   }
 
-  await supabase
-    .from('chairman_decisions')
-    .update(decisionUpdate)
-    .eq('id', decisionId);
+  await updateChairmanDecisionSmsFields(supabase, { decisionId, token, expiresAt, options, consequenceLevel: consequence });
 
   // FR-6: this decision is being ASKED over SMS — stamp channel='sms' (fail-soft; no-op pre-apply).
   await stampSmsChannel(supabase, decisionId);

--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -27,8 +27,39 @@
  * real Twilio sender via makeDefaultSender() (a private factory); it is NOT exported.
  */
 
+import crypto from 'crypto';
 import { evaluate as defaultEvaluate, effectiveType } from '../rubric-engine/index.js';
 import { inQuietHours } from '../rubric-engine/lint.js';
+import { stageDecisionSmsNotification, TOKEN_TTL_MS } from '../../../chairman/sms-bridge.js';
+
+/**
+ * Lazily construct a real Supabase client for the FR-3 staging guard — matching the EXACT
+ * pattern makeDefaultSender().send() already uses below, not a second/different client
+ * construction (SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 TR-4). Only called when the guard
+ * actually needs to stage a decision notification and no opts.supabase was injected; unit tests
+ * always inject opts.supabase and never reach this.
+ */
+async function makeDefaultSupabaseClient() {
+  const { createClient } = await import('@supabase/supabase-js');
+  return createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+}
+
+/**
+ * message.options may carry either bare label strings or {label} objects (the rubric-engine's
+ * own lint tolerates both — see rubric-engine/lint.js's `o.label ?? o`). The matcher
+ * (lib/chairman/sms-bridge.js matchSmsOption) and brief_data.sms_options require plain strings.
+ * @param {unknown} options
+ * @returns {string[]}
+ */
+function extractOptionLabels(options) {
+  if (!Array.isArray(options)) return [];
+  return options
+    .map((o) => (typeof o === 'string' ? o : o && typeof o.label === 'string' ? o.label : null))
+    .filter((label) => typeof label === 'string' && label.trim() !== '');
+}
 
 /**
  * Private Twilio-sender factory. The ONLY place credentials are read. Not exported — callers
@@ -299,6 +330,45 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   if (result.authorityClass === 'console') {
     log.warn('[chairman-sms-gate] console-authority message routed to console, not SMS');
     return { sent: false, routedToConsole: true, reason: 'console_authority', verdict: 'pass', authorityClass: 'console' };
+  }
+
+  // SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-3: a decision packet without a matchable
+  // chairman_notifications row must never go out. Scoped to type='decision' with a decisionId —
+  // status/heartbeat sends (TR-3) and decision sends already held above are untouched, and no
+  // supabase client is ever constructed for them. Runs BEFORE dispatch; never throws out of
+  // sendChairmanSMS (TR-3) — not every caller of this function wraps it in try/catch.
+  if (isDecision && message.decisionId) {
+    try {
+      const supabase = opts.supabase || await makeDefaultSupabaseClient();
+      // TR-5: resolve chairman identity ONCE, via the same env-var fallback already proven in
+      // lib/switch-automation/switchon-decision-packet.js, and reuse it for BOTH staging and
+      // dispatch below — a caller (e.g. the decision-scheduler) supplying none of these must not
+      // have staging and dispatch silently resolve to two different phone numbers.
+      const chairmanUserId = message.chairmanUserId || process.env.CHAIRMAN_USER_ID;
+      const chairmanEmail = message.chairmanEmail || process.env.CHAIRMAN_EMAIL;
+      const recipientPhone = message.recipientPhone || process.env.CHAIRMAN_PHONE;
+      const token = crypto.randomBytes(16).toString('hex');
+      const expiresAt = new Date(Date.now() + TOKEN_TTL_MS).toISOString();
+
+      await stageDecisionSmsNotification(supabase, {
+        decisionId: message.decisionId,
+        chairmanUserId,
+        chairmanEmail,
+        chairmanPhone: recipientPhone,
+        options: extractOptionLabels(message.options),
+        token,
+        expiresAt,
+        status: 'queued', // this gate always dispatches via the async obligation path below
+        providerMessageId: null,
+        sentAt: null,
+        errorMessage: null,
+      });
+
+      if (!message.recipientPhone) message = { ...message, recipientPhone };
+    } catch (err) {
+      log.error(`[chairman-sms-gate] decision notification staging failed, NOT sending: ${err.message}`);
+      return { sent: false, reason: 'notification_stage_failed', detail: err.message, verdict: 'pass', authorityClass: 'sms' };
+    }
   }
 
   // pass + sms-authority -> send via the isolated sender.

--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -30,7 +30,7 @@
 import crypto from 'crypto';
 import { evaluate as defaultEvaluate, effectiveType } from '../rubric-engine/index.js';
 import { inQuietHours } from '../rubric-engine/lint.js';
-import { stageDecisionSmsNotification, TOKEN_TTL_MS } from '../../../chairman/sms-bridge.js';
+import { stageDecisionSmsNotification, invalidateDecisionSmsStaging, TOKEN_TTL_MS } from '../../../chairman/sms-bridge.js';
 
 /**
  * Lazily construct a real Supabase client for the FR-3 staging guard — matching the EXACT
@@ -337,6 +337,15 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   // status/heartbeat sends (TR-3) and decision sends already held above are untouched, and no
   // supabase client is ever constructed for them. Runs BEFORE dispatch; never throws out of
   // sendChairmanSMS (TR-3) — not every caller of this function wraps it in try/catch.
+  //
+  // decisionStaging is captured (not just discarded) because this gate's default sender
+  // DISPATCHES SYNCHRONOUSLY and reports a definitive outcome (makeDefaultSender().send() below,
+  // QF-20260725-738) — unlike sendChairmanSmsQuestion's obligation branch, staging here can be
+  // proven wrong by the time send() returns. Adversarial-review finding: without rolling back on
+  // a confirmed transport failure, a staged-but-undelivered decision stays live and matchable for
+  // the full token TTL — the "enqueue is not delivery" class this module was hardened against
+  // twice before, reopened through this new staging path.
+  let decisionStaging = null;
   if (isDecision && message.decisionId) {
     try {
       const supabase = opts.supabase || await makeDefaultSupabaseClient();
@@ -350,7 +359,7 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
       const token = crypto.randomBytes(16).toString('hex');
       const expiresAt = new Date(Date.now() + TOKEN_TTL_MS).toISOString();
 
-      await stageDecisionSmsNotification(supabase, {
+      const { notificationId } = await stageDecisionSmsNotification(supabase, {
         decisionId: message.decisionId,
         chairmanUserId,
         chairmanEmail,
@@ -363,6 +372,7 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
         sentAt: null,
         errorMessage: null,
       });
+      decisionStaging = { supabase, decisionId: message.decisionId, token, notificationId };
 
       if (!message.recipientPhone) message = { ...message, recipientPhone };
     } catch (err) {
@@ -371,12 +381,28 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
     }
   }
 
-  // pass + sms-authority -> send via the isolated sender.
-  const sendResult = await sender.send(message);
+  // pass + sms-authority -> send via the isolated sender. Wrapped in try/catch so a sender that
+  // THROWS (rather than resolving to {softFailed:true}, the documented contract every current
+  // caller's makeDefaultSender() honours) still rolls back a staged token instead of bypassing
+  // the check below entirely (adversarial-review hardening — defensive, not currently reachable
+  // via any production caller, but the invariant should not depend on every future sender
+  // honouring an unenforced contract).
+  let sendResult;
+  try {
+    sendResult = await sender.send(message);
+  } catch (err) {
+    sendResult = { sid: null, softFailed: true, reason: `sender_threw: ${err.message}` };
+  }
   if (sendResult && sendResult.softFailed) {
     // QF-20260719-509 LIVE INCIDENT: a soft-failed transport must NEVER report sent:true (the
     // exact "false success" the chairman hit — "text me if you need me" dropped silently).
     log.error(`[chairman-sms-gate] TRANSPORT SOFT-FAILED, message NOT delivered: ${sendResult.reason}`);
+    if (decisionStaging) {
+      await invalidateDecisionSmsStaging(decisionStaging.supabase, {
+        decisionId: decisionStaging.decisionId, token: decisionStaging.token,
+        notificationId: decisionStaging.notificationId, reason: sendResult.reason,
+      });
+    }
     const fb = await fallbackSend({ message, reason: sendResult.reason });
     return { sent: false, transportFailed: true, fallbackFired: !!fb.fired, reason: sendResult.reason, verdict: 'pass', authorityClass: 'sms' };
   }

--- a/scripts/__tests__/adam-chairman-decision-decision-id-required.test.js
+++ b/scripts/__tests__/adam-chairman-decision-decision-id-required.test.js
@@ -1,0 +1,48 @@
+/**
+ * SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-4 / TS-5 — scripts/adam-chairman-decision.mjs
+ * must refuse to build a send when --decision-id is omitted, matching its existing
+ * --body/--option/--no-reply-policy required-field pattern.
+ *
+ * Subprocess-based (spawnSync), matching tests/cli-graceful-exit.test.js's convention — this
+ * script has top-level, argv-driven side-effecting code that can only be exercised by actually
+ * running it. --dry-run keeps it offline (no Twilio/Supabase reached).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'adam-chairman-decision.mjs');
+
+function runCli(args, timeoutMs = 15000) {
+  return spawnSync(process.execPath, [SCRIPT, '--dry-run', ...args], {
+    encoding: 'utf8', timeout: timeoutMs, cwd: ROOT,
+  });
+}
+
+describe('adam-chairman-decision.mjs — --decision-id required (FR-4)', () => {
+  it('TS-5: --body/--option x2/--no-reply-policy but NO --decision-id refuses, exit 0, no dry-run payload printed', () => {
+    const r = runCli(['--body', 'Ship now or wait?', '--option', 'A', '--option', 'B', '--no-reply-policy', 'defaults to hold']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).not.toContain('DRY RUN');
+    expect(r.stdout + r.stderr).toContain('--decision-id');
+  });
+
+  it('the same invocation WITH --decision-id proceeds exactly as before this SD (dry-run payload printed, carries decisionId)', () => {
+    const r = runCli(['--body', 'Ship now or wait?', '--option', 'A', '--option', 'B', '--no-reply-policy', 'defaults to hold', '--decision-id', 'dec-cli-test-1']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('DRY RUN');
+    const jsonStart = r.stdout.indexOf('{');
+    const payload = JSON.parse(r.stdout.slice(jsonStart));
+    expect(payload.decisionId).toBe('dec-cli-test-1');
+    expect(payload.type).toBe('decision');
+  });
+
+  it('still refuses on other pre-existing missing-field cases (regression: the OR-condition was extended, not replaced)', () => {
+    const r = runCli(['--option', 'A', '--option', 'B', '--no-reply-policy', 'defaults to hold', '--decision-id', 'dec-cli-test-2']); // no --body
+    expect(r.status).toBe(0);
+    expect(r.stdout).not.toContain('DRY RUN');
+  });
+});

--- a/scripts/adam-chairman-decision.mjs
+++ b/scripts/adam-chairman-decision.mjs
@@ -40,8 +40,14 @@ const noReplyConsequence = argValue('--no-reply-policy');
 const replyInstruction = argValue('--reply-instruction')
   || `Reply with the option letter, or DETAILS for more context (ref ${replyId}).`;
 
-if (!bodyText || !bodyText.trim() || options.length < 2 || !noReplyConsequence || !noReplyConsequence.trim()) {
-  console.warn('[adam-chairman-decision] --body, at least two --option, and --no-reply-policy are required — nothing sent');
+const decisionId = argValue('--decision-id');
+
+// SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-4: --decision-id is required, not optional.
+// Without it the chairman-sms-gate's staging guard never fires (it only fires when a decisionId
+// is present), and the decisionId must reference an EXISTING chairman_decisions row anyway for a
+// letter reply to resolve anything — a decision packet with no decisionId has nothing to answer.
+if (!bodyText || !bodyText.trim() || options.length < 2 || !noReplyConsequence || !noReplyConsequence.trim() || !decisionId) {
+  console.warn('[adam-chairman-decision] --body, at least two --option, --no-reply-policy, and --decision-id are required — nothing sent');
   process.exit(0);
 }
 
@@ -53,7 +59,7 @@ const message = {
   replyInstruction,
   replyId,
   noReplyConsequence: noReplyConsequence.trim(),
-  decisionId: argValue('--decision-id') || null,
+  decisionId,
   dedupeKey: argValue('--dedupe-key') || null,
 };
 if (DRY) {

--- a/tests/unit/chairman/sms-decision-notification-staging.test.js
+++ b/tests/unit/chairman/sms-decision-notification-staging.test.js
@@ -1,0 +1,250 @@
+/**
+ * SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 — the shared decision-SMS staging helper
+ * (stageDecisionSmsNotification, extracted from sendChairmanSmsQuestion) and the round-trip
+ * proof that staging alone produces state handleInboundSmsReply can actually resolve.
+ *
+ * Fake supabase mirrors tests/unit/chairman/sms-decision-guardrails.test.js's shape (not
+ * imported/modified — that file belongs to a different, already-shipped SD and must keep
+ * passing unmodified per this SD's own FR-2), extended with insert/update error injection and a
+ * faithful .select()-after-.update() readback (returns the matched rows, or [] when none match)
+ * so the zero-rows-matched (TR-2) path is directly testable.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  sendChairmanSmsQuestion,
+  stageDecisionSmsNotification,
+  handleInboundSmsReply,
+} from '../../../lib/chairman/sms-bridge.js';
+
+function makeFakeSupabase(seed = {}, { forceInsertError = null, forceUpdateError = null } = {}) {
+  const tables = {
+    chairman_notifications: [...(seed.chairman_notifications || [])],
+    chairman_decisions: [...(seed.chairman_decisions || [])],
+    sms_inbound_log: [...(seed.sms_inbound_log || [])],
+    sms_inbound_suspensions: [...(seed.sms_inbound_suspensions || [])],
+    sms_decision_class_whitelist: [...(seed.sms_decision_class_whitelist || [])],
+  };
+  let seq = 0;
+
+  function applyFilters(rows, filters) {
+    return rows.filter((row) =>
+      filters.every(([col, op, val]) => {
+        if (op === 'eq') return row[col] === val;
+        if (op === 'gte') return (row[col] ?? null) !== null && row[col] >= val;
+        if (op === 'not_is_null') return row[col] !== null && row[col] !== undefined;
+        if (op === 'in') return Array.isArray(val) && val.includes(row[col]);
+        if (op === 'is') return (row[col] ?? null) === val;
+        return true;
+      })
+    );
+  }
+
+  function from(table) {
+    const ctx = { filters: [], order: null, limitN: null, mode: null, countMode: false, returnSelect: false };
+    const api = {
+      select(_cols, opts) {
+        if (ctx.mode === 'update' || ctx.mode === 'insert') { ctx.returnSelect = true; return api; }
+        ctx.mode = 'select';
+        if (opts?.count === 'exact' && opts?.head) ctx.countMode = true;
+        return api;
+      },
+      insert(row) { ctx.mode = 'insert'; ctx.row = { id: `row-${++seq}`, created_at: new Date().toISOString(), ...row }; return api; },
+      update(vals) { ctx.mode = 'update'; ctx.vals = vals; return api; },
+      eq(col, val) { ctx.filters.push([col, 'eq', val]); return api; },
+      gte(col, val) { ctx.filters.push([col, 'gte', val]); return api; },
+      not(col) { ctx.filters.push([col, 'not_is_null', null]); return api; },
+      in(col, arr) { ctx.filters.push([col, 'in', arr]); return api; },
+      is(col, val) { ctx.filters.push([col, 'is', val]); return api; },
+      order(col, { ascending } = {}) { ctx.order = { col, ascending: !!ascending }; return api; },
+      limit(n) { ctx.limitN = n; return api; },
+      async maybeSingle() {
+        const rows = applyFilters(tables[table], ctx.filters);
+        return { data: rows[0] || null, error: null };
+      },
+      then(resolve) {
+        if (ctx.mode === 'insert') {
+          if (forceInsertError && forceInsertError.table === table) {
+            resolve({ data: null, error: { message: forceInsertError.message || 'forced insert error' } });
+            return;
+          }
+          tables[table].push(ctx.row);
+          resolve({ data: [{ id: ctx.row.id }], error: null });
+          return;
+        }
+        if (ctx.mode === 'update') {
+          if (forceUpdateError && forceUpdateError.table === table) {
+            resolve({ data: null, error: { message: forceUpdateError.message || 'forced update error' } });
+            return;
+          }
+          const rows = applyFilters(tables[table], ctx.filters);
+          rows.forEach((r) => Object.assign(r, ctx.vals));
+          resolve({ data: ctx.returnSelect ? rows.map((r) => ({ id: r.id })) : null, error: null });
+          return;
+        }
+        let rows = applyFilters(tables[table], ctx.filters);
+        if (ctx.order) {
+          rows = [...rows].sort((a, b) => {
+            const cmp = a[ctx.order.col] < b[ctx.order.col] ? -1 : a[ctx.order.col] > b[ctx.order.col] ? 1 : 0;
+            return ctx.order.ascending ? cmp : -cmp;
+          });
+        }
+        if (ctx.limitN != null) rows = rows.slice(0, ctx.limitN);
+        if (ctx.countMode) resolve({ count: rows.length, data: null, error: null });
+        else resolve({ data: rows, error: null });
+      },
+    };
+    return api;
+  }
+
+  return { from, _tables: tables };
+}
+
+const future = () => new Date(Date.now() + 10 * 60_000).toISOString();
+
+describe('stageDecisionSmsNotification (FR-1)', () => {
+  it('TS-1: stages exactly one matchable chairman_notifications row + chairman_decisions patch', async () => {
+    const sb = makeFakeSupabase({
+      chairman_decisions: [{ id: 'dec-1', status: 'pending', brief_data: {} }],
+    });
+    await stageDecisionSmsNotification(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'chairman@example.com', chairmanPhone: '+15551234567',
+      options: ['A) ship', 'B) hold'], token: 'tok-1', expiresAt: future(),
+    });
+    expect(sb._tables.chairman_notifications).toHaveLength(1);
+    const row = sb._tables.chairman_notifications[0];
+    expect(row).toMatchObject({
+      channel: 'sms', decision_id: 'dec-1', chairman_user_id: 'u1', recipient_email: 'chairman@example.com',
+      recipient_phone: '+15551234567', status: 'queued',
+    });
+    const decision = sb._tables.chairman_decisions[0];
+    expect(decision.sms_reply_token).toBe('tok-1');
+    expect(decision.brief_data.sms_options).toEqual(['A) ship', 'B) hold']);
+  });
+
+  it('TS-2: an injected chairman_notifications insert error throws, and chairman_decisions is never touched', async () => {
+    const sb = makeFakeSupabase(
+      { chairman_decisions: [{ id: 'dec-1', status: 'pending', brief_data: {} }] },
+      { forceInsertError: { table: 'chairman_notifications', message: 'insert boom' } },
+    );
+    await expect(stageDecisionSmsNotification(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+1555',
+      options: [], token: 'tok-1', expiresAt: future(),
+    })).rejects.toThrow(/insert boom/);
+    expect(sb._tables.chairman_decisions[0].sms_reply_token).toBeUndefined();
+  });
+
+  it('TR-2: a decisionId that matches zero chairman_decisions rows throws decision_not_found (the notification row is already staged by then)', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [] }); // no row for 'dec-missing'
+    await expect(stageDecisionSmsNotification(sb, {
+      decisionId: 'dec-missing', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+1555',
+      options: [], token: 'tok-1', expiresAt: future(),
+    })).rejects.toThrow(/decision_not_found/);
+    // The notification insert still landed — this is the "loud, distinguishable failure" FR-4 relies on.
+    expect(sb._tables.chairman_notifications).toHaveLength(1);
+  });
+
+  it('an injected chairman_decisions update error throws', async () => {
+    const sb = makeFakeSupabase(
+      { chairman_decisions: [{ id: 'dec-1', status: 'pending', brief_data: {} }] },
+      { forceUpdateError: { table: 'chairman_decisions', message: 'update boom' } },
+    );
+    await expect(stageDecisionSmsNotification(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+1555',
+      options: [], token: 'tok-1', expiresAt: future(),
+    })).rejects.toThrow(/update boom/);
+  });
+});
+
+describe('TS-3: staging alone produces state the matcher can resolve — no hand-seeded matcher columns', () => {
+  it("a bare pending chairman_decisions row + sendChairmanSmsQuestion's own staging resolves a 'B' reply", async () => {
+    const sb = makeFakeSupabase({
+      sms_decision_class_whitelist: [{ decision_class: 'schedule', active: true }],
+      chairman_decisions: [{ id: 'dec-1', status: 'pending', brief_data: {} }],
+    });
+    const provider = { send: async () => ({ provider_message_id: 'SID-1', status: 'queued' }) };
+    // Bare-letter labels — matches the real production convention (Adam's CLI passes
+    // --option A --option B as literal single-letter labels; matchSmsOption does an exact
+    // case-insensitive label match, so a reply body of 'B' must match a label of exactly 'B').
+    const sent = await sendChairmanSmsQuestion(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+15551234567',
+      title: 'Ship now or hold?', decisionType: 'schedule', options: ['A', 'B'],
+    }, provider, { quietWindow: () => false });
+    expect(sent.sent).toBe(true);
+
+    const reply = await handleInboundSmsReply(sb, {
+      from: '+15551234567', to: '+15559999999', body: 'B', messageSid: 'SM-in-1', signatureValid: true,
+    });
+    expect(reply.outcome).toBe('answered');
+    expect(reply.resolved).toBe(true);
+    expect(reply.decisionId).toBe('dec-1');
+    const decision = sb._tables.chairman_decisions[0];
+    expect(decision.brief_data.sms_reply.option).toBe('B');
+  });
+});
+
+describe('TS-4: sendChairmanSmsQuestion regression pin — both branches keep their exact pre-refactor field values', () => {
+  // A FACTORY, not a shared literal — makeFakeSupabase's `[...(seed.chairman_decisions || [])]`
+  // only shallow-copies the array; the row OBJECTS inside would still be shared (and mutated) by
+  // reference across all three tests below if this were one const object reused by each `it()`.
+  const seedWhitelisted = () => ({
+    sms_decision_class_whitelist: [{ decision_class: 'schedule', active: true }],
+    chairman_decisions: [{ id: 'dec-1', status: 'pending', brief_data: {} }],
+  });
+
+  it('obligation-enqueue branch (durable table live): status=queued, provider_message_id=null, sent_at=null, error_message=null', async () => {
+    const sb = makeFakeSupabase(seedWhitelisted());
+    sb._tables.sms_outbound_obligations = []; // presence of the table makes smsOutboundObligationsLive() true
+    const origFrom = sb.from;
+    sb.from = (table) => {
+      if (table === 'sms_outbound_obligations') {
+        return { select: () => ({ limit: async () => ({ error: null }) }), upsert: () => ({ select: async () => ({ data: [{ id: 'ob-1' }], error: null }) }) };
+      }
+      return origFrom(table);
+    };
+    const provider = { send: async () => ({ provider_message_id: 'UNUSED', status: 'queued' }) };
+    const result = await sendChairmanSmsQuestion(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+1555',
+      title: 'Ship now or hold?', decisionType: 'schedule',
+    }, provider, { quietWindow: () => false });
+    expect(result.enqueued).toBe(true);
+    const row = sb._tables.chairman_notifications[0];
+    expect(row.status).toBe('queued');
+    expect(row.provider_message_id).toBeNull();
+    expect(row.sent_at).toBeNull();
+    expect(row.error_message).toBeNull();
+    expect(sb._tables.chairman_decisions[0].sms_reply_token).toBeTruthy();
+  });
+
+  it('fallback branch, provider success: status/provider_message_id/sent_at from the real send result, chairman_decisions IS updated', async () => {
+    const sb = makeFakeSupabase(seedWhitelisted()); // no sms_outbound_obligations table -> fallback path
+    const provider = { send: async () => ({ provider_message_id: 'SID-OK', status: 'sent' }) };
+    const result = await sendChairmanSmsQuestion(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+1555',
+      title: 'Ship now or hold?', decisionType: 'schedule',
+    }, provider, { quietWindow: () => false });
+    expect(result.sent).toBe(true);
+    const row = sb._tables.chairman_notifications[0];
+    expect(row.status).toBe('sent');
+    expect(row.provider_message_id).toBe('SID-OK');
+    expect(row.sent_at).not.toBeNull();
+    expect(row.error_message).toBeNull();
+    expect(sb._tables.chairman_decisions[0].sms_reply_token).toBeTruthy();
+  });
+
+  it('fallback branch, provider failure: status=failed, error_message set, sent_at=null, chairman_decisions NOT updated', async () => {
+    const sb = makeFakeSupabase(seedWhitelisted());
+    const provider = { send: async () => ({ status: 'failed', reason: 'carrier_rejected' }) };
+    const result = await sendChairmanSmsQuestion(sb, {
+      decisionId: 'dec-1', chairmanUserId: 'u1', chairmanEmail: 'c@example.com', chairmanPhone: '+1555',
+      title: 'Ship now or hold?', decisionType: 'schedule',
+    }, provider, { quietWindow: () => false });
+    expect(result.sent).toBe(false);
+    expect(result.reason).toBe('carrier_rejected');
+    const row = sb._tables.chairman_notifications[0];
+    expect(row.status).toBe('failed');
+    expect(row.error_message).toBe('carrier_rejected');
+    expect(row.sent_at).toBeNull();
+    // The chairman_decisions row must NOT receive a reply token for a send that never went out.
+    expect(sb._tables.chairman_decisions[0].sms_reply_token).toBeUndefined();
+  });
+});

--- a/tests/unit/comms/chairman-sms-gate/chairman-sms-gate-decision-staging.test.js
+++ b/tests/unit/comms/chairman-sms-gate/chairman-sms-gate-decision-staging.test.js
@@ -1,0 +1,216 @@
+/**
+ * SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001 FR-3 — the Adam-outbound gate's decision-staging
+ * guard: stage BEFORE dispatch, fail closed (never throw) on staging failure, resolve chairman
+ * identity once and reuse it for both staging and dispatch.
+ *
+ * wellFormedDecision/DAYTIME/makeSender/silentConsole are duplicated locally (small, self-
+ * contained) rather than imported from chairman-sms-gate.test.js — that file belongs to a
+ * different SD and its local helpers are not exported; duplicating ~10 lines avoids any risk to
+ * its own passing suite.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { sendChairmanSMS } from '../../../../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+import { handleInboundSmsReply } from '../../../../lib/chairman/sms-bridge.js';
+
+function wellFormedDecision(overrides = {}) {
+  return {
+    type: 'decision',
+    body: 'Approve the deploy? Reply A or B. Reply DETAILS for the rationale.',
+    options: [{ label: 'A' }, { label: 'B' }],
+    decisionCount: 1,
+    replyInstruction: 'Reply A or B (or DETAILS)',
+    replyId: 'dec-c-1',
+    noReplyConsequence: 'no reply by 5pm ET -> I hold (reversible)',
+    ...overrides,
+  };
+}
+
+const DAYTIME = { nowHourET: 14, rateCap: 10, sentInWindow: 0 };
+const makeSender = () => ({ send: vi.fn(async () => ({ sid: 'SM-test' })) });
+const silentConsole = { warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+
+/** Minimal fake supabase covering exactly what stageDecisionSmsNotification + handleInboundSmsReply need. */
+function makeFakeSupabase(seed = {}, { forceInsertError = null } = {}) {
+  const tables = {
+    chairman_notifications: [...(seed.chairman_notifications || [])],
+    chairman_decisions: [...(seed.chairman_decisions || [])],
+    sms_inbound_log: [...(seed.sms_inbound_log || [])],
+    sms_inbound_suspensions: [...(seed.sms_inbound_suspensions || [])],
+  };
+  let seq = 0;
+  function applyFilters(rows, filters) {
+    return rows.filter((row) =>
+      filters.every(([col, op, val]) => {
+        if (op === 'eq') return row[col] === val;
+        if (op === 'gte') return (row[col] ?? null) !== null && row[col] >= val;
+        if (op === 'not_is_null') return row[col] !== null && row[col] !== undefined;
+        if (op === 'in') return Array.isArray(val) && val.includes(row[col]);
+        if (op === 'is') return (row[col] ?? null) === val;
+        return true;
+      })
+    );
+  }
+  function from(table) {
+    const ctx = { filters: [], order: null, limitN: null, mode: null, countMode: false, returnSelect: false };
+    const api = {
+      select(_cols, opts) {
+        if (ctx.mode === 'update' || ctx.mode === 'insert') { ctx.returnSelect = true; return api; }
+        ctx.mode = 'select';
+        if (opts?.count === 'exact' && opts?.head) ctx.countMode = true;
+        return api;
+      },
+      insert(row) { ctx.mode = 'insert'; ctx.row = { id: `row-${++seq}`, created_at: new Date().toISOString(), ...row }; return api; },
+      update(vals) { ctx.mode = 'update'; ctx.vals = vals; return api; },
+      eq(col, val) { ctx.filters.push([col, 'eq', val]); return api; },
+      gte(col, val) { ctx.filters.push([col, 'gte', val]); return api; },
+      not(col) { ctx.filters.push([col, 'not_is_null', null]); return api; },
+      in(col, arr) { ctx.filters.push([col, 'in', arr]); return api; },
+      is(col, val) { ctx.filters.push([col, 'is', val]); return api; },
+      order(col, { ascending } = {}) { ctx.order = { col, ascending: !!ascending }; return api; },
+      limit(n) { ctx.limitN = n; return api; },
+      async maybeSingle() {
+        const rows = applyFilters(tables[table], ctx.filters);
+        return { data: rows[0] || null, error: null };
+      },
+      then(resolve) {
+        if (ctx.mode === 'insert') {
+          if (forceInsertError && forceInsertError.table === table) {
+            resolve({ data: null, error: { message: forceInsertError.message || 'forced insert error' } });
+            return;
+          }
+          tables[table].push(ctx.row);
+          resolve({ data: [{ id: ctx.row.id }], error: null });
+          return;
+        }
+        if (ctx.mode === 'update') {
+          const rows = applyFilters(tables[table], ctx.filters);
+          rows.forEach((r) => Object.assign(r, ctx.vals));
+          resolve({ data: ctx.returnSelect ? rows.map((r) => ({ id: r.id })) : null, error: null });
+          return;
+        }
+        let rows = applyFilters(tables[table], ctx.filters);
+        if (ctx.order) rows = [...rows].sort((a, b) => (a[ctx.order.col] < b[ctx.order.col] ? -1 : a[ctx.order.col] > b[ctx.order.col] ? 1 : -0));
+        if (ctx.limitN != null) rows = rows.slice(0, ctx.limitN);
+        if (ctx.countMode) resolve({ count: rows.length, data: null, error: null });
+        else resolve({ data: rows, error: null });
+      },
+    };
+    return api;
+  }
+  return { from, _tables: tables };
+}
+
+describe('chairman-sms-gate sendChairmanSMS() — FR-3 decision staging guard', () => {
+  it('TS-1: decision send with decisionId stages exactly one matchable row + token via env-var identity resolution', async () => {
+    const prevUser = process.env.CHAIRMAN_USER_ID, prevEmail = process.env.CHAIRMAN_EMAIL, prevPhone = process.env.CHAIRMAN_PHONE;
+    process.env.CHAIRMAN_USER_ID = 'u-env';
+    process.env.CHAIRMAN_EMAIL = 'chairman@env.example';
+    process.env.CHAIRMAN_PHONE = '+15550001111';
+    try {
+      const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-env-1', status: 'pending', brief_data: {} }] });
+      const sender = makeSender();
+      const res = await sendChairmanSMS(
+        wellFormedDecision({ decisionId: 'dec-env-1' }),
+        DAYTIME,
+        { sender, console: silentConsole, supabase: sb },
+      );
+      expect(res.sent).toBe(true);
+      expect(sender.send).toHaveBeenCalledTimes(1);
+      expect(sb._tables.chairman_notifications).toHaveLength(1);
+      const row = sb._tables.chairman_notifications[0];
+      expect(row).toMatchObject({
+        channel: 'sms', decision_id: 'dec-env-1', chairman_user_id: 'u-env',
+        recipient_email: 'chairman@env.example', recipient_phone: '+15550001111', status: 'queued',
+      });
+      expect(sb._tables.chairman_decisions[0].sms_reply_token).toBeTruthy();
+      // The dispatched message carries the SAME resolved phone staging used (TR-5).
+      expect(sender.send.mock.calls[0][0].recipientPhone).toBe('+15550001111');
+    } finally {
+      process.env.CHAIRMAN_USER_ID = prevUser; process.env.CHAIRMAN_EMAIL = prevEmail; process.env.CHAIRMAN_PHONE = prevPhone;
+    }
+  });
+
+  it('TS-2: a staging error blocks the send and returns notification_stage_failed WITHOUT throwing', async () => {
+    const sb = makeFakeSupabase(
+      { chairman_decisions: [{ id: 'dec-2', status: 'pending', brief_data: {} }] },
+      { forceInsertError: { table: 'chairman_notifications', message: 'staging boom' } },
+    );
+    const sender = makeSender();
+    const res = await sendChairmanSMS(
+      wellFormedDecision({ decisionId: 'dec-2' }),
+      DAYTIME,
+      { sender, console: silentConsole, supabase: sb },
+    );
+    expect(res.sent).toBe(false);
+    expect(res.reason).toBe('notification_stage_failed');
+    expect(sender.send).not.toHaveBeenCalled();
+    expect(silentConsole.error).toHaveBeenCalled();
+  });
+
+  it('TS-3: the round trip starts from sendChairmanSMS itself — a bare letter reply resolves against what the guard staged', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-3', status: 'pending', brief_data: {} }] });
+    const sender = { send: vi.fn(async (message) => ({ sid: 'SM-3', recipientPhoneUsed: message.recipientPhone })) };
+    const res = await sendChairmanSMS(
+      wellFormedDecision({ decisionId: 'dec-3', recipientPhone: '+15559998888' }),
+      DAYTIME,
+      { sender, console: silentConsole, supabase: sb },
+    );
+    expect(res.sent).toBe(true);
+
+    const reply = await handleInboundSmsReply(sb, {
+      from: '+15559998888', to: '+15550000000', body: 'B', messageSid: 'SM-in-3', signatureValid: true,
+    });
+    expect(reply.outcome).toBe('answered');
+    expect(reply.resolved).toBe(true);
+    expect(reply.decisionId).toBe('dec-3');
+  });
+
+  it('TS-6: a type=status message never stages and never constructs a supabase client', async () => {
+    const sender = makeSender();
+    const supabaseSpy = vi.fn();
+    const res = await sendChairmanSMS(
+      { type: 'status', body: 'heartbeat: all clear', kind: 'heartbeat' },
+      DAYTIME,
+      { sender, console: silentConsole, get supabase() { supabaseSpy(); return undefined; } },
+    );
+    expect(res.sent).toBe(true);
+    expect(supabaseSpy).not.toHaveBeenCalled();
+  });
+
+  it('TS-7: the gate always stages with status=queued (async-obligation shape), never a synchronous post-send shape', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-7', status: 'pending', brief_data: {} }] });
+    const sender = makeSender();
+    await sendChairmanSMS(wellFormedDecision({ decisionId: 'dec-7' }), DAYTIME, { sender, console: silentConsole, supabase: sb });
+    const row = sb._tables.chairman_notifications[0];
+    expect(row.status).toBe('queued');
+    expect(row.provider_message_id).toBeNull();
+    expect(row.sent_at).toBeNull();
+  });
+
+  it('TS-8: a message the classifier does NOT resolve to decision never stages, regardless of decisionId', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-8', status: 'pending', brief_data: {} }] });
+    const sender = makeSender();
+    // type='status' with a decisionId still present -- effectiveType(message) reads message.type,
+    // so this is NOT classified as 'decision' and must not stage regardless of decisionId.
+    const res = await sendChairmanSMS(
+      { type: 'status', body: 'informational only', kind: 'status_update', decisionId: 'dec-8' },
+      DAYTIME,
+      { sender, console: silentConsole, supabase: sb },
+    );
+    expect(res.sent).toBe(true);
+    expect(sb._tables.chairman_notifications).toHaveLength(0);
+  });
+
+  it('TS-9: type=decision with a falsy decisionId skips staging without error (defensive — FR-4 makes this unreachable via the CLI)', async () => {
+    const sb = makeFakeSupabase({});
+    const sender = makeSender();
+    const res = await sendChairmanSMS(
+      wellFormedDecision({ decisionId: null }),
+      DAYTIME,
+      { sender, console: silentConsole, supabase: sb },
+    );
+    expect(res.sent).toBe(true);
+    expect(sb._tables.chairman_notifications).toHaveLength(0);
+    expect(sender.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/comms/chairman-sms-gate/chairman-sms-gate-decision-staging.test.js
+++ b/tests/unit/comms/chairman-sms-gate/chairman-sms-gate-decision-staging.test.js
@@ -213,4 +213,44 @@ describe('chairman-sms-gate sendChairmanSMS() — FR-3 decision staging guard', 
     expect(sb._tables.chairman_notifications).toHaveLength(0);
     expect(sender.send).toHaveBeenCalledTimes(1);
   });
+
+  it('TS-10 (adversarial-review finding): a confirmed transport failure rolls back the just-staged token — the decision is no longer matcher-eligible', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-10', status: 'pending', brief_data: {} }] });
+    const sender = { send: vi.fn(async () => ({ sid: null, softFailed: true, reason: 'enqueued_not_dispatched: status=owed' })) };
+    const res = await sendChairmanSMS(
+      wellFormedDecision({ decisionId: 'dec-10', recipientPhone: '+15557778888' }),
+      DAYTIME,
+      { sender, console: silentConsole, supabase: sb },
+    );
+    expect(res.sent).toBe(false);
+    expect(res.transportFailed).toBe(true);
+
+    // Staging DID run (the row exists, for audit) but the token must be cleared...
+    expect(sb._tables.chairman_notifications).toHaveLength(1);
+    expect(sb._tables.chairman_notifications[0].status).toBe('failed');
+    const decision = sb._tables.chairman_decisions[0];
+    expect(decision.sms_reply_token).toBeNull();
+    expect(decision.sms_reply_token_expires_at).toBeNull();
+
+    // ...so a subsequent inbound reply to the phone the (undelivered) message would have used
+    // finds no eligible candidate — it must NOT be silently consumed as this decision's answer.
+    const reply = await handleInboundSmsReply(sb, {
+      from: '+15557778888', to: '+15550000000', body: 'A', messageSid: 'SM-in-10', signatureValid: true,
+    });
+    expect(reply.outcome).not.toBe('answered');
+  });
+
+  it('TS-11 (defensive hardening): a sender that THROWS instead of resolving softFailed still rolls back the staged token', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-11', status: 'pending', brief_data: {} }] });
+    const sender = { send: vi.fn(async () => { throw new Error('boom'); }) };
+    const res = await sendChairmanSMS(
+      wellFormedDecision({ decisionId: 'dec-11', recipientPhone: '+15556667777' }),
+      DAYTIME,
+      { sender, console: silentConsole, supabase: sb },
+    );
+    expect(res.sent).toBe(false);
+    expect(res.transportFailed).toBe(true);
+    expect(res.reason).toContain('sender_threw');
+    expect(sb._tables.chairman_decisions[0].sms_reply_token).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adam's SMS decision-packet path (`scripts/adam-chairman-decision.mjs` → `lib/comms/adam-outbound/chairman-sms-gate/index.js`) enqueued sends with a `decisionId` but never staged a `chairman_notifications` row or reply token — so a chairman letter reply to those packets always parked as `no_match` instead of resolving. Live evidence: zero `chairman_notifications` SMS rows with a `decision_id` since 2026-07-17, witnessed live 2026-08-15 (chairman replied "B", it parked, Adam resolved by hand).

- Extract a shared, error-checked **two-write** staging helper (`stageDecisionSmsNotification`, composed from `insertChairmanSmsNotification` + `updateChairmanDecisionSmsFields`) from `sendChairmanSmsQuestion` into `lib/chairman/sms-bridge.js`. Split into two pieces so `sendChairmanSmsQuestion`'s fallback branch can still skip the `chairman_decisions` token patch on a failed provider send, exactly as before the refactor.
- Wire the same helper into `chairman-sms-gate`'s `sendChairmanSMS` as a fail-closed guard: stage before dispatch, never throw out of the gate on a staging error (`{sent:false, reason:'notification_stage_failed'}`), resolve chairman identity (user id / email / phone) **once** via the same `process.env.CHAIRMAN_*` fallback `lib/switch-automation/switchon-decision-packet.js` already uses in production, shared between staging and dispatch.
- Require `--decision-id` on the Adam CLI, extending its existing required-field check (`--body`/`--option`×2/`--no-reply-policy`) — the gate's guard only fires when a `decisionId` is present, and the other two production callers (`record-pending-decision.mjs`, the decision-scheduler) already always supply one by construction.
- A PLAN-phase TESTING sub-agent review caught two real gaps in the original design before EXEC: (1) an insert-only helper satisfies the matcher's candidate lookup but not its eligibility filter (`status='pending'` + live token + options) — the helper now does both writes; (2) the gate/CLI call sites had no chairman identity in scope for `chairman_notifications`'s `NOT NULL` columns — closed via the env-var resolution above.

## Test plan

- [x] 18 new unit tests: staging helper (insert/update error injection, zero-rows-matched detection, round-trip through `handleInboundSmsReply`), gate guard (env-var identity resolution, fail-closed staging error, round-trip, scope boundaries for status-kind/non-decision/no-decisionId sends), CLI flag requirement (subprocess-spawned)
- [x] Full chairman/comms-gate regression suite: 52 test files, 763 tests, all pass unmodified (including the pre-existing real-caller test `lib/chairman/__tests__/sms-decision-whitelist.test.js`)
- [x] `npx eslint` clean on all changed/new files
- [ ] Post-merge live smoke: next real Adam decision packet's chairman letter-reply shows `outcome != no_match` in `sms_inbound_log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)