### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PAT-LES-001): flip control-seed-test-lint to blocking (soak completed)

### DIFF
--- a/.github/workflows/control-seed-test-lint.yml
+++ b/.github/workflows/control-seed-test-lint.yml
@@ -7,21 +7,18 @@
 # exactly as blind as the gauge it inspects — it RUNS the control against a real seeded defect
 # and requires it to fire.
 #
-# *** THE ADVISORY SOAK IS AN IRONY AND I AM NAMING IT RATHER THAN HIDING IT ***
-# Repo convention (schema-reference-lint, diagnostic-gauge-citation-lint) is continue-on-error
-# for a 7-day soak on any brand-new lint. But "advisory controls block nothing at merge time" is
-# finding #2 of this SD's own FR-1 census — session-coordination-insert-classguard-lint found a
-# real seeded violation, named the file, and exited 0. So this gate ships in precisely the state
-# it exists to criticise, and that is a deliberate, bounded trade rather than an oversight:
-#   - WHY SOAK ANYWAY: this gate EXECUTES other people's controls inside CI. That is a genuine
-#     flake surface (one sampled control already crashed on a git revision error against a
-#     scratch repo), and a new gate that flakes gets disabled rather than fixed.
-#   - WHY THE SOAK IS SHORT AND NARROW: it only evaluates files ADDED in the diff that match the
-#     control globs. It does not sweep existing code, so there is no pre-existing backlog able to
-#     block an unrelated PR — the usual reason a soak runs long does not apply.
-# FLIP CRITERION, dated and falsifiable: 7 days from merge with zero false-positive reports in
-# the harness backlog -> set continue-on-error to false. If that flip has not happened by then,
-# the correct read is that this gate joined the census, not that it is still soaking.
+# BLOCKING (SD-LEARN-FIX-ADDRESS-PAT-LES-001): the soak ran 15 days (merged 2026-07-31, reviewed
+# 2026-08-15 — more than double the originally stated 7) and held clean at the phenomenon level:
+# 10 true-positive firings against real controls across 7 branches (eol-renormalization-lint,
+# or-filter-must-project, schema-reference-lint, fixture-producer-guard-lint,
+# scanner-convention-lint, stage-advancement-chokepoint-lint, diagnostic-gauge-citation-lint,
+# session-coordination-insert-classguard-lint), every one merged only after the underlying
+# control was fixed. One HARNESS_ERROR (CI run 30957843441): a seedTest trial spawned a real git
+# worktree and a nested vitest inside this gate's own test file, and blew vitest's 60s default
+# under full-suite CI contention. Root-caused and fixed in commit eb48a344bf4 before this review —
+# see tests/unit/lint/control-seed-test-lint.test.js:238-258 (exec/spawn are now stubbed there).
+# No further reports since. Escape hatch for a genuine new false positive: revert this one line
+# in a normal PR, same as any other CI gate.
 name: Control Seed-Test Lint
 
 on:
@@ -40,8 +37,8 @@ jobs:
   control-seed-test-lint:
     name: control-seed-test-lint
     runs-on: ubuntu-latest
-    # ADVISORY SOAK — see the flip criterion in the header. Not a permanent state.
-    continue-on-error: true
+    # BLOCKING (soak completed, see header comment) — SD-LEARN-FIX-ADDRESS-PAT-LES-001.
+    continue-on-error: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tests/unit/control-seed-test-lint-workflow-blocking.test.js
+++ b/tests/unit/control-seed-test-lint-workflow-blocking.test.js
@@ -1,0 +1,54 @@
+/**
+ * SD-LEARN-FIX-ADDRESS-PAT-LES-001: pins control-seed-test-lint.yml's flip from advisory
+ * (continue-on-error: true) to blocking (continue-on-error: false) now that the soak (2026-07-31
+ * to 2026-08-15, 15 days) held clean at the phenomenon level.
+ *
+ * Parses the YAML rather than regex-matching raw text: a regex-only assertion is wrong on a file
+ * whose header legitimately mentions the string "continue-on-error: true" in prose (e.g. the
+ * rollback/escape-hatch instructions), and a naive positive regex can match true even on an
+ * unflipped file with a decoy comment. Modeled on tests/unit/schema-reference-lint-workflow-blocking.test.js
+ * and the parsed-job pattern in tests/unit/crossrepo-drift-guards.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const yaml = require('js-yaml');
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = path.resolve(__dirname, '../../.github/workflows/control-seed-test-lint.yml');
+const SOURCE = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+const DOC = yaml.load(SOURCE);
+const JOB = DOC.jobs['control-seed-test-lint'];
+
+describe('control-seed-test-lint.yml is blocking (SD-LEARN-FIX-ADDRESS-PAT-LES-001)', () => {
+  it('the job sets continue-on-error: false', () => {
+    expect(JOB['continue-on-error']).toBe(false);
+  });
+
+  it('the job does not set continue-on-error: true', () => {
+    expect(JOB['continue-on-error']).not.toBe(true);
+  });
+
+  it('documents the flip and the soak-completion rationale in the header', () => {
+    expect(SOURCE).toMatch(/SD-LEARN-FIX-ADDRESS-PAT-LES-001/);
+    expect(SOURCE).toMatch(/soak[\s\S]*held clean/i);
+  });
+
+  it('does not still narrate itself as an open, still-pending advisory soak', () => {
+    expect(SOURCE).not.toMatch(/FLIP CRITERION/i);
+    expect(SOURCE).not.toMatch(/zero\s+false[- ]positive/i);
+  });
+
+  it('names the one false positive found during the soak and its fix, not a bare "clean" claim', () => {
+    expect(SOURCE).toMatch(/HARNESS_ERROR/);
+    expect(SOURCE).toMatch(/eb48a344bf4/);
+  });
+
+  it('still preserves the SECURITY tripwire block (out of scope for this flip)', () => {
+    expect(SOURCE).toMatch(/--ignore-scripts/);
+    expect(SOURCE).toMatch(/SAFETY BY COINCIDENCE/);
+  });
+});


### PR DESCRIPTION
## Summary
- AC-9/FR-9 from SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 was never delivered: control-seed-test-lint.yml's `continue-on-error: true` outlived its own dated 7-day soak criterion (deadline 2026-08-07 21:41 UTC) by 8 days.
- Job-level CI history (59 runs since merge) shows 10 true-positive firings against real controls — all merged only after the underlying control was fixed — and one already-fixed HARNESS_ERROR flake (commit `eb48a344bf4`). Zero unresolved false-positive reports.
- Flips `continue-on-error` to `false`, rewrites the header to document the measured soak outcome (mirroring the proven `schema-reference-lint.yml` template), and adds a regression test that parses the workflow YAML (not regex) so legitimate rollback-instruction prose can't produce a false negative.

## Test plan
- [x] `npx vitest run tests/unit/control-seed-test-lint-workflow-blocking.test.js tests/unit/lint/control-seed-test-lint.test.js tests/unit/lint/observability-proof.test.js` — 65/65 pass
- [x] Mutation dry-run: reverting `continue-on-error` back to `true` turns the new test red (non-vacuous), confirmed then restored
- [x] `node scripts/check-workflow-yaml.mjs` — all 191 workflow files parse OK
- [x] LEAD-TO-PLAN, PLAN-TO-EXEC handoffs passed with fresh sub-agent evidence (VALIDATION, Explore, TESTING)

🤖 Generated with [Claude Code](https://claude.com/claude-code)