### PR TITLE
feat(SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001): encode the chairman's drive-score 6/6 goal + per-leg breakdown into Adam/Solomon contracts and chairman comms

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: a22ef1a57d87e22e -->
+<!-- file_content_hash: dc8065515f6e86a4 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-08-15 4:55:00 PM
+**Generated**: 2026-08-15 5:49:14 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -215,6 +215,8 @@ The north-star gauges (§5e) are **SUBORDINATE diagnostics** — they inform the
 **RUNG PROGRESS REUSES THE EXISTING MEASUREMENT** — `computeBuildGauge` for BUILD rungs and `sd_key_result_alignment` for OUTCOME rungs. It is **not a new measurement system**; do not build a parallel one.
 
 **THE DEFERRED QUESTION ADAM OWNS**: "which 1-2 ventures get the first dedicated revenue push?" is chairman-DEFERRED until the backlog is implemented AND the Roadmap is laid out. **Adam re-asks it at that moment — the chairman must not have to remember.**
+
+**THE DRIVE-SCORE GOAL**: the harness's standing goal is `drive_reports.drive_score` at its **maximum — 6/6 over the ratified 3 legs** (`lib/drive-loop/score/drive-score-legs.js`: leg1_landed, leg2_uptake, leg4_capacity). Every drive read Adam carries — the hourly heartbeat, the morning brief, the exec summary, and plan-check — is framed **PER LEG against 6/6**, never a bare aggregate number alone, **with the largest remaining lever named**. Solomon diagnoses which leg is holding the score down and proposes the fix shape (propose-only, CONST-002 — Solomon's DRIVE-SCORE DIAGNOSIS duty); **Adam sources and drives those fixes** to resolution — the same sourcing/driving duty this section already assigns him, now with the drive-score gap as a first-class, standing input. (Chairman directive 2026-08-15.)
 
 ### 5f. SOURCING SSOT — order of operations
 

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: dc8065515f6e86a4 -->
+<!-- file_content_hash: c647cfd70763f572 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-08-15 5:49:14 PM
+**Generated**: 2026-08-15 6:55:43 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -216,7 +216,7 @@ The north-star gauges (§5e) are **SUBORDINATE diagnostics** — they inform the
 
 **THE DEFERRED QUESTION ADAM OWNS**: "which 1-2 ventures get the first dedicated revenue push?" is chairman-DEFERRED until the backlog is implemented AND the Roadmap is laid out. **Adam re-asks it at that moment — the chairman must not have to remember.**
 
-**THE DRIVE-SCORE GOAL**: the harness's standing goal is `drive_reports.drive_score` at its **maximum — 6/6 over the ratified 3 legs** (`lib/drive-loop/score/drive-score-legs.js`: leg1_landed, leg2_uptake, leg4_capacity). Every drive read Adam carries — the hourly heartbeat, the morning brief, the exec summary, and plan-check — is framed **PER LEG against 6/6**, never a bare aggregate number alone, **with the largest remaining lever named**. Solomon diagnoses which leg is holding the score down and proposes the fix shape (propose-only, CONST-002 — Solomon's DRIVE-SCORE DIAGNOSIS duty); **Adam sources and drives those fixes** to resolution — the same sourcing/driving duty this section already assigns him, now with the drive-score gap as a first-class, standing input. (Chairman directive 2026-08-15.)
+**THE DRIVE-SCORE GOAL**: the harness's standing goal is `drive_reports.drive_score` at its **maximum — 6/6 over the ratified 3 legs** (`lib/drive-loop/score/drive-score-legs.js`: leg1_landed, leg2_uptake, leg4_capacity). Every drive read Adam carries — the hourly heartbeat, the morning brief, the exec summary, and plan-check — is framed **PER LEG against 6/6**, never a bare aggregate number alone, **with the largest remaining lever named**. Solomon diagnoses which leg is holding the score down and proposes the fix shape (propose-only, CONST-002 — Solomon's DRIVE-SCORE DIAGNOSIS duty); **Adam sources and drives those fixes** to resolution — the same sourcing/driving duty this section already assigns him, now with the drive-score gap as a first-class, standing input. (Chairman directive 2026-08-15.) **EARNABLE-IN-THIS-REPO, per leg (Solomon systemic flag 0f127ce4, 2026-08-15) — a leg whose earnability is unknown reads unknown, never assumed:** leg1_landed — is the landed corpus blind to the repo's actual ship path (squash merges)? Currently **squash-blind, pending chairman decision dc828e43.** leg4_capacity — has TIGHT ever been reachable on honest depth? Currently **0 of 206 verdicts ever TIGHT; re-check 7 days after SD-LEO-INFRA-QF-SUPPLY-PREDICATE-AUTO-START-001 lands.** Framing a drive read against 6/6 before these are resolved risks training on a target a leg cannot earn — cite the current answer, not the aspirational 6/6, when either caveat is still open.
 
 ### 5f. SOURCING SSOT — order of operations
 

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: a299d443199ba29d -->
+<!-- file_content_hash: d66bfb49a15cd9db -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-08-15 4:55:00 PM
+**Generated**: 2026-08-15 5:49:15 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -99,6 +99,8 @@ Grounded in the **Fable backlog** — fifteen deferred use-cases the Chairman fi
 **REINFORCEMENT-LEARNING SIGNAL DUTY (durable)**: Distinct from process improvement — design and improve the **reward/learning signal** the harness optimizes (what "better" means, reward shaping, what behavior the signal actually reinforces). The Chairman paired "self-improvement process AND reinforcement learning" deliberately; keep them paired but name the RL object (the signal), not just the process.
 
 **DEEP ARCHITECTURE REVIEW DUTY (durable)**: Periodic deep architecture reviews across EHG + EHG_Engineer; propose high-leverage **refactors against existing structure** (NOT new architecture-plan generation — that is EVA's). Multi-step, large-blast-radius reasoning is the Fable-shaped core.
+
+**DRIVE-SCORE DIAGNOSIS (durable)**: on the Mode-B sweep, and on every new `drive_reports` row, Solomon reads the per-leg score (`drive_score.measured_legs[]`, the ratified 3-leg set in `lib/drive-loop/score/drive-score-legs.js`) against the standing 6/6 goal, identifies the leg(s) that are the areas of concern lowering it, and proposes the FIX SHAPE — never the fix itself (propose-only, CONST-002; routed to Adam via a feedback flag / sourcing hand-off, same as the other duties in this cluster). **Systemic-flag → Chairman/Adam** when the lever is itself a RATIFICATION question rather than an execution gap — e.g. leg4_capacity's TIGHT-only earning rule, where the fix is a policy change only the chairman can ratify, not a task Adam can simply source and build. Silence-by-default (`[SOLOMON_OK]`) when nothing clears the bar.
 
 ### Cluster 2 — Where-Deep-Thinking-Is-Needed (CORE; self-targeting)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,179 +1,19 @@
 {
-  "generated_at": "2026-08-15T21:49:14.921Z",
-  "git_commit": "7c30435f",
+  "generated_at": "2026-08-15T22:55:43.081Z",
+  "git_commit": "321b2565",
   "db_snapshot_hash": "8de3099c543fb99b",
   "files": {
-    "CLAUDE.md": {
-      "type": "full",
-      "chars": 19564,
-      "bytes": 19703,
-      "estimated_tokens": 4891,
-      "content_hash": "91b0c479ced58edc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE.md"
-    },
-    "CLAUDE_CORE.md": {
-      "type": "full",
-      "chars": 94415,
-      "bytes": 95006,
-      "estimated_tokens": 23604,
-      "content_hash": "b847cc802709fe05",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_CORE.md"
-    },
-    "CLAUDE_LEAD.md": {
-      "type": "full",
-      "chars": 58425,
-      "bytes": 58621,
-      "estimated_tokens": 14607,
-      "content_hash": "c95f43b8f7f9933a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_LEAD.md"
-    },
-    "CLAUDE_LEAD_MANUAL.md": {
-      "type": "full",
-      "chars": 8818,
-      "bytes": 8862,
-      "estimated_tokens": 2205,
-      "content_hash": "280b187ee6130d2d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_LEAD_MANUAL.md"
-    },
-    "CLAUDE_PLAN.md": {
-      "type": "full",
-      "chars": 54928,
-      "bytes": 55185,
-      "estimated_tokens": 13732,
-      "content_hash": "2a5db036ba85a6ec",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_PLAN.md"
-    },
-    "CLAUDE_PLAN_MANUAL.md": {
-      "type": "full",
-      "chars": 38353,
-      "bytes": 38460,
-      "estimated_tokens": 9589,
-      "content_hash": "3b955908e83cebba",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_PLAN_MANUAL.md"
-    },
-    "CLAUDE_EXEC.md": {
-      "type": "full",
-      "chars": 89641,
-      "bytes": 90071,
-      "estimated_tokens": 22411,
-      "content_hash": "27cea777ab713d77",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_EXEC.md"
-    },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 47769,
-      "bytes": 48291,
-      "estimated_tokens": 11943,
-      "content_hash": "dc8065515f6e86a4",
+      "chars": 48444,
+      "bytes": 48974,
+      "estimated_tokens": 12111,
+      "content_hash": "c647cfd70763f572",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM.md"
-    },
-    "CLAUDE_ADAM_MANUAL.md": {
-      "type": "full",
-      "chars": 15698,
-      "bytes": 15842,
-      "estimated_tokens": 3925,
-      "content_hash": "96b70da93c02d6d1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM_MANUAL.md"
-    },
-    "CLAUDE_ADAM_PROVENANCE.md": {
-      "type": "full",
-      "chars": 6924,
-      "bytes": 6988,
-      "estimated_tokens": 1731,
-      "content_hash": "08f3917562c0e0b6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM_PROVENANCE.md"
-    },
-    "CLAUDE_COORDINATOR.md": {
-      "type": "full",
-      "chars": 26376,
-      "bytes": 26580,
-      "estimated_tokens": 6594,
-      "content_hash": "ef66b4ecffd40e17",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_COORDINATOR.md"
-    },
-    "CLAUDE_SOLOMON.md": {
-      "type": "full",
-      "chars": 61308,
-      "bytes": 61853,
-      "estimated_tokens": 15327,
-      "content_hash": "d66bfb49a15cd9db",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_SOLOMON.md"
-    },
-    "CLAUDE_SOLOMON_MANUAL.md": {
-      "type": "full",
-      "chars": 11227,
-      "bytes": 11324,
-      "estimated_tokens": 2807,
-      "content_hash": "647475c4da64cffb",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_SOLOMON_MANUAL.md"
-    },
-    "CLAUDE_DIGEST.md": {
-      "type": "digest",
-      "chars": 9611,
-      "bytes": 9653,
-      "estimated_tokens": 2403,
-      "content_hash": "67092da26643a7ae",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_DIGEST.md"
-    },
-    "CLAUDE_CORE_DIGEST.md": {
-      "type": "digest",
-      "chars": 13747,
-      "bytes": 13861,
-      "estimated_tokens": 3437,
-      "content_hash": "739f7f8bb4753f13",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_CORE_DIGEST.md"
-    },
-    "CLAUDE_LEAD_DIGEST.md": {
-      "type": "digest",
-      "chars": 5551,
-      "bytes": 5571,
-      "estimated_tokens": 1388,
-      "content_hash": "aa559568b677ee7e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_LEAD_DIGEST.md"
-    },
-    "CLAUDE_PLAN_DIGEST.md": {
-      "type": "digest",
-      "chars": 8541,
-      "bytes": 8581,
-      "estimated_tokens": 2136,
-      "content_hash": "1e2b0144b44537b8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_PLAN_DIGEST.md"
-    },
-    "CLAUDE_EXEC_DIGEST.md": {
-      "type": "digest",
-      "chars": 10964,
-      "bytes": 11046,
-      "estimated_tokens": 2741,
-      "content_hash": "97c64ec522e89d12",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_EXEC_DIGEST.md"
-    },
-    "CLAUDE_ADAM_DIGEST.md": {
-      "type": "digest",
-      "chars": 17736,
-      "bytes": 18068,
-      "estimated_tokens": 4434,
-      "content_hash": "5d1eb9c164d345cc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM_DIGEST.md"
-    },
-    "CLAUDE_COORDINATOR_DIGEST.md": {
-      "type": "digest",
-      "chars": 6091,
-      "bytes": 6161,
-      "estimated_tokens": 1523,
-      "content_hash": "6473b055b1c344b5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_COORDINATOR_DIGEST.md"
-    },
-    "CLAUDE_SOLOMON_DIGEST.md": {
-      "type": "digest",
-      "chars": 3969,
-      "bytes": 4011,
-      "estimated_tokens": 993,
-      "content_hash": "160a2f06859eb85b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "26d91fc4e2d4a22a",
+    "global": "75a3d8988c1fa8b6",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -427,7 +267,7 @@
       "596": "0251044882a17550",
       "597": "ca5efc991922f3b8",
       "599": "7ddd3e2178799aa8",
-      "601": "e4026682f77bc8cd",
+      "601": "2a1457d7f0b96c27",
       "602": "52425599b58d0a12",
       "603": "98d7b093d064f76a",
       "605": "a374b16fd546f8bd",

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-15T20:55:00.004Z",
-  "git_commit": "b28ff864",
+  "generated_at": "2026-08-15T21:49:14.921Z",
+  "git_commit": "7c30435f",
   "db_snapshot_hash": "8de3099c543fb99b",
   "files": {
     "CLAUDE.md": {
@@ -9,7 +9,7 @@
       "bytes": 19703,
       "estimated_tokens": 4891,
       "content_hash": "91b0c479ced58edc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
@@ -17,7 +17,7 @@
       "bytes": 95006,
       "estimated_tokens": 23604,
       "content_hash": "b847cc802709fe05",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
@@ -25,7 +25,7 @@
       "bytes": 58621,
       "estimated_tokens": 14607,
       "content_hash": "c95f43b8f7f9933a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_LEAD_MANUAL.md": {
       "type": "full",
@@ -33,7 +33,7 @@
       "bytes": 8862,
       "estimated_tokens": 2205,
       "content_hash": "280b187ee6130d2d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_LEAD_MANUAL.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
@@ -41,7 +41,7 @@
       "bytes": 55185,
       "estimated_tokens": 13732,
       "content_hash": "2a5db036ba85a6ec",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_PLAN_MANUAL.md": {
       "type": "full",
@@ -49,7 +49,7 @@
       "bytes": 38460,
       "estimated_tokens": 9589,
       "content_hash": "3b955908e83cebba",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_PLAN_MANUAL.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
@@ -57,15 +57,15 @@
       "bytes": 90071,
       "estimated_tokens": 22411,
       "content_hash": "27cea777ab713d77",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 46958,
-      "bytes": 47470,
-      "estimated_tokens": 11740,
-      "content_hash": "a22ef1a57d87e22e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM.md"
+      "chars": 47769,
+      "bytes": 48291,
+      "estimated_tokens": 11943,
+      "content_hash": "dc8065515f6e86a4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_ADAM_MANUAL.md": {
       "type": "full",
@@ -73,7 +73,7 @@
       "bytes": 15842,
       "estimated_tokens": 3925,
       "content_hash": "96b70da93c02d6d1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM_MANUAL.md"
     },
     "CLAUDE_ADAM_PROVENANCE.md": {
       "type": "full",
@@ -81,7 +81,7 @@
       "bytes": 6988,
       "estimated_tokens": 1731,
       "content_hash": "08f3917562c0e0b6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_PROVENANCE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM_PROVENANCE.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
@@ -89,15 +89,15 @@
       "bytes": 26580,
       "estimated_tokens": 6594,
       "content_hash": "ef66b4ecffd40e17",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
-      "chars": 60473,
-      "bytes": 61012,
-      "estimated_tokens": 15119,
-      "content_hash": "a299d443199ba29d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON.md"
+      "chars": 61308,
+      "bytes": 61853,
+      "estimated_tokens": 15327,
+      "content_hash": "d66bfb49a15cd9db",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_SOLOMON_MANUAL.md": {
       "type": "full",
@@ -105,7 +105,7 @@
       "bytes": 11324,
       "estimated_tokens": 2807,
       "content_hash": "647475c4da64cffb",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_SOLOMON_MANUAL.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
@@ -113,7 +113,7 @@
       "bytes": 9653,
       "estimated_tokens": 2403,
       "content_hash": "67092da26643a7ae",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
@@ -121,7 +121,7 @@
       "bytes": 13861,
       "estimated_tokens": 3437,
       "content_hash": "739f7f8bb4753f13",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
@@ -129,7 +129,7 @@
       "bytes": 5571,
       "estimated_tokens": 1388,
       "content_hash": "aa559568b677ee7e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
@@ -137,7 +137,7 @@
       "bytes": 8581,
       "estimated_tokens": 2136,
       "content_hash": "1e2b0144b44537b8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
@@ -145,7 +145,7 @@
       "bytes": 11046,
       "estimated_tokens": 2741,
       "content_hash": "97c64ec522e89d12",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
@@ -153,7 +153,7 @@
       "bytes": 18068,
       "estimated_tokens": 4434,
       "content_hash": "5d1eb9c164d345cc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
@@ -161,7 +161,7 @@
       "bytes": 6161,
       "estimated_tokens": 1523,
       "content_hash": "6473b055b1c344b5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
@@ -169,11 +169,11 @@
       "bytes": 4011,
       "estimated_tokens": 993,
       "content_hash": "160a2f06859eb85b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON_DIGEST.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "7ad99e968b368fb9",
+    "global": "26d91fc4e2d4a22a",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -427,14 +427,14 @@
       "596": "0251044882a17550",
       "597": "ca5efc991922f3b8",
       "599": "7ddd3e2178799aa8",
-      "601": "6cad87d0a7fadc0f",
+      "601": "e4026682f77bc8cd",
       "602": "52425599b58d0a12",
       "603": "98d7b093d064f76a",
       "605": "a374b16fd546f8bd",
       "608": "7f99a4321502367e",
       "609": "9790a74a362ff0ca",
       "610": "34fedae699d8c9f3",
-      "611": "37f413e238b9804c",
+      "611": "f65ce46a919dbf66",
       "612": "13e03eddf5300bcc",
       "613": "1e1de64689c1ad82",
       "614": "a4d5064f0ffbe97c",

--- a/lib/drive-loop/compose-report.js
+++ b/lib/drive-loop/compose-report.js
@@ -24,7 +24,13 @@
 
 import { isAvailable } from './report-posture.js';
 
-export const SCHEMA_VERSION = 1;
+// SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: bumped 1 -> 2. aggregate.js's `measured_legs[]` now
+// carries each leg's own earned `value` (previously: leg/table/row_ids/grains/source/predicate
+// only) — a disclosed, unshimmed shape change per that file's own convention (zero runtime
+// consumers found; see aggregate.js's header). The row's `schema_version` column is how a future
+// reader distinguishes an old-shape row (pre-migration, per-leg values absent) from a new one,
+// rather than sniffing the shape itself.
+export const SCHEMA_VERSION = 2;
 // SD-LEO-INFRA-HOURLY-DRIVE-SCORE-001 FR-5: 'hourly' added. This allowlist is a SEPARATE
 // enforcement point from the drive_reports.cadence DB CHECK constraint (widened by the same
 // SD's migration) -- both must stay in sync, pinned by vocabulary-drift.test.js.

--- a/lib/drive-loop/score/aggregate.js
+++ b/lib/drive-loop/score/aggregate.js
@@ -44,6 +44,24 @@
  * Option A, ratified (SMS row 5d90338c, and the migration says so at :37). It is reported and never
  * folded into the total. Grading it would convert a measurement of the chairman's queue into a mark
  * against the fleet's drive, which is a different claim about a different actor.
+ *
+ * ── EACH MEASURED LEG NOW CARRIES ITS OWN POINT VALUE ──────────────────────────────────────
+ * SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001 (chairman directive 2026-08-15): the chairman-facing
+ * per-leg breakdown (drive-report-sms.mjs formatDriveBreakdown) needs to say what EACH leg earned,
+ * not only the fused total — "X/6 = leg1_landed 2 + leg2_uptake 1 + leg4_capacity 0" instead of a
+ * bare aggregate number. That per-leg number was already computed here (`l.points.value`, summed
+ * into `earned` two lines above); it was simply never carried into the projection.
+ *
+ * NO per-leg `possible`/denominator is added alongside it. POINTS_PER_LEG (=2) is already a
+ * uniform module constant every leg shares — a per-leg copy of it would be a second representation
+ * of the same fact, free to drift the day a 4th leg is ever ratified. A per-leg consumer computes
+ * its own denominator from POINTS_PER_LEG, imported, never re-declared.
+ *
+ * BREAKING SHAPE CHANGE, by this file's own convention two sections up (FR-1's string[] -> object[]
+ * move): disclosed rather than shimmed. A fresh census (this SD) found the same thing the FR-1
+ * census found — ZERO runtime consumers of `measured_legs` under scripts/ or lib/, only tests — so
+ * there is, again, no reader for a back-compat shim to protect. compose-report.js's SCHEMA_VERSION
+ * is bumped 1 -> 2 alongside this change so a future reader can gate on the shape rather than guess.
  */
 
 import { cite } from '../citation.js';
@@ -128,6 +146,10 @@ export function aggregateScore({ legs = [], decisionLatency = null, citationVeri
         ...(Array.isArray(c.grains) && c.grains.length > 0 ? { grains: c.grains } : {}),
         ...(c.source ? { source: c.source } : {}),
         predicate: l.points.predicate,
+        // SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: THIS leg's own earned points (0..POINTS_PER_LEG),
+        // already computed above when `earned` was summed — carried through, not re-derived. This
+        // is what lets a per-leg chairman render say "leg2_uptake 1" instead of only the fused total.
+        value: l.points.value,
       };
     }),
     unavailable_legs: unavailableLegs,

--- a/lib/fleet/exec-email-drive-line.mjs
+++ b/lib/fleet/exec-email-drive-line.mjs
@@ -1,0 +1,125 @@
+// exec-email-drive-line.mjs
+// SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001 — the chairman-facing per-leg drive-score breakdown
+// line, shared VERBATIM by the two chairman surfaces that render a drive number in one morning:
+// the chairman morning-brief SMS (scripts/cron/chairman-morning-review-sweep.mjs) and the chairman
+// exec-summary email (scripts/adam-exec-summary.mjs). ONE query, ONE per-leg conversion, ONE call
+// into the formatter — so the two surfaces structurally CANNOT disagree about which row is "the
+// current score" in one morning (they are not two implementations that happen to agree; they are
+// the same implementation, called twice). Mirrors the existing exec-email-* modules in this
+// directory (exec-email-alignment.mjs, exec-email-ops-actuals.mjs, exec-email-rung-rollup.js):
+// PURE where possible, FAIL-SOFT everywhere, `io.supabase` convention.
+//
+// PURE + FAIL-SOFT: composeDriveLine() never throws. A read failure, an absent row, an unreadable
+// score, or a row with nothing measured all degrade to null (the caller renders nothing for this
+// line) -- the same contract every sibling exec-email-* helper in this file's directory keeps.
+
+import { POINTS_PER_LEG } from '../drive-loop/score/aggregate.js';
+import { RATIFIED_LEG_IDS, SPEC_LEG_COUNT } from '../drive-loop/score/drive-score-legs.js';
+import { formatDriveBreakdown } from '../../scripts/drive-report-sms.mjs';
+
+const usable = (n) => Number.isFinite(n) && n >= 0;
+
+// The FIXED ratified maximum (6), never aggregate.js's own run-scoped `possible` (which shrinks
+// when a leg is unavailable -- correct for that file's own audit purpose, but the WRONG number to
+// show the chairman here). The chairman directive frames every drive read against the STANDING
+// goal: "6/6", every time, even on a run where a leg could not be measured -- that gap is what the
+// per-leg breakdown's "unavailable" marker is for, not a shrinking denominator that quietly hides it.
+export const RATIFIED_POSSIBLE = SPEC_LEG_COUNT * POINTS_PER_LEG;
+
+/**
+ * PURE: convert a drive_reports row's `drive_score` into formatDriveBreakdown's input shape.
+ * Returns null when the row cannot supply a usable score, OR when not even one ratified leg has a
+ * measured value -- in both cases there is nothing honest to frame against 6/6 yet.
+ * @param {object} report a drive_reports row (needs .drive_score)
+ * @returns {{score:number, possible:number, legs:Array<{id:string,value:number|null}>, topLeverLeg:string} | null}
+ */
+export function driveBreakdownFactsFromReport(report) {
+  const score = report?.drive_score;
+  const value = score?.score?.value;
+  if (!usable(value)) return null;
+
+  const measuredLegs = Array.isArray(score?.measured_legs) ? score.measured_legs : [];
+  // ALL ratified legs are represented, even ones this run's measured_legs never mentions -- an
+  // unavailable leg must be SHOWN unavailable, not silently dropped from the breakdown. The
+  // chairman directive asks every drive read to be framed per leg against 6/6, every time, and a
+  // breakdown that quietly omits the leg nobody could measure is the same false-reassurance shape
+  // aggregate.js's own header exists to prevent, one layer up.
+  const legs = RATIFIED_LEG_IDS.map((id) => {
+    const m = measuredLegs.find((l) => l && l.leg === id);
+    const v = m && usable(m.value) ? m.value : null;
+    return { id, value: v };
+  });
+
+  const anyMeasured = legs.some((l) => l.value !== null);
+  if (!anyMeasured) return null; // an old-shape row, or a run with nothing measured at all
+
+  return { score: value, possible: RATIFIED_POSSIBLE, legs, topLeverLeg: selectTopLeverLeg(legs) };
+}
+
+/**
+ * PURE: which ratified leg is the biggest remaining lever.
+ *
+ * An UNAVAILABLE leg wins first, deterministically (ratified id order) when more than one is
+ * unavailable -- "cannot even measure this" is at least as urgent as "measured and low", and it is
+ * Solomon's own DRIVE-SCORE DIAGNOSIS duty to systemic-flag exactly this shape (a ratification
+ * question, e.g. leg4_capacity's TIGHT-only earning rule) as a legitimate lever category. Crowning
+ * a MEASURED leg's numeric gap as "the" lever while a sibling leg is unmeasured would bury the more
+ * urgent fact under a smaller, merely-numeric one.
+ *
+ * Otherwise: the MEASURED leg with the largest remaining gap to its own per-leg max
+ * (POINTS_PER_LEG). Ties resolve to the first in ratified id order (stable `reduce`, strict `>`).
+ * @param {Array<{id:string, value:number|null}>} legs
+ * @returns {string|null}
+ */
+export function selectTopLeverLeg(legs) {
+  if (!Array.isArray(legs) || legs.length === 0) return null;
+  const unavailable = legs.find((l) => l.value === null);
+  if (unavailable) return unavailable.id;
+
+  const measured = legs.filter((l) => l.value !== null);
+  if (measured.length === 0) return null;
+  return measured.reduce((worst, l) =>
+    (POINTS_PER_LEG - l.value) > (POINTS_PER_LEG - worst.value) ? l : worst
+  ).id;
+}
+
+/**
+ * Query the latest drive_reports row and render the chairman-facing per-leg breakdown line.
+ * THE ONE QUERY both chairman surfaces share: `generated_at` desc, `limit(1)` -- so the morning
+ * brief and the exec-summary can never render two different drive numbers from two different rows
+ * in one morning (they call this same function). Fail-soft throughout: never throws.
+ * @param {{ supabase: object }} io
+ * @returns {Promise<{ line: string, runId: string|null, generatedAt: string|null } | null>}
+ */
+export async function composeDriveLine(io) {
+  const db = io && io.supabase;
+  if (!db) return null;
+  try {
+    const { data, error } = await db
+      .from('drive_reports')
+      .select('run_id, generated_at, drive_score')
+      .order('generated_at', { ascending: false })
+      .limit(1);
+    if (error) return null;
+    const row = Array.isArray(data) ? data[0] : null;
+    if (!row) return null;
+
+    const facts = driveBreakdownFactsFromReport(row);
+    if (!facts) return null;
+
+    // Traceability (SD FR-8): the date the row was generated, so a reader can tell which run's
+    // score this is without a second query. Appended HERE, outside formatDriveBreakdown, so that
+    // function's own pinned string format (score/legs/top-lever only) stays exactly what its own
+    // unit tests exercise -- this is composition, not a change to the formatter's contract.
+    const dateTag = typeof row.generated_at === 'string' ? ` (as of ${row.generated_at.slice(0, 10)})` : '';
+    return {
+      line: `${formatDriveBreakdown(facts)}${dateTag}`,
+      runId: row.run_id ?? null,
+      generatedAt: row.generated_at ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export default { RATIFIED_POSSIBLE, driveBreakdownFactsFromReport, selectTopLeverLeg, composeDriveLine };

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -51,6 +51,10 @@ import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: chairman_decisions has no filter
 // below and is displayed as an honest "consumed X of Y" total to the chairman.
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
+// SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: the chairman-facing per-leg drive-score breakdown,
+// shared VERBATIM with the morning-brief SMS (same module, same query) so the two surfaces can
+// never disagree about which row is "the current score" in one morning.
+import { composeDriveLine } from '../lib/fleet/exec-email-drive-line.mjs';
 
 enforceCliSendGuard({
   scriptName: 'scripts/adam-exec-summary.mjs',
@@ -233,6 +237,12 @@ try {
   visNote = `(gauge unavailable ${EM} compute error)`;
 }
 
+// SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: the drive-score breakdown line -- additive only, never
+// touches the vision-gauge variables above. composeDriveLine never throws (fail-soft by construction).
+let driveLine = null;
+try { driveLine = (await composeDriveLine({ supabase: db }))?.line ?? null; }
+catch (e) { console.warn('[adam-email] drive-score breakdown skipped (fail-soft): ' + (e?.message || e)); }
+
 // SD-LEO-INFRA-EXEC-EMAIL-STRATEGY-ALIGNED-001 (FR-3): the infra-build-completion forecast line is
 // STRIPPED from the exec-summary email surface. Its compute (a read of build_completion_forecast_log)
 // is removed with the line — the forecast table keeps being WRITTEN by its own cron for other
@@ -394,6 +404,8 @@ const text = [
   ...(metaLine ? ['   ' + metaLine] : []),
   ...(distanceToQuitLine ? ['   ' + distanceToQuitLine] : []),
   ...(watchdogLine ? ['   ' + watchdogLine] : []),
+  // SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: the drive-score goal, framed per leg against 6/6.
+  ...(driveLine ? ['   Drive: ' + driveLine] : []),
   ...(opsActualsLines.length ? ['', 'Venture actuals:', ...opsActualsLines.map((l) => '   ' + l)] : []),
   ...(recentText ? ['', recentText] : []),
   ...(decisionsLine ? [decisionsLine] : []),
@@ -424,6 +436,8 @@ const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px
   (metaLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(metaLine)}</div>` : '') +
   (distanceToQuitLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(distanceToQuitLine)}</div>` : '') +
   (watchdogLine ? `<div style="font-size:12px;color:#b54708;margin:2px 0 0">${esc(watchdogLine)}</div>` : '') +
+  // SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: the drive-score goal, framed per leg against 6/6.
+  (driveLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">Drive: ${esc(driveLine)}</div>` : '') +
   (opsActualsLines.length
     ? `<p style="font-size:13px;font-weight:600;margin:8px 0 0">Venture actuals:</p>` +
       opsActualsLines.map((l) => `<div style="font-size:12px;color:#444;margin:2px 0 0">${esc(l)}</div>`).join('')

--- a/scripts/cron/chairman-morning-review-sweep.mjs
+++ b/scripts/cron/chairman-morning-review-sweep.mjs
@@ -45,6 +45,10 @@ import { resolveCanonicalRoadmap } from '../../lib/roadmap/canonical-roadmap.js'
 import { buildRoadmapStatusDoc } from '../../lib/chairman/daily-review/roadmap-status-doc.js';
 import { renderGanttPng } from '../../lib/chairman/daily-review/gantt-renderer.js';
 import { uploadPrivateAndSign } from '../../lib/storage/private-signed-upload.js';
+// SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: the chairman-facing per-leg drive-score breakdown,
+// shared VERBATIM with the exec-summary email (same module, same query) so the two surfaces can
+// never disagree about which row is "the current score" in one morning.
+import { composeDriveLine } from '../../lib/fleet/exec-email-drive-line.mjs';
 
 export const SD_KEY = 'SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B';
 export const ACTIVATION_TRIGGER = '.github/workflows/chairman-morning-review-cron.yml';
@@ -193,6 +197,25 @@ async function gatherYesterday(supabase, priorMorningIso) {
   return { shipped, inFlight };
 }
 
+/**
+ * PURE: join the proven 3-line core with the optional drive-score line, dropping the DRIVE LINE
+ * FIRST if the ceiling would be breached — the core trio is the pinned, proven surface (TS-6); the
+ * drive line is the newest addition and the one that grows with the leg vocabulary, so it is the
+ * one that yields rather than forcing a mid-sentence truncation onto a line that used to always fit.
+ * Falls back to the pre-existing whole-body truncation (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B)
+ * only if the core trio ALONE still exceeds the ceiling.
+ * @param {string[]} coreLines
+ * @param {string|null} driveLine
+ * @param {number} [ceiling]
+ */
+export function assembleMorningBody(coreLines, driveLine, ceiling = BODY_CEILING) {
+  const core = coreLines.filter(Boolean);
+  let body = [...core, driveLine].filter(Boolean).join('\n');
+  if (driveLine && body.length > ceiling) body = core.join('\n');
+  if (body.length > ceiling) body = `${body.slice(0, ceiling - 1)}…`;
+  return body;
+}
+
 /** Build the SHORT, PII-free morning-review body. Login-gated summary data only. */
 export async function buildMorningReviewBody(supabase, { now = new Date() } = {}) {
   const nowMs = now.getTime();
@@ -205,9 +228,12 @@ export async function buildMorningReviewBody(supabase, { now = new Date() } = {}
   const { shipped, inFlight } = await gatherYesterday(supabase, etPrior545Iso(now));
   const yesterdayLine = `Yesterday: ${shipped} shipped, ${inFlight} in-flight`;
 
-  let body = [forecastLine, roadmapLine, yesterdayLine].join('\n');
-  if (body.length > BODY_CEILING) body = `${body.slice(0, BODY_CEILING - 1)}…`;
-  return body;
+  // SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: fail-soft by construction (composeDriveLine never
+  // throws) -- a read/format failure degrades to the SAME "line omitted" behavior as "no row yet".
+  const drive = await composeDriveLine({ supabase });
+  const driveLine = drive?.line ?? null;
+
+  return assembleMorningBody([forecastLine, roadmapLine, yesterdayLine], driveLine);
 }
 
 // SD-LEO-INFRA-DAILY-BRIEF-E2E-WIRING-001 FR-2: feature flag gating the composed (text + MMS

--- a/scripts/drive-report-sms.mjs
+++ b/scripts/drive-report-sms.mjs
@@ -202,6 +202,11 @@ export function formatDriveBreakdown(facts = {}) {
     if (!leg || typeof leg !== 'object' || typeof leg.id !== 'string' || leg.id.trim() === '') {
       throw new Error(`formatDriveBreakdown(): every leg needs a string id — got ${JSON.stringify(leg)}`);
     }
+    // CLOSED-SET, same discipline as topLeverLeg below. A leg id reaches the wire either way —
+    // this loop must not be the free-text passthrough the module's own header rules out.
+    if (!RATIFIED_LEG_IDS.includes(leg.id)) {
+      throw new Error(`formatDriveBreakdown(): leg id must be one of ${RATIFIED_LEG_IDS.join(', ')} — got ${JSON.stringify(leg.id)}`);
+    }
     // UNAVAILABLE, never 0. `value` may be absent, null, or undefined — all three mean the same
     // thing here: nothing was measured for this leg on the row this facts object was built from
     // (e.g. an old-shape pre-migration row that predates per-leg values entirely).

--- a/scripts/drive-report-sms.mjs
+++ b/scripts/drive-report-sms.mjs
@@ -25,10 +25,28 @@
  * cron is a bill and a trust problem at the same time.
  *
  * LIVES IN scripts/ because it SENDS. The FR-7 propose-only scan forbids that under lib/drive-loop.
+ *
+ * ── formatDriveBreakdown: THE PER-LEG SIBLING OF formatBody (SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001) ──
+ * Chairman directive 2026-08-15: chairman-facing drive reads must show the per-leg breakdown and a
+ * named top lever, not a bare aggregate number alone. This is a NEW, SEPARATE function rather than
+ * a parameter on formatBody — formatBody's 7 callers are pinned on its exact byte-for-byte output,
+ * and giving it an optional "breakdown" mode is exactly the kind of change that quietly reshapes a
+ * pinned contract. formatDriveBreakdown mirrors formatBody's own disciplines (own-properties-only,
+ * non-negative numeric validation, a closed-set throw, a length-budget throw) rather than reusing
+ * any of its code, so the two can evolve independently and neither can silently break the other.
  */
+
+import { RATIFIED_LEG_IDS } from '../lib/drive-loop/score/drive-score-legs.js';
 
 export const MAX_RECIPIENTS = 3;
 export const MAX_BODY_CHARS = 320;   // 2 SMS segments; beyond this carriers split unpredictably
+// formatDriveBreakdown's OWN budget, deliberately larger than MAX_BODY_CHARS: a full per-leg
+// breakdown ("X/6 = leg1_landed 2 + leg2_uptake 1 + leg4_capacity 0; top lever: leg4_capacity") is
+// appended to callers' own bodies (morning-brief SMS, exec-summary email) rather than sent as a
+// bare SMS body itself, so it does not need to fit inside one/two SMS segments on its own — but it
+// still needs SOME bound, so a malformed/runaway input (e.g. an absurd leg count) fails loud rather
+// than producing an unbounded string.
+export const MAX_BREAKDOWN_CHARS = 400;
 export const VERDICTS = Object.freeze(['DEFICIT-URGENT', 'DEFICIT', 'TIGHT', 'SURPLUS', 'UNKNOWN']);
 
 /** E.164: a leading + and 8-15 digits. Anything else is not a phone number we will dial. */
@@ -133,6 +151,79 @@ export function formatBody(facts = {}) {
   ].filter(Boolean);
   const body = parts.join(' | ');
   if (body.length > MAX_BODY_CHARS) throw new Error('formatBody(): body exceeds the segment cap');
+  return body;
+}
+
+/**
+ * The per-leg sibling of formatBody (SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001). Renders the
+ * chairman-facing breakdown: "X/6 = leg1_landed 2 + leg2_uptake 1 + leg4_capacity 0; top lever:
+ * leg4_capacity". Same closed-inputs discipline as formatBody — numbers and closed-set leg ids
+ * only, so no upstream free text (predicates, limitation strings, reasons) can reach this string.
+ *
+ * `facts.topLeverLeg` is a CALLER-SUPPLIED leg id, not computed here — this function renders and
+ * VALIDATES, it does not decide which leg is the biggest lever (that judgement lives with the
+ * caller composing `facts`, e.g. lib/fleet/exec-email-drive-line.mjs), exactly as formatBody does
+ * not decide the capacity verdict, only validates it against VERDICTS.
+ *
+ * @param {object} facts
+ * @param {number} facts.score earned points this run (non-negative)
+ * @param {number} facts.possible the denominator to show against (non-negative — callers frame
+ *   this as the fixed ratified max, not aggregate.js's own run-scoped `possible`, so the chairman
+ *   always reads progress against the standing 6/6 goal rather than a denominator that shrinks
+ *   when a leg is unavailable)
+ * @param {Array<{id:string, value:number|null}>} facts.legs one entry per leg to render, in
+ *   display order. `value: null` (or omitted) means UNAVAILABLE for that leg — rendered as such,
+ *   NEVER as 0: an unmeasured leg and a measured zero are different claims (aggregate.js's own
+ *   rule, one layer down).
+ * @param {string} facts.topLeverLeg the leg id to name as the top lever — MUST be a ratified leg
+ *   id (RATIFIED_LEG_IDS); anything else throws.
+ */
+export function formatDriveBreakdown(facts = {}) {
+  if (facts === null || typeof facts !== 'object') {
+    throw new Error(`formatDriveBreakdown(): facts must be an object — got ${JSON.stringify(facts)}`);
+  }
+  // OWN PROPERTIES ONLY — see formatBody's own comment on prototype pollution; the same hazard
+  // applies here and the same fix applies here.
+  for (const k of ['score', 'possible', 'legs', 'topLeverLeg']) {
+    if (!Object.hasOwn(facts, k)) {
+      throw new Error(`formatDriveBreakdown(): ${k} must be an OWN property of facts — an inherited value means it was not computed by this run`);
+    }
+  }
+  const { score, possible, legs, topLeverLeg } = facts;
+
+  for (const [k, v] of Object.entries({ score, possible })) {
+    if (!Number.isFinite(v) || v < 0) throw new Error(`formatDriveBreakdown(): ${k} must be a non-negative number — got ${JSON.stringify(v)}`);
+  }
+  if (!Array.isArray(legs) || legs.length === 0) {
+    throw new Error('formatDriveBreakdown(): legs must be a non-empty array');
+  }
+
+  const legParts = legs.map((leg) => {
+    if (!leg || typeof leg !== 'object' || typeof leg.id !== 'string' || leg.id.trim() === '') {
+      throw new Error(`formatDriveBreakdown(): every leg needs a string id — got ${JSON.stringify(leg)}`);
+    }
+    // UNAVAILABLE, never 0. `value` may be absent, null, or undefined — all three mean the same
+    // thing here: nothing was measured for this leg on the row this facts object was built from
+    // (e.g. an old-shape pre-migration row that predates per-leg values entirely).
+    if (leg.value === null || leg.value === undefined) {
+      return `${leg.id} unavailable`;
+    }
+    if (!Number.isFinite(leg.value) || leg.value < 0) {
+      throw new Error(`formatDriveBreakdown(): leg ${leg.id} value must be a non-negative number — got ${JSON.stringify(leg.value)}`);
+    }
+    return `${leg.id} ${leg.value}`;
+  });
+
+  // CLOSED-SET, imported — never a locally re-declared id list, and never a free-text reason. The
+  // whole point of naming a leg id (not a prose explanation) is that "top lever" stays a pointer
+  // into the ratified vocabulary a reader can cross-check, not another string this function would
+  // have to trust.
+  if (typeof topLeverLeg !== 'string' || !RATIFIED_LEG_IDS.includes(topLeverLeg)) {
+    throw new Error(`formatDriveBreakdown(): topLeverLeg must be one of ${RATIFIED_LEG_IDS.join(', ')} — got ${JSON.stringify(topLeverLeg)}`);
+  }
+
+  const body = `${score}/${possible} = ${legParts.join(' + ')}; top lever: ${topLeverLeg}`;
+  if (body.length > MAX_BREAKDOWN_CHARS) throw new Error('formatDriveBreakdown(): body exceeds the breakdown length budget');
   return body;
 }
 

--- a/tests/unit/cron/chairman-morning-review-sweep.test.js
+++ b/tests/unit/cron/chairman-morning-review-sweep.test.js
@@ -15,6 +15,7 @@ import {
   parseArgs,
   buildMorningReviewBody,
   buildComposedBody,
+  assembleMorningBody,
   etLocalHour,
   etDateStr,
   et6amIso,
@@ -54,6 +55,11 @@ function makeSupabase(data = {}) {
         if (table === 'strategic_roadmaps') rows = data.roadmaps || [];
         else if (table === 'roadmap_waves') rows = data.waves || [];
         else if (table === 'strategic_directives_v2') rows = has('not') ? (data.inFlight || []) : (data.completed || []);
+        // SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001: absent by default (rows stays []), so every
+        // PRE-EXISTING test in this file (none of which set data.driveReports) sees the SAME
+        // empty-result behavior composeDriveLine already degrades gracefully from — the drive
+        // line is simply omitted, and this file's 27 pre-existing tests are untouched by this addition.
+        else if (table === 'drive_reports') rows = data.driveReports || [];
         return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
       },
     };
@@ -395,5 +401,84 @@ describe('buildComposedBody (FR-2) — render/upload failure degrades to text-on
     expect(result.body.length).toBeLessThanOrEqual(COMPOSED_BODY_CEILING);
     expect(result.body.endsWith('…')).toBe(true);
     expect(result.body).not.toMatch(/wor…$/); // never cuts mid-word
+  });
+});
+
+// ── SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001 — the drive-score breakdown 4th line ──────────────
+
+const DRIVE_ROW = {
+  run_id: 'drive-2026-07-18',
+  generated_at: '2026-07-18T09:00:00Z',
+  drive_score: {
+    score: { value: 4 },
+    possible: 6,
+    measured_legs: [
+      { leg: 'leg1_landed', value: 2, table: 't', predicate: 'p' },
+      { leg: 'leg2_uptake', value: 1, table: 't', predicate: 'p' },
+      { leg: 'leg4_capacity', value: 1, table: 't', predicate: 'p' },
+    ],
+    unavailable_legs: [],
+  },
+};
+
+describe('TS (drive line) — the 4th line, additive, fail-soft, never breaking the pinned 3-line core', () => {
+  it('no drive_reports row available (every pre-existing test\'s shape): body is UNCHANGED from the 3-line core (TS-6/TS-11 byte-identity)', async () => {
+    const body = await buildMorningReviewBody(makeSupabase(richData), { now: SUMMER_WORK });
+    expect(body.split('\n')).toHaveLength(3);
+    expect(body).not.toMatch(/top lever/);
+  });
+
+  it('a real drive_reports row adds a 4th line carrying the per-leg breakdown', async () => {
+    const data = { ...richData, driveReports: [DRIVE_ROW] };
+    const body = await buildMorningReviewBody(makeSupabase(data), { now: SUMMER_WORK });
+    const lines = body.split('\n');
+    expect(lines).toHaveLength(4);
+    expect(lines[3]).toBe('4/6 = leg1_landed 2 + leg2_uptake 1 + leg4_capacity 1; top lever: leg2_uptake (as of 2026-07-18)');
+  });
+
+  it('queries drive_reports via composeDriveLine\'s .limit(1)+data[0] shape -- this mock exposes no .single()/.maybeSingle(), so that shape is REQUIRED for the wiring to work at all', async () => {
+    const data = { ...richData, driveReports: [DRIVE_ROW] };
+    const sb = makeSupabase(data);
+    await buildMorningReviewBody(sb, { now: SUMMER_WORK });
+    const driveCall = sb._calls.find((c) => c.table === 'drive_reports');
+    expect(driveCall, 'the sweep must query drive_reports').toBeDefined();
+    expect(driveCall.ops.some((o) => o.m === 'limit' && o.args[0] === 1)).toBe(true);
+  });
+
+  it('an unreadable drive_score row degrades to the 3-line core, never throws', async () => {
+    const data = { ...richData, driveReports: [{ run_id: 'r', generated_at: '2026-07-18T09:00:00Z', drive_score: {} }] };
+    const body = await buildMorningReviewBody(makeSupabase(data), { now: SUMMER_WORK });
+    expect(body.split('\n')).toHaveLength(3);
+  });
+});
+
+describe('assembleMorningBody — PURE ceiling-drop decision (the "which line yields" choice, pinned)', () => {
+  it('includes the drive line when everything fits under the ceiling', () => {
+    const body = assembleMorningBody(['a', 'b', 'c'], 'drive line', 100);
+    expect(body).toBe('a\nb\nc\ndrive line');
+  });
+
+  it('DROPS THE DRIVE LINE FIRST when its presence would breach the ceiling -- the core 3 lines survive intact', () => {
+    const core = ['a'.repeat(50), 'b'.repeat(50), 'c'.repeat(50)]; // 150 chars + 2 separators = 152
+    const driveLine = 'd'.repeat(100); // would push well past a 200 ceiling
+    const body = assembleMorningBody(core, driveLine, 200);
+    expect(body).toBe(core.join('\n'));
+    expect(body).not.toContain('d'.repeat(100));
+  });
+
+  it('falls back to the pre-existing whole-body ellipsis truncation only when the core ALONE still exceeds the ceiling', () => {
+    const core = ['x'.repeat(300)];
+    const body = assembleMorningBody(core, 'drive line', 200);
+    expect(body.length).toBe(200);
+    expect(body.endsWith('…')).toBe(true);
+  });
+
+  it('a null/omitted drive line never appears and never affects the core', () => {
+    expect(assembleMorningBody(['a', 'b'], null, 100)).toBe('a\nb');
+    expect(assembleMorningBody(['a', 'b'], undefined, 100)).toBe('a\nb');
+  });
+
+  it('falsy core lines (empty forecast/roadmap/yesterday) are filtered, matching the pre-existing .filter(Boolean) contract implicitly relied on by callers', () => {
+    expect(assembleMorningBody(['a', '', null, 'b'], 'd', 100)).toBe('a\nb\nd');
   });
 });

--- a/tests/unit/drive-loop/score/aggregate.test.js
+++ b/tests/unit/drive-loop/score/aggregate.test.js
@@ -147,6 +147,29 @@ describe('aggregate — PER-001: a citation names one table, so it may carry onl
     expect(byLeg.leg1_landed.predicate).toBe('p:leg1_landed');
   });
 
+  it('[SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001] each measured leg carries its OWN earned point value', () => {
+    // twoTables(): leg1_landed=2, leg2_uptake=1, leg4_capacity=2 (see the leg() calls above).
+    const r = twoTables();
+    const byLeg = Object.fromEntries(r.measured_legs.map((m) => [m.leg, m]));
+    expect(byLeg.leg1_landed.value).toBe(2);
+    expect(byLeg.leg2_uptake.value).toBe(1);
+    expect(byLeg.leg4_capacity.value).toBe(2);
+    // The per-leg values sum to the SAME earned total the aggregate reports — one fact, not two
+    // that could drift apart.
+    const sum = r.measured_legs.reduce((s, m) => s + m.value, 0);
+    expect(sum).toBe(r.score.value);
+  });
+
+  it('[SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001] a MEASURED zero leg carries value:0, not an absent field', () => {
+    // Mirrors the file's own "a measured zero is not an unavailable one" rule, one layer down: a
+    // leg that measured and earned nothing must still show up with a real 0, never omit `value`.
+    const r = aggregateScore({ legs: [leg('a', 0), leg('b', 2)] });
+    const byLeg = Object.fromEntries(r.measured_legs.map((m) => [m.leg, m]));
+    expect(Object.hasOwn(byLeg.a, 'value')).toBe(true);
+    expect(byLeg.a.value).toBe(0);
+    expect(byLeg.b.value).toBe(2);
+  });
+
   it('[FR-1/TS-12] leg2 grains survive, and a leg with no row grain has row_ids ABSENT, not []', () => {
     const r = twoTables();
     const byLeg = Object.fromEntries(r.measured_legs.map((m) => [m.leg, m]));

--- a/tests/unit/fleet/exec-email-drive-line.test.js
+++ b/tests/unit/fleet/exec-email-drive-line.test.js
@@ -1,0 +1,216 @@
+/**
+ * SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001 — lib/fleet/exec-email-drive-line.mjs.
+ *
+ * This is THE shared query + composition both chairman surfaces (morning-brief SMS,
+ * exec-summary email) call — see the cross-surface wiring block at the bottom, which is the
+ * FR-8 "can't render two different drive numbers from two different rows in one morning" check.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  driveBreakdownFactsFromReport, selectTopLeverLeg, composeDriveLine, RATIFIED_POSSIBLE,
+} from '../../../lib/fleet/exec-email-drive-line.mjs';
+import { RATIFIED_LEG_IDS } from '../../../lib/drive-loop/score/drive-score-legs.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const scoreFixture = (legs, extra = {}) => ({
+  score: { value: legs.reduce((s, l) => s + (l.value ?? 0), 0) },
+  possible: legs.length * 2,
+  measured_legs: legs.map((l) => ({ leg: l.leg, value: l.value, table: 't', predicate: 'p' })),
+  unavailable_legs: [],
+  ...extra,
+});
+
+describe('RATIFIED_POSSIBLE — the fixed standing-goal denominator', () => {
+  it('is 6 (3 ratified legs x 2 points), never the aggregate\'s own run-scoped possible', () => {
+    expect(RATIFIED_POSSIBLE).toBe(6);
+  });
+});
+
+describe('driveBreakdownFactsFromReport — converts a drive_reports row into formatter input', () => {
+  it('a fully-measured row produces all 3 ratified legs with their values, possible fixed at 6', () => {
+    const report = { drive_score: scoreFixture([
+      { leg: 'leg1_landed', value: 2 }, { leg: 'leg2_uptake', value: 1 }, { leg: 'leg4_capacity', value: 1 },
+    ]) };
+    const facts = driveBreakdownFactsFromReport(report);
+    expect(facts.score).toBe(4);
+    expect(facts.possible).toBe(6);
+    expect(facts.legs).toEqual([
+      { id: 'leg1_landed', value: 2 }, { id: 'leg2_uptake', value: 1 }, { id: 'leg4_capacity', value: 1 },
+    ]);
+    expect(RATIFIED_LEG_IDS).toContain(facts.topLeverLeg);
+  });
+
+  it('a leg ABSENT from measured_legs renders as value:null (unavailable), never fabricated 0', () => {
+    const report = { drive_score: scoreFixture([{ leg: 'leg1_landed', value: 2 }, { leg: 'leg2_uptake', value: 1 }]) };
+    const facts = driveBreakdownFactsFromReport(report);
+    const byId = Object.fromEntries(facts.legs.map((l) => [l.id, l.value]));
+    expect(byId.leg1_landed).toBe(2);
+    expect(byId.leg2_uptake).toBe(1);
+    expect(byId.leg4_capacity).toBeNull(); // absent from measured_legs -> null, not 0
+  });
+
+  it('possible is ALWAYS 6, even when the aggregate\'s own possible shrank (a leg was unavailable)', () => {
+    // aggregate.js's own possible would be 4 here (2 measured legs x 2) -- the chairman-facing
+    // fact must stay framed against the FIXED standing goal, not that shrunken number.
+    const report = { drive_score: scoreFixture([{ leg: 'leg1_landed', value: 2 }, { leg: 'leg2_uptake', value: 1 }], { possible: 4 }) };
+    const facts = driveBreakdownFactsFromReport(report);
+    expect(facts.possible).toBe(6);
+  });
+
+  it('returns null when the row score is unreadable (old-shape / corrupt / missing)', () => {
+    expect(driveBreakdownFactsFromReport(null)).toBeNull();
+    expect(driveBreakdownFactsFromReport({})).toBeNull();
+    expect(driveBreakdownFactsFromReport({ drive_score: {} })).toBeNull();
+    expect(driveBreakdownFactsFromReport({ drive_score: { score: { value: -1 }, possible: 6 } })).toBeNull();
+  });
+
+  it('returns null when NOTHING is measured — an old-shape row (bare-string measured_legs) or a genuinely empty run', () => {
+    // Old-shape rows carry measured_legs as bare strings (pre this SD); `.leg` on a string is
+    // undefined, so nothing matches any ratified id and every leg ends up null.
+    const oldShape = { drive_score: { score: { value: 0 }, possible: 0, measured_legs: ['leg1_landed'], unavailable_legs: [] } };
+    expect(driveBreakdownFactsFromReport(oldShape)).toBeNull();
+
+    const nothingMeasured = { drive_score: { score: { value: 0 }, possible: 0, measured_legs: [], unavailable_legs: RATIFIED_LEG_IDS.map((leg) => ({ leg, reason: 'x' })) } };
+    expect(driveBreakdownFactsFromReport(nothingMeasured)).toBeNull();
+  });
+
+  it('a MEASURED zero is a real 0 leg, not treated as unavailable', () => {
+    const report = { drive_score: scoreFixture([{ leg: 'leg1_landed', value: 0 }, { leg: 'leg2_uptake', value: 1 }]) };
+    const facts = driveBreakdownFactsFromReport(report);
+    const byId = Object.fromEntries(facts.legs.map((l) => [l.id, l.value]));
+    expect(byId.leg1_landed).toBe(0);
+  });
+});
+
+describe('selectTopLeverLeg', () => {
+  it('picks the leg with the largest remaining gap among MEASURED legs', () => {
+    const legs = [{ id: 'leg1_landed', value: 2 }, { id: 'leg2_uptake', value: 0 }, { id: 'leg4_capacity', value: 1 }];
+    expect(selectTopLeverLeg(legs)).toBe('leg2_uptake'); // gap 2, largest
+  });
+
+  it('an UNAVAILABLE leg wins over every measured leg, regardless of numeric gaps', () => {
+    const legs = [{ id: 'leg1_landed', value: 2 }, { id: 'leg2_uptake', value: null }, { id: 'leg4_capacity', value: 2 }];
+    expect(selectTopLeverLeg(legs)).toBe('leg2_uptake');
+  });
+
+  it('multiple unavailable legs resolve deterministically to the first in ratified id order', () => {
+    const legs = [{ id: 'leg1_landed', value: null }, { id: 'leg2_uptake', value: null }, { id: 'leg4_capacity', value: 2 }];
+    expect(selectTopLeverLeg(legs)).toBe('leg1_landed');
+  });
+
+  it('ties among measured legs resolve to the first in list order', () => {
+    const legs = [{ id: 'leg1_landed', value: 1 }, { id: 'leg2_uptake', value: 1 }, { id: 'leg4_capacity', value: 2 }];
+    expect(selectTopLeverLeg(legs)).toBe('leg1_landed');
+  });
+
+  it('empty/invalid input returns null rather than throwing', () => {
+    expect(selectTopLeverLeg([])).toBeNull();
+    expect(selectTopLeverLeg(null)).toBeNull();
+  });
+});
+
+// ── composeDriveLine: the shared query ──────────────────────────────────────────────────────
+
+/** Minimal chainable fake, matching the convention already used by chairman-morning-review-sweep.test.js. */
+function makeDriveSupabase(rows = null, { error = null, throwOnQuery = false } = {}) {
+  const calls = [];
+  function from(table) {
+    const q = { table, ops: [] };
+    const rec = (m, args) => { q.ops.push({ m, args }); return api; };
+    const api = {
+      select: (...a) => rec('select', a),
+      order: (...a) => rec('order', a),
+      limit: (...a) => rec('limit', a),
+      then: (resolve, reject) => {
+        calls.push(q);
+        if (throwOnQuery) return Promise.reject(new Error('connection reset')).then(resolve, reject);
+        return Promise.resolve({ data: rows, error }).then(resolve, reject);
+      },
+    };
+    return api;
+  }
+  return { from, _calls: calls };
+}
+
+describe('composeDriveLine — the ONE query both chairman surfaces share', () => {
+  const ROW = {
+    run_id: 'drive-2026-08-15', generated_at: '2026-08-15T10:00:00Z',
+    drive_score: scoreFixture([{ leg: 'leg1_landed', value: 2 }, { leg: 'leg2_uptake', value: 1 }, { leg: 'leg4_capacity', value: 1 }]),
+  };
+
+  it('queries drive_reports ordered by generated_at DESC, limited to 1 (FR-8)', async () => {
+    const sb = makeDriveSupabase([ROW]);
+    await composeDriveLine({ supabase: sb });
+    expect(sb._calls).toHaveLength(1);
+    const call = sb._calls[0];
+    expect(call.table).toBe('drive_reports');
+    expect(call.ops.some((o) => o.m === 'order' && o.args[0] === 'generated_at' && o.args[1]?.ascending === false)).toBe(true);
+    expect(call.ops.some((o) => o.m === 'limit' && o.args[0] === 1)).toBe(true);
+  });
+
+  it('returns the rendered line plus runId/generatedAt for traceability', async () => {
+    const sb = makeDriveSupabase([ROW]);
+    const result = await composeDriveLine({ supabase: sb });
+    expect(result.runId).toBe('drive-2026-08-15');
+    expect(result.generatedAt).toBe('2026-08-15T10:00:00Z');
+    expect(result.line).toMatch(/^4\/6 = leg1_landed 2 \+ leg2_uptake 1 \+ leg4_capacity 1; top lever: \w+ \(as of 2026-08-15\)$/);
+  });
+
+  it('fail-soft: no supabase client -> null, never throws', async () => {
+    await expect(composeDriveLine({})).resolves.toBeNull();
+    await expect(composeDriveLine(null)).resolves.toBeNull();
+  });
+
+  it('fail-soft: a query error -> null', async () => {
+    const sb = makeDriveSupabase(null, { error: { message: 'relation does not exist' } });
+    await expect(composeDriveLine({ supabase: sb })).resolves.toBeNull();
+  });
+
+  it('fail-soft: a thrown exception -> null', async () => {
+    const sb = makeDriveSupabase(null, { throwOnQuery: true });
+    await expect(composeDriveLine({ supabase: sb })).resolves.toBeNull();
+  });
+
+  it('fail-soft: no row yet -> null', async () => {
+    const sb = makeDriveSupabase([]);
+    await expect(composeDriveLine({ supabase: sb })).resolves.toBeNull();
+  });
+
+  it('fail-soft: a row with an unreadable score -> null', async () => {
+    const sb = makeDriveSupabase([{ run_id: 'r1', generated_at: '2026-08-15T00:00:00Z', drive_score: {} }]);
+    await expect(composeDriveLine({ supabase: sb })).resolves.toBeNull();
+  });
+});
+
+// ── FR-8: cross-surface consistency — both consumers share THIS module, not two copies ────────
+describe('[WIRING / FR-8] morning-brief and exec-summary both call THIS shared module', () => {
+  const read = (p) => fs.readFileSync(p, 'utf8');
+  const MORNING_SWEEP = path.join(repoRoot, 'scripts', 'cron', 'chairman-morning-review-sweep.mjs');
+  const EXEC_SUMMARY = path.join(repoRoot, 'scripts', 'adam-exec-summary.mjs');
+
+  it('chairman-morning-review-sweep.mjs imports composeDriveLine from exec-email-drive-line.mjs', () => {
+    expect(read(MORNING_SWEEP)).toMatch(/import\s*\{[^}]*composeDriveLine[^}]*\}\s*from\s*['"].*exec-email-drive-line\.mjs['"]/);
+  });
+
+  it('adam-exec-summary.mjs imports composeDriveLine from exec-email-drive-line.mjs', () => {
+    expect(read(EXEC_SUMMARY)).toMatch(/import\s*\{[^}]*composeDriveLine[^}]*\}\s*from\s*['"].*exec-email-drive-line\.mjs['"]/);
+  });
+
+  it('neither consumer re-implements its own drive_reports query — the module owns the ONLY order/limit call site for this table', () => {
+    // A second, independent `.from('drive_reports')` in either file would mean the two surfaces
+    // COULD diverge even while both also call composeDriveLine -- the wiring assertions above
+    // alone would not catch that. Grep is a source-truth check, not a claim about behavior; a
+    // relative call `.order(...).limit(1)` next to a `drive_reports` literal in the SAME file is
+    // exactly the shape a re-implementation would take.
+    for (const file of [MORNING_SWEEP, EXEC_SUMMARY]) {
+      const src = read(file).replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      expect(src, `${file} must not name drive_reports directly outside the shared module`).not.toMatch(/from\(['"]drive_reports['"]\)/);
+    }
+  });
+});

--- a/tests/unit/scripts/drive-report-sms-breakdown.test.js
+++ b/tests/unit/scripts/drive-report-sms-breakdown.test.js
@@ -1,0 +1,183 @@
+/**
+ * SD-FDBK-INFRA-ENCODE-DRIVE-SIX-GOAL-001 — formatDriveBreakdown, the per-leg sibling of
+ * formatBody. A NEW, separate file (not appended to drive-report-sms.test.js) so the 7
+ * byte-pinned formatBody strings in that file are provably untouched by this change — this file
+ * imports formatBody too, purely to run that regression check inline.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatDriveBreakdown, formatBody, MAX_BREAKDOWN_CHARS } from '../../../scripts/drive-report-sms.mjs';
+import { RATIFIED_LEG_IDS } from '../../../lib/drive-loop/score/drive-score-legs.js';
+
+const FACTS = {
+  score: 4,
+  possible: 6,
+  legs: [
+    { id: 'leg1_landed', value: 2 },
+    { id: 'leg2_uptake', value: 1 },
+    { id: 'leg4_capacity', value: 1 },
+  ],
+  topLeverLeg: 'leg2_uptake',
+};
+
+describe('formatDriveBreakdown — correct rendering', () => {
+  it('renders "X/possible = leg value + leg value + ...; top lever: <id>"', () => {
+    expect(formatDriveBreakdown(FACTS)).toBe(
+      '4/6 = leg1_landed 2 + leg2_uptake 1 + leg4_capacity 1; top lever: leg2_uptake',
+    );
+  });
+
+  it('renders legs in the order given, not sorted or reordered', () => {
+    const reordered = { ...FACTS, legs: [...FACTS.legs].reverse() };
+    expect(formatDriveBreakdown(reordered)).toBe(
+      '4/6 = leg4_capacity 1 + leg2_uptake 1 + leg1_landed 2; top lever: leg2_uptake',
+    );
+  });
+
+  it('a single leg still renders correctly', () => {
+    expect(formatDriveBreakdown({ score: 2, possible: 2, legs: [{ id: 'leg1_landed', value: 2 }], topLeverLeg: 'leg1_landed' }))
+      .toBe('2/2 = leg1_landed 2; top lever: leg1_landed');
+  });
+
+  it('a MEASURED zero renders as a real 0, not "unavailable"', () => {
+    const facts = { ...FACTS, legs: [{ id: 'leg1_landed', value: 0 }, { id: 'leg2_uptake', value: 1 }] };
+    expect(formatDriveBreakdown(facts)).toContain('leg1_landed 0');
+    expect(formatDriveBreakdown(facts)).not.toContain('leg1_landed unavailable');
+  });
+});
+
+describe('formatDriveBreakdown — old-shape-row graceful degradation (an unavailable leg is NEVER 0)', () => {
+  it('a leg with value:null renders as "<id> unavailable", never "<id> 0"', () => {
+    const facts = {
+      score: 3, possible: 6,
+      legs: [{ id: 'leg1_landed', value: 2 }, { id: 'leg2_uptake', value: null }, { id: 'leg4_capacity', value: 1 }],
+      topLeverLeg: 'leg2_uptake',
+    };
+    const out = formatDriveBreakdown(facts);
+    expect(out).toBe('3/6 = leg1_landed 2 + leg2_uptake unavailable + leg4_capacity 1; top lever: leg2_uptake');
+    expect(out).not.toMatch(/leg2_uptake 0/);
+  });
+
+  it('a leg with value OMITTED entirely (old-shape row, no per-leg value field at all) also renders unavailable, not 0', () => {
+    const facts = {
+      score: 2, possible: 6,
+      legs: [{ id: 'leg1_landed' }, { id: 'leg2_uptake', value: 2 }, { id: 'leg4_capacity' }],
+      topLeverLeg: 'leg1_landed',
+    };
+    const out = formatDriveBreakdown(facts);
+    expect(out).toBe('2/6 = leg1_landed unavailable + leg2_uptake 2 + leg4_capacity unavailable; top lever: leg1_landed');
+  });
+
+  it('EVERY leg unavailable does not throw and does not fabricate zeros', () => {
+    const facts = {
+      score: 0, possible: 6,
+      legs: RATIFIED_LEG_IDS.map((id) => ({ id, value: null })),
+      topLeverLeg: RATIFIED_LEG_IDS[0],
+    };
+    const out = formatDriveBreakdown(facts);
+    expect(out).not.toMatch(/\d 0\b/); // no leg renders as a bare numeric zero
+    for (const id of RATIFIED_LEG_IDS) expect(out).toContain(`${id} unavailable`);
+  });
+});
+
+describe('formatDriveBreakdown — the closed-set throw for top lever', () => {
+  it('throws when topLeverLeg is not a ratified leg id', () => {
+    expect(() => formatDriveBreakdown({ ...FACTS, topLeverLeg: 'leg3_never_existed' })).toThrow(/topLeverLeg must be one of/);
+  });
+
+  it('refuses a free-text reason in place of a leg id — the whole point is a pointer, not prose', () => {
+    expect(() => formatDriveBreakdown({ ...FACTS, topLeverLeg: 'the uptake leg is the biggest gap' })).toThrow(/topLeverLeg must be one of/);
+  });
+
+  it('every RATIFIED leg id is accepted', () => {
+    for (const id of RATIFIED_LEG_IDS) {
+      expect(() => formatDriveBreakdown({ ...FACTS, topLeverLeg: id })).not.toThrow();
+    }
+  });
+
+  it('rejects a non-string topLeverLeg', () => {
+    expect(() => formatDriveBreakdown({ ...FACTS, topLeverLeg: null })).toThrow(/topLeverLeg must be one of/);
+    expect(() => formatDriveBreakdown({ ...FACTS, topLeverLeg: 42 })).toThrow(/topLeverLeg must be one of/);
+  });
+});
+
+describe('formatDriveBreakdown — numeric validation throws for every numeric field', () => {
+  it('refuses a negative or non-finite score/possible', () => {
+    expect(() => formatDriveBreakdown({ ...FACTS, score: -1 })).toThrow(/non-negative/);
+    expect(() => formatDriveBreakdown({ ...FACTS, possible: NaN })).toThrow(/non-negative/);
+    expect(() => formatDriveBreakdown({ ...FACTS, possible: Infinity })).toThrow(/non-negative/);
+  });
+
+  it('refuses a negative or non-finite MEASURED leg value', () => {
+    const bad = { ...FACTS, legs: [{ id: 'leg1_landed', value: -1 }] };
+    expect(() => formatDriveBreakdown(bad)).toThrow(/leg1_landed value must be a non-negative number/);
+    const bad2 = { ...FACTS, legs: [{ id: 'leg1_landed', value: NaN }] };
+    expect(() => formatDriveBreakdown(bad2)).toThrow(/non-negative number/);
+  });
+
+  it('refuses a leg with a missing or non-string id', () => {
+    expect(() => formatDriveBreakdown({ ...FACTS, legs: [{ value: 1 }] })).toThrow(/every leg needs a string id/);
+    expect(() => formatDriveBreakdown({ ...FACTS, legs: [{ id: '', value: 1 }] })).toThrow(/every leg needs a string id/);
+  });
+
+  it('refuses a non-array / empty legs list', () => {
+    expect(() => formatDriveBreakdown({ ...FACTS, legs: [] })).toThrow(/legs must be a non-empty array/);
+    expect(() => formatDriveBreakdown({ ...FACTS, legs: 'nope' })).toThrow(/legs must be a non-empty array/);
+  });
+});
+
+describe('formatDriveBreakdown — own-properties-only (prototype pollution parity with formatBody)', () => {
+  it('an inherited value is NOT a computed one', () => {
+    Object.prototype.score = 99;         // eslint-disable-line no-extend-native
+    Object.prototype.possible = 99;      // eslint-disable-line no-extend-native
+    Object.prototype.legs = [{ id: 'leg1_landed', value: 99 }]; // eslint-disable-line no-extend-native
+    Object.prototype.topLeverLeg = 'leg1_landed'; // eslint-disable-line no-extend-native
+    try {
+      expect(() => formatDriveBreakdown()).toThrow(/must be an OWN property/);
+      expect(() => formatDriveBreakdown({})).toThrow(/must be an OWN property/);
+      expect(formatDriveBreakdown({ ...FACTS })).toBe(
+        '4/6 = leg1_landed 2 + leg2_uptake 1 + leg4_capacity 1; top lever: leg2_uptake',
+      );
+    } finally {
+      delete Object.prototype.score;
+      delete Object.prototype.possible;
+      delete Object.prototype.legs;
+      delete Object.prototype.topLeverLeg;
+    }
+  });
+
+  it('refuses a non-object facts rather than reading properties off it', () => {
+    for (const bad of [null, 'TIGHT', 42]) expect(() => formatDriveBreakdown(bad)).toThrow(/must be an object|must be an OWN property/);
+  });
+});
+
+describe('formatDriveBreakdown — its own length-budget throw', () => {
+  it('throws rather than silently truncating when the rendered body exceeds MAX_BREAKDOWN_CHARS', () => {
+    // A pathological leg count (well beyond the ratified 3) forces the body past the budget.
+    const manyLegs = Array.from({ length: 60 }, (_, i) => ({ id: 'leg1_landed', value: i }));
+    expect(() => formatDriveBreakdown({ score: 4, possible: 6, legs: manyLegs, topLeverLeg: 'leg1_landed' }))
+      .toThrow(/exceeds the breakdown length budget/);
+  });
+
+  it('a realistic 3-leg breakdown stays comfortably under the budget', () => {
+    expect(formatDriveBreakdown(FACTS).length).toBeLessThan(MAX_BREAKDOWN_CHARS);
+  });
+
+  it('MAX_BREAKDOWN_CHARS is its OWN constant, distinct from formatBody\'s MAX_BODY_CHARS', () => {
+    expect(MAX_BREAKDOWN_CHARS).not.toBe(320);
+    expect(MAX_BREAKDOWN_CHARS).toBeGreaterThan(320);
+  });
+});
+
+// ── REGRESSION: formatBody is untouched by this addition ──────────────────────────────────────
+// The 7 byte-pinned strings live in tests/unit/scripts/drive-report-sms.test.js,
+// tests/unit/cron/drive-report-sms-sweep.test.js, and
+// tests/unit/hooks/session-role-orient-adam-branch.test.js — this is not a duplicate of those,
+// it is an independent spot-check that formatBody's behavior did not shift when its new sibling
+// was added to the same file (shared module-scope constants, shared imports).
+describe('REGRESSION — formatBody is unmodified by the formatDriveBreakdown addition', () => {
+  it('formatBody still produces its pinned byte-for-byte output', () => {
+    const facts = { score: 4, possible: 6, verdict: 'TIGHT', unavailableLegs: 0, unownedBlockers: 0 };
+    expect(formatBody(facts)).toBe('Drive 4/6 | capacity TIGHT');
+  });
+});

--- a/tests/unit/scripts/drive-report-sms-breakdown.test.js
+++ b/tests/unit/scripts/drive-report-sms-breakdown.test.js
@@ -101,6 +101,24 @@ describe('formatDriveBreakdown — the closed-set throw for top lever', () => {
   });
 });
 
+describe('formatDriveBreakdown — the closed-set throw applies to leg ids too, not just topLeverLeg', () => {
+  it('throws when a leg id is not a ratified leg id (adversarial review finding)', () => {
+    const bad = { ...FACTS, legs: [{ id: 'leg3_never_existed', value: 1 }] };
+    expect(() => formatDriveBreakdown(bad)).toThrow(/leg id must be one of/);
+  });
+
+  it('refuses a free-text reason in place of a leg id — same discipline as topLeverLeg', () => {
+    const bad = { ...FACTS, legs: [{ id: 'the uptake leg is the biggest gap', value: 1 }] };
+    expect(() => formatDriveBreakdown(bad)).toThrow(/leg id must be one of/);
+  });
+
+  it('every RATIFIED leg id is accepted as a leg id', () => {
+    for (const id of RATIFIED_LEG_IDS) {
+      expect(() => formatDriveBreakdown({ ...FACTS, legs: [{ id, value: 1 }], topLeverLeg: id })).not.toThrow();
+    }
+  });
+});
+
 describe('formatDriveBreakdown — numeric validation throws for every numeric field', () => {
   it('refuses a negative or non-finite score/possible', () => {
     expect(() => formatDriveBreakdown({ ...FACTS, score: -1 })).toThrow(/non-negative/);


### PR DESCRIPTION
## Summary

Chairman-directed (SMS 2026-08-15 12:19Z): encodes the drive-score goal (6/6 across the 3 ratified legs) and the Adam/Solomon ownership split (Solomon diagnoses what's lowering it, Adam sources the fix) into both AI role contracts, and wires all 3 chairman-facing comms surfaces to render a per-leg breakdown with a closed-set "top lever" instead of a bare aggregate number.

The original proposal (authored by Adam, refined by Solomon) named the wrong consumer-wiring targets. This was caught and corrected across **3 successive rounds of adversarial LEAD/PLAN verification** within this SD:
- Round 1 (Explore): `scripts/adam-chairman-sms.mjs` has no composer at all; `scripts/adam-exec-summary.mjs`'s `computeBuildGauge` is the *wrong*, unrelated vision-build-% gauge. Retargeted to `scripts/drive-report-sms.mjs`.
- Round 2 (independent validation-agent, instructed to refute round 1): round 1's own correction was itself unbuildable — the per-leg point values are computed by the producer but deliberately dropped before persisting, so nothing downstream is renderable without a producer change. Also found morning-brief needs real code (a durable GHA-cron composer), not contract-text alone.
- Round 3 (PLAN-TO-EXEC testing-agent): found a missing `.filter(Boolean)` bug, a length-budget truncation hazard, and required the closed-set "top lever" constraint to be an enforced throw, not just a test.

## Changes
- `leo_protocol_sections` id=601/611 (Adam/Solomon role contracts) — new DRIVE-SCORE GOAL + DRIVE-SCORE DIAGNOSIS sections, including a per-leg "earnable-in-this-repo" caveat (Solomon systemic flag `0f127ce4`)
- `lib/drive-loop/score/aggregate.js` — persists each leg's own point value (breaking shape change, `SCHEMA_VERSION` 1→2, zero live consumers confirmed via census)
- `scripts/drive-report-sms.mjs` — new sibling `formatDriveBreakdown()` beside the untouched, pinned `formatBody()`, enforcing a closed-set "top lever" token (throws on anything else)
- `lib/fleet/exec-email-drive-line.mjs` (new) — shared pure module used identically by morning-brief and exec-summary, so they can't render two different drive numbers
- `scripts/cron/chairman-morning-review-sweep.mjs`, `scripts/adam-exec-summary.mjs` — wired additively

## Test plan
- [x] 169/169 across the 7 directly-touched test files (109 pre-existing baseline unchanged, incl. all 7 `formatBody` exact-string pins; 60 new)
- [x] Independently re-verified (not just EXEC's self-report): closed-set throw confirmed at `scripts/drive-report-sms.mjs:221-222` importing the real `RATIFIED_LEG_IDS`; `SCHEMA_VERSION=2` confirmed; both consumer surfaces confirmed importing the identical shared formatter
- [x] `node scripts/check-claude-md-drift.cjs` passes
- [x] LEAD-TO-PLAN (96/100), PLAN-TO-EXEC (96/100), PLAN-TO-LEAD (93/100) handoff gates all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)