### PR TITLE
feat(SD-LEO-FIX-STRIP-DEAD-DB-CREDENTIAL-LITERALS-001): hardened tree-at-rest connection-string-literal guard (PR 2 of 2)

### DIFF
--- a/.github/workflows/no-connection-string-literals-lint.yml
+++ b/.github/workflows/no-connection-string-literals-lint.yml
@@ -1,0 +1,41 @@
+name: No Connection String Literals Lint
+
+# SD-LEO-FIX-STRIP-DEAD-DB-CREDENTIAL-LITERALS-001, FR-3.
+# Tree-at-rest guard: scans every git-tracked file for (A) a postgres(ql):// URL shape with
+# something in the password slot, and (B) the specific rotated credential from this SD's
+# incident, via length-bounded hash comparison (see scripts/lint/no-connection-string-literals-
+# lint.mjs for the full design rationale). Verified clean against this repo's full tracked
+# tree (17.8k files, ~1m40s) before this workflow was added -- blocking from day one, no
+# advisory period needed (contrast .github/workflows/eol-renormalization-lint.yml, which had
+# 3 known unresolved violations at authoring time and so started advisory).
+
+on:
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - '**/*.ts'
+      - '**/*.md'
+      - '**/*.sh'
+      - '**/*.sql'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '.husky/**'
+      - 'scripts/lint/no-connection-string-literals-lint.mjs'
+      - '.github/workflows/no-connection-string-literals-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-connection-string-literals-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Scan tracked tree for connection-string literals
+        run: node scripts/lint/no-connection-string-literals-lint.mjs

--- a/.github/workflows/no-connection-string-literals-lint.yml
+++ b/.github/workflows/no-connection-string-literals-lint.yml
@@ -5,25 +5,26 @@ name: No Connection String Literals Lint
 # something in the password slot, and (B) the specific rotated credential from this SD's
 # incident, via length-bounded hash comparison (see scripts/lint/no-connection-string-literals-
 # lint.mjs for the full design rationale). Verified clean against this repo's full tracked
-# tree (17.8k files, ~1m40s) before this workflow was added -- blocking from day one, no
-# advisory period needed (contrast .github/workflows/eol-renormalization-lint.yml, which had
-# 3 known unresolved violations at authoring time and so started advisory).
+# tree (17.8k files, ~1m30s) before this workflow was added.
+#
+# Deliberately NO `paths:` filter: an adversarial review of an earlier draft (which did filter
+# by extension) measured 745+ tracked files this workflow would silently never scan --
+# .json, .ps1, extensionless files (incl. supabase/.temp/pooler-url, whose entire purpose is
+# holding a pooler connection URL), .env.example/.env.claude*, .tsx/.jsx, .py, .toml, .npmrc,
+# .pem. A credential can land in any tracked file; this job always runs on every PR instead.
+# Also runs on push to main so a squash-merge or an admin-bypassed PR still gets scanned.
+#
+# NOT yet a required status check in branch protection (verified via `gh api
+# repos/.../branches/main/protection` at authoring time -- only "Run Unit Tier (quarantine-aware)"
+# is required). This workflow reports and can fail the run, but cannot yet BLOCK a merge on its
+# own; making it required is a branch-protection admin action outside this PR's scope, signaled
+# to the coordinator separately rather than self-granted here.
 
 on:
-  pull_request:
-    paths:
-      - '**/*.js'
-      - '**/*.mjs'
-      - '**/*.cjs'
-      - '**/*.ts'
-      - '**/*.md'
-      - '**/*.sh'
-      - '**/*.sql'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '.husky/**'
-      - 'scripts/lint/no-connection-string-literals-lint.mjs'
-      - '.github/workflows/no-connection-string-literals-lint.yml'
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "lint:ismainmodule-classguard": "node scripts/lint/ismainmodule-classguard-lint.mjs",
     "lint:mocked-sut-import": "node scripts/lint/no-mocked-sut-import-lint.mjs",
     "lint:session-coordination-insert": "node scripts/lint/session-coordination-insert-classguard-lint.mjs",
+    "lint:no-connection-string-literals": "node scripts/lint/no-connection-string-literals-lint.mjs",
     "lint:repo-resolution-drift": "node scripts/lint-repo-resolution-drift.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",

--- a/scripts/lint/no-connection-string-literals-lint.mjs
+++ b/scripts/lint/no-connection-string-literals-lint.mjs
@@ -37,17 +37,28 @@ export const URL_SHAPE_RE = /postgres(?:ql)?:\/\/[^\s'"`]+:[^\s'"@]+@/;
 // strategic_directives_v2.metadata.credential_validity_probe), in both encodings it appeared
 // in across the tree. Never the plaintext. A sliding window of the exact LENGTH is hashed and
 // compared, so this list can only ever grow by adding another {length, sha256} pair, never a
-// literal value.
+// literal value. ROTATED/DEAD VALUES ONLY: a sha256 digest of an unsalted secret is a crackable
+// offline oracle for anyone who reads this file, so never add a hash for a value that is still
+// live -- rotate first, then add the digest here as a permanent regression check.
 export const SECRET_HASHES = [
   { length: 18, sha256: '3a6157e77d6a1702c932da50c2718c74e287850c6a1d45362cdbf7c3fb6a63a7', note: 'url-encoded form' },
   { length: 14, sha256: '027815e1921626ed2078c557acf22e31b48c947a52a9829496c830ccb5c66fc4', note: 'raw-decoded form' },
 ];
 
-// Bounds total scan cost on a pathological single-line file (minified bundle, generated
-// lockfile) rather than any backtracking risk in the patterns above, which are linear.
-const MAX_LINE_LENGTH = 4096;
+// Assertion A's regex cost is linear in line length (no backtracking risk -- the character
+// classes are all negated, single-step matches), so it is run against every line regardless of
+// length. Assertion B is bounded per TOKEN, not per line (see MAX_TOKEN_LENGTH below) --
+// tokenizing first already makes an ordinary long line cheap, so a line-wide cutoff would only
+// ever discard genuine coverage (a real credential can sit anywhere in a long line, e.g. a long
+// comment or a long list) without buying back any real cost protection.
+const MAX_TOKEN_LENGTH = 16384;
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 
+// Assertion-A-only, same rule as PATH_ALLOWLIST below: assertion B is NEVER path-exempted,
+// including for these two files. An adversarial review of an earlier draft caught a real bug
+// here -- evaluateFiles() used to `continue` past a self-path entirely, silently disabling
+// assertion B for exactly the file (this guard's own test) a future maintainer is most likely
+// to paste the real plaintext into "to check the hash matches".
 export const SELF_PATHS = new Set([
   'scripts/lint/no-connection-string-literals-lint.mjs',
   'tests/unit/hygiene/no-connection-string-literals.test.js',
@@ -89,6 +100,17 @@ export const PATH_ALLOWLIST = [
     rationale: 'Feature reference doc: illustrative connection-string URL with a generic user/pass example.',
   },
   {
+    path: 'CLAUDE_CORE.md',
+    rationale: 'Protocol doc: an explicit "wrong, do not do this" connection example with a literal '
+      + 'PROJECT placeholder token in both the username and host positions.',
+  },
+  {
+    path: 'scripts/__tests__/replay/README.md',
+    rationale: 'Documents a DIFFERENT pattern-detection system\'s own regex convention '
+      + '(postgres_conn_with_password) as a reference table -- a pattern DEFINITION, same class '
+      + 'as the .husky/pre-commit entry above, not an instance of the shape.',
+  },
+  {
     pattern: /(^|\/)tests\//,
     rationale: 'Test fixtures legitimately contain fictional example connection strings to '
       + 'exercise parsing/redaction logic (e.g. tests/unit/session-summary/secret-redactor.test.js '
@@ -114,9 +136,15 @@ export const VALUE_ALLOWLIST_PATTERNS = [
   // are live JS template-literal CODE interpolating a variable at runtime, never a literal
   // value -- exactly the "template-literal prefix, not an embedded credential" false-positive
   // class this SD's own LEAD-phase investigation found in the original (wrong) premise.
-  { name: 'template-or-env-var-reference', re: /^(\$\{.+\}|\$[A-Za-z0-9_]+|%[A-Za-z0-9_]+%)$/ },
+  // [^{}]+ (not .+) is load-bearing: a greedy .+ lets this match SPAN two separate ${...}
+  // expressions with a real secret sandwiched between them (e.g. "${a}REALSECRET${b}") --
+  // excluding brace characters forces exactly one balanced expression per match.
+  { name: 'template-or-env-var-reference', re: /^(\$\{[^{}]+\}|\$[A-Za-z0-9_]+|%[A-Za-z0-9_]+%)$/ },
   { name: 'redaction-mask', re: /^(\*{3,}|[xX]{3,}|REDACTED)$/i },
-  { name: 'bare-marker-word', re: /^(PASSWORD|SECRET|CREDENTIAL|TOKEN)$/i },
+  // Case-SENSITIVE (no /i): the all-caps convention is what documentation markers actually use
+  // (PASSWORD, YOUR_PASSWORD); a real weak credential is far more likely spelled "password" or
+  // "Password123", which this deliberately does NOT exempt.
+  { name: 'bare-marker-word', re: /^(PASSWORD|SECRET|CREDENTIAL|TOKEN)$/ },
 ];
 
 export function isAllowlistedValue(text) {
@@ -131,12 +159,15 @@ export function isSelfPath(filePath, selfPaths = SELF_PATHS) {
   return selfPaths.has(filePath);
 }
 
-// The password slot is the text between the LAST ':' before '@' and '@' itself -- lastIndexOf
-// searches backward from just before '@', so it lands on the user:password separator rather
-// than the earlier scheme "://" colon.
+// The password slot is the text between the FIRST ':' after the scheme separator and '@'.
+// Deliberately the FIRST colon, not the last one before '@': a real user:password delimiter
+// never repeats, so using the LAST colon let a value like "user:REALSECRET:MARKER@" extract
+// only the trailing "MARKER" as the checked slot, silently allowlisting the embedded real
+// secret sitting in what this parse would otherwise treat as part of the username.
 function extractPasswordSlot(matchText) {
+  const schemeEnd = matchText.indexOf('://') + 3;
+  const colonIdx = matchText.indexOf(':', schemeEnd);
   const atIdx = matchText.lastIndexOf('@');
-  const colonIdx = matchText.lastIndexOf(':', atIdx - 1);
   return matchText.slice(colonIdx + 1, atIdx);
 }
 
@@ -159,13 +190,22 @@ export function findUrlShapeMatches(line) {
 // anywhere within a long token (a URL, an env-var value, a base64 blob). This intentionally
 // cannot catch a credential word-wrapped mid-token across a line break -- not a realistic
 // placement for a connection-string value, and unbounded whole-line scanning is not tractable.
+//
+// Bounded per TOKEN (MAX_TOKEN_LENGTH), not per line: an ordinary long line (many short tokens)
+// costs nothing extra regardless of its total length, so only a single pathologically long
+// unbroken token (a minified blob, a giant base64 chunk) is ever skipped -- and that skip is
+// reported via `skipped`, never silent.
 export function findHashMatches(line, hashes = SECRET_HASHES) {
   const hits = [];
-  if (line.length > MAX_LINE_LENGTH) return hits;
+  const skipped = [];
   const tokens = line.match(/\S+/g);
-  if (!tokens) return hits;
-  for (const entry of hashes) {
-    for (const token of tokens) {
+  if (!tokens) return { hits, skipped };
+  for (const token of tokens) {
+    if (token.length > MAX_TOKEN_LENGTH) {
+      skipped.push({ length: token.length });
+      continue;
+    }
+    for (const entry of hashes) {
       for (let i = 0; i + entry.length <= token.length; i++) {
         const window = token.slice(i, i + entry.length);
         if (createHash('sha256').update(window, 'utf8').digest('hex') === entry.sha256) {
@@ -174,24 +214,30 @@ export function findHashMatches(line, hashes = SECRET_HASHES) {
       }
     }
   }
-  return hits;
+  return { hits, skipped };
 }
 
 /**
  * Pure evaluator over already-loaded {path, content} pairs, so tests can exercise allowlist /
  * self-exclusion / hash-match behavior without depending on live repo state or git.
+ *
+ * SELF_PATHS and PATH_ALLOWLIST both narrow assertion A ONLY. Assertion B is never
+ * path-exempted for ANY file, including the guard's own source and test: B is
+ * self-exclusion-safe by construction (finding a substring that hashes to a stored digest is
+ * computationally infeasible without the plaintext), so it needs no exemption -- and the guard's
+ * own test file is exactly where a future maintainer is most likely to paste the real value "to
+ * check the hash matches", which a path exemption would silently swallow.
  */
 export function evaluateFiles(files, { pathAllowlist = PATH_ALLOWLIST, selfPaths = SELF_PATHS, hashes = SECRET_HASHES } = {}) {
   const violations = [];
+  const skippedTokens = [];
 
   for (const { path: filePath, content } of files) {
-    if (isSelfPath(filePath, selfPaths)) continue;
-    const skipAssertionA = isAllowlistedPath(filePath, pathAllowlist);
+    const skipAssertionA = isSelfPath(filePath, selfPaths) || isAllowlistedPath(filePath, pathAllowlist);
     const lines = content.split('\n');
 
     lines.forEach((line, i) => {
       const lineNumber = i + 1;
-      if (line.length > MAX_LINE_LENGTH) return;
 
       if (!skipAssertionA) {
         for (const match of findUrlShapeMatches(line)) {
@@ -201,36 +247,59 @@ export function evaluateFiles(files, { pathAllowlist = PATH_ALLOWLIST, selfPaths
         }
       }
 
-      for (const hit of findHashMatches(line, hashes)) {
+      const { hits, skipped } = findHashMatches(line, hashes);
+      for (const hit of hits) {
         violations.push({ file: filePath, line: lineNumber, assertion: 'B', detail: `known-bad value (${hit.note})` });
+      }
+      for (const s of skipped) {
+        skippedTokens.push({ file: filePath, line: lineNumber, length: s.length });
       }
     });
   }
 
-  return { violations, ok: violations.length === 0 };
+  return { violations, ok: violations.length === 0, skippedTokens };
 }
 
 function loadTrackedFiles() {
-  const raw = execFileSync('git', ['ls-files'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
-  const paths = raw.split('\n').filter(Boolean);
+  // -z: NUL-delimited output. Plain `git ls-files` quote-escapes any path with non-ASCII or
+  // special characters (core.quotePath, on by default) as e.g. "caf\303\251.md" -- a string
+  // readFileSync can't open, silently dropping that file via the catch below with zero
+  // indication. -z sidesteps quoting entirely and hands back raw path bytes.
+  const raw = execFileSync('git', ['ls-files', '-z'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  const paths = raw.split('\0').filter(Boolean);
   const files = [];
+  const skippedFiles = [];
   for (const p of paths) {
     try {
       const buf = readFileSync(p);
-      if (buf.length > MAX_FILE_BYTES) continue;
+      if (buf.length > MAX_FILE_BYTES) {
+        skippedFiles.push({ path: p, bytes: buf.length });
+        continue;
+      }
       files.push({ path: p, content: buf.toString('utf8') });
     } catch {
       continue; // binary decode failure, deleted-since-ls-files, permission error -- not a violation
     }
   }
-  return files;
+  return { files, skippedFiles };
 }
 
 function main() {
-  const files = loadTrackedFiles();
+  const { files, skippedFiles } = loadTrackedFiles();
   const result = evaluateFiles(files);
 
   console.log(`[no-connection-string-literals-lint] scanned ${files.length} tracked file(s)`);
+
+  // No silent caps: a bounded scan that never reports what it dropped reads as "covered
+  // everything" when it didn't.
+  if (skippedFiles.length > 0) {
+    console.log(`⚠ skipped ${skippedFiles.length} file(s) over the ${MAX_FILE_BYTES}-byte cap (not scanned):`);
+    for (const s of skippedFiles) console.log(`   ${s.path} (${s.bytes} bytes)`);
+  }
+  if (result.skippedTokens.length > 0) {
+    console.log(`⚠ skipped ${result.skippedTokens.length} token(s) over the ${MAX_TOKEN_LENGTH}-char cap for assertion B (not hash-scanned):`);
+    for (const s of result.skippedTokens) console.log(`   ${s.file}:${s.line} (token length ${s.length})`);
+  }
 
   if (!result.ok) {
     console.error(`\n❌ ${result.violations.length} connection-string-literal violation(s):`);

--- a/scripts/lint/no-connection-string-literals-lint.mjs
+++ b/scripts/lint/no-connection-string-literals-lint.mjs
@@ -1,0 +1,253 @@
+// SD-LEO-FIX-STRIP-DEAD-DB-CREDENTIAL-LITERALS-001, FR-3/FR-4.
+//
+// Hardened tree-at-rest guard: scans every git-tracked file for two independent, unrelated
+// signals so either one alone is sufficient to fail the check.
+//
+// Assertion A (structural): a postgres(ql):// URL shape with something in the password slot.
+// Mirrors .husky/pre-commit's own scanner pattern (scheme, then a colon-delimited credential
+// slot ending in '@') — deliberately PURELY STRUCTURAL, no knowledge of any specific
+// credential, so it also fires on a
+// documented marker in the password slot (see VALUE_ALLOWLIST_PATTERNS) unless the value is
+// recognized as a marker, or the file is a reference doc that legitimately shows connection-
+// string shapes (see PATH_ALLOWLIST — narrows assertion A only, never assertion B below).
+//
+// Assertion B (content): the ACTUAL known-bad credential value, in either encoding, detected
+// via a length-bounded sliding-window SHA-256 comparison rather than a literal string match.
+// This is deliberate: embedding the plaintext anywhere in this guard's own source would be
+// exactly the class of exposure this SD exists to close. Because SECRET_HASHES holds only
+// {length, sha256} pairs, this file is self-exclusion-safe for assertion B BY CONSTRUCTION —
+// finding a substring that hashes to a stored digest is computationally infeasible, so this
+// guard can never flag itself no matter how the source is phrased or reformatted.
+//
+// Assertion A's self-exclusion is not as automatic (a shape regex, unlike a hash compare, COULD
+// in principle match adversarial text), so SELF_PATHS adds an explicit path exclusion as a
+// second, independent safeguard on top of the regex's own escaped-slash construction (see
+// URL_SHAPE_RE below) never containing a literal "://" run in this file's own source text.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+// Escaped slashes (\/\/  rather than //) are not cosmetic: they mean this file's own source
+// text never contains a literal "://" 3-character run, so assertion A structurally cannot
+// match this file's own pattern definition even before SELF_PATHS is consulted.
+export const URL_SHAPE_RE = /postgres(?:ql)?:\/\/[^\s'"`]+:[^\s'"@]+@/;
+
+// {length, sha256} pairs for the known-dead credential (rotated 2026-08-15T22:40:46Z — see
+// strategic_directives_v2.metadata.credential_validity_probe), in both encodings it appeared
+// in across the tree. Never the plaintext. A sliding window of the exact LENGTH is hashed and
+// compared, so this list can only ever grow by adding another {length, sha256} pair, never a
+// literal value.
+export const SECRET_HASHES = [
+  { length: 18, sha256: '3a6157e77d6a1702c932da50c2718c74e287850c6a1d45362cdbf7c3fb6a63a7', note: 'url-encoded form' },
+  { length: 14, sha256: '027815e1921626ed2078c557acf22e31b48c947a52a9829496c830ccb5c66fc4', note: 'raw-decoded form' },
+];
+
+// Bounds total scan cost on a pathological single-line file (minified bundle, generated
+// lockfile) rather than any backtracking risk in the patterns above, which are linear.
+const MAX_LINE_LENGTH = 4096;
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+
+export const SELF_PATHS = new Set([
+  'scripts/lint/no-connection-string-literals-lint.mjs',
+  'tests/unit/hygiene/no-connection-string-literals.test.js',
+]);
+
+// Assertion-A-only exemptions: reference docs whose entire purpose is illustrating connection-
+// string shapes (including deliberate anti-pattern examples), the scanner's own pattern
+// definition, and test fixtures that legitimately exercise parsing/redaction logic against a
+// fictional example credential. Assertion B still scans every one of these files in full --
+// the actual leaked value must never reappear anywhere, reference doc or test fixture or not.
+// Measured against this repo's full 17.8k-file tracked tree (not guessed): every entry here
+// corresponds to an actual false positive the live scan produced.
+export const PATH_ALLOWLIST = [
+  {
+    path: 'docs/guides/supabase-connectivity.md',
+    rationale: 'Connectivity reference guide: shows the connection-string shape multiple times, '
+      + 'including a deliberate "what NOT to do" shell-escaping example with a fictional password.',
+  },
+  {
+    path: 'docs/06_deployment/ci-cd-secrets-consolidated-report.md',
+    rationale: 'Secrets/deployment reference doc in the same genre -- catalogs connection-string '
+      + 'shapes for operational reference.',
+  },
+  {
+    path: '.husky/pre-commit',
+    rationale: 'Contains the secret scanner\'s own grep -oiE regex pattern as literal shell text '
+      + '-- a pattern DEFINITION naming the shape, not an instance of it.',
+  },
+  {
+    path: 'CONTRIBUTING.md',
+    rationale: 'Contributor guide: illustrative connection-string URL with a generic user/pass example.',
+  },
+  {
+    path: 'database/migrations/EXECUTION-GUIDE.md',
+    rationale: 'Migration execution reference: illustrative connection-string URL with a fictional example password.',
+  },
+  {
+    path: 'docs/reference/session-summary-feature.md',
+    rationale: 'Feature reference doc: illustrative connection-string URL with a generic user/pass example.',
+  },
+  {
+    pattern: /(^|\/)tests\//,
+    rationale: 'Test fixtures legitimately contain fictional example connection strings to '
+      + 'exercise parsing/redaction logic (e.g. tests/unit/session-summary/secret-redactor.test.js '
+      + 'testing the redactor itself needs an unredacted example to redact).',
+  },
+  {
+    pattern: /\.test\.(js|mjs|cjs|ts)$/,
+    rationale: 'Same rationale as the tests/ pattern, for test files living outside the tests/ '
+      + 'directory (e.g. scripts/worker-signal.test.js).',
+  },
+];
+
+// Six marker/placeholder families a password slot may legitimately hold in documentation or
+// code. Structural (bracket/template-expression/case convention), not tied to any specific
+// wording, so future docs and code using the same conventions are covered without an
+// allowlist edit.
+export const VALUE_ALLOWLIST_PATTERNS = [
+  { name: 'angle-bracket-marker', re: /^<[^<>]+>$/ },
+  { name: 'square-bracket-marker', re: /^\[[^[\]]+\]$/ },
+  { name: 'your-my-convention', re: /^(YOUR|MY)_[A-Z0-9_]+$/ },
+  // Any ${...} / $VAR / %VAR% reference -- deliberately broad on the ${...} case (not just
+  // ${SIMPLE_VAR}): ${encodeURIComponent(password)} and ${process.env.SUPABASE_DB_PASSWORD}
+  // are live JS template-literal CODE interpolating a variable at runtime, never a literal
+  // value -- exactly the "template-literal prefix, not an embedded credential" false-positive
+  // class this SD's own LEAD-phase investigation found in the original (wrong) premise.
+  { name: 'template-or-env-var-reference', re: /^(\$\{.+\}|\$[A-Za-z0-9_]+|%[A-Za-z0-9_]+%)$/ },
+  { name: 'redaction-mask', re: /^(\*{3,}|[xX]{3,}|REDACTED)$/i },
+  { name: 'bare-marker-word', re: /^(PASSWORD|SECRET|CREDENTIAL|TOKEN)$/i },
+];
+
+export function isAllowlistedValue(text) {
+  return VALUE_ALLOWLIST_PATTERNS.some((p) => p.re.test(text));
+}
+
+export function isAllowlistedPath(filePath, allowlist = PATH_ALLOWLIST) {
+  return allowlist.some((e) => (e.path && e.path === filePath) || (e.pattern && e.pattern.test(filePath)));
+}
+
+export function isSelfPath(filePath, selfPaths = SELF_PATHS) {
+  return selfPaths.has(filePath);
+}
+
+// The password slot is the text between the LAST ':' before '@' and '@' itself -- lastIndexOf
+// searches backward from just before '@', so it lands on the user:password separator rather
+// than the earlier scheme "://" colon.
+function extractPasswordSlot(matchText) {
+  const atIdx = matchText.lastIndexOf('@');
+  const colonIdx = matchText.lastIndexOf(':', atIdx - 1);
+  return matchText.slice(colonIdx + 1, atIdx);
+}
+
+export function findUrlShapeMatches(line) {
+  const re = new RegExp(URL_SHAPE_RE.source, 'g');
+  const matches = [];
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    matches.push({ matchText: m[0], passwordSlot: extractPasswordSlot(m[0]) });
+  }
+  return matches;
+}
+
+// A whole-line character-by-character slide is O(line_length) SHA-256 calls PER hash family,
+// regardless of content -- measured catastrophic at repo scale (17.8k tracked files: minutes,
+// not seconds). A real connection-string credential is always a single unbroken non-whitespace
+// token (whitespace inside one would break the URL/env-var syntax it lives in), so restricting
+// the slide to within each whitespace-delimited token cuts an ordinary line (many short tokens,
+// none reaching the window length) to zero hash calls, while still finding the credential
+// anywhere within a long token (a URL, an env-var value, a base64 blob). This intentionally
+// cannot catch a credential word-wrapped mid-token across a line break -- not a realistic
+// placement for a connection-string value, and unbounded whole-line scanning is not tractable.
+export function findHashMatches(line, hashes = SECRET_HASHES) {
+  const hits = [];
+  if (line.length > MAX_LINE_LENGTH) return hits;
+  const tokens = line.match(/\S+/g);
+  if (!tokens) return hits;
+  for (const entry of hashes) {
+    for (const token of tokens) {
+      for (let i = 0; i + entry.length <= token.length; i++) {
+        const window = token.slice(i, i + entry.length);
+        if (createHash('sha256').update(window, 'utf8').digest('hex') === entry.sha256) {
+          hits.push({ note: entry.note });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Pure evaluator over already-loaded {path, content} pairs, so tests can exercise allowlist /
+ * self-exclusion / hash-match behavior without depending on live repo state or git.
+ */
+export function evaluateFiles(files, { pathAllowlist = PATH_ALLOWLIST, selfPaths = SELF_PATHS, hashes = SECRET_HASHES } = {}) {
+  const violations = [];
+
+  for (const { path: filePath, content } of files) {
+    if (isSelfPath(filePath, selfPaths)) continue;
+    const skipAssertionA = isAllowlistedPath(filePath, pathAllowlist);
+    const lines = content.split('\n');
+
+    lines.forEach((line, i) => {
+      const lineNumber = i + 1;
+      if (line.length > MAX_LINE_LENGTH) return;
+
+      if (!skipAssertionA) {
+        for (const match of findUrlShapeMatches(line)) {
+          if (!isAllowlistedValue(match.passwordSlot)) {
+            violations.push({ file: filePath, line: lineNumber, assertion: 'A', detail: match.matchText });
+          }
+        }
+      }
+
+      for (const hit of findHashMatches(line, hashes)) {
+        violations.push({ file: filePath, line: lineNumber, assertion: 'B', detail: `known-bad value (${hit.note})` });
+      }
+    });
+  }
+
+  return { violations, ok: violations.length === 0 };
+}
+
+function loadTrackedFiles() {
+  const raw = execFileSync('git', ['ls-files'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  const paths = raw.split('\n').filter(Boolean);
+  const files = [];
+  for (const p of paths) {
+    try {
+      const buf = readFileSync(p);
+      if (buf.length > MAX_FILE_BYTES) continue;
+      files.push({ path: p, content: buf.toString('utf8') });
+    } catch {
+      continue; // binary decode failure, deleted-since-ls-files, permission error -- not a violation
+    }
+  }
+  return files;
+}
+
+function main() {
+  const files = loadTrackedFiles();
+  const result = evaluateFiles(files);
+
+  console.log(`[no-connection-string-literals-lint] scanned ${files.length} tracked file(s)`);
+
+  if (!result.ok) {
+    console.error(`\n❌ ${result.violations.length} connection-string-literal violation(s):`);
+    for (const v of result.violations) {
+      console.error(`   ${v.file}:${v.line} [assertion ${v.assertion}] ${v.detail}`);
+    }
+    console.error('   Fix: remove the literal, use an env var, or use a documented marker (see VALUE_ALLOWLIST_PATTERNS in this file).');
+  } else {
+    console.log('✅ OK — no connection-string literals found.');
+  }
+
+  // process.exitCode rather than process.exit(): matches this repo's other lint drivers
+  // (e.g. scripts/lint/eol-renormalization-lint.mjs) to avoid a Windows libuv race that can
+  // turn a clean exit into a spurious failure.
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/tests/unit/hygiene/no-connection-string-literals.test.js
+++ b/tests/unit/hygiene/no-connection-string-literals.test.js
@@ -62,6 +62,19 @@ describe('URL_SHAPE_RE / findUrlShapeMatches: assertion A shape detection', () =
   it('URL_SHAPE_RE source contains no literal "://" run (self-exclusion by construction)', () => {
     expect(URL_SHAPE_RE.source.includes('://')).toBe(false);
   });
+
+  // F4 from an adversarial review of an earlier draft: extracting text after the LAST colon
+  // before '@' (rather than the FIRST colon after the scheme) let a real secret embedded
+  // earlier in the credential slot hide behind a trailing marker-shaped decoy.
+  it('extracts everything after the FIRST colon, not just the text after the last one -- ' +
+     'a real secret cannot hide behind a trailing marker-shaped decoy', () => {
+    const line = pgUrl('user', 'REALSECRETVALUE:REDACTED', 'host/db');
+    const matches = findUrlShapeMatches(line);
+    expect(matches[0].passwordSlot).toBe('REALSECRETVALUE:REDACTED');
+    // and therefore does NOT match any allowlist family (unlike the bare "REDACTED" it would
+    // have extracted under the old last-colon logic)
+    expect(isAllowlistedValue(matches[0].passwordSlot)).toBe(false);
+  });
 });
 
 describe('isAllowlistedValue: the 6 documented marker families', () => {
@@ -98,6 +111,21 @@ describe('isAllowlistedValue: the 6 documented marker families', () => {
   ])('recognizes a JS template-literal expression as code, not a value: %s', (value) => {
     expect(isAllowlistedValue(value)).toBe(true);
   });
+
+  // F4 from an adversarial review of an earlier draft: a greedy `.+` inside `${...}` let the
+  // pattern span TWO separate template expressions with a real secret sandwiched between them.
+  it('does NOT allowlist a real secret sandwiched between two separate ${...} expressions', () => {
+    expect(isAllowlistedValue('${a}REALSECRETVALUE${b}')).toBe(false);
+  });
+
+  // F5 from the same review: the marker-word family used to be case-insensitive, exempting
+  // real (if weak) lowercase credentials that happen to spell the word "password".
+  it.each(['password', 'Password', 'secret', 'Token'])(
+    'does NOT allowlist a lowercase/mixed-case bare word (real weak credential, not a marker): %s',
+    (value) => {
+      expect(isAllowlistedValue(value)).toBe(false);
+    },
+  );
 });
 
 describe('isAllowlistedPath / isSelfPath', () => {
@@ -135,30 +163,45 @@ describe('findHashMatches: assertion B sliding-window hash detection (synthetic 
   const testHashes = [{ length: fixture.length, sha256: sha256(fixture), note: 'synthetic-fixture' }];
 
   it('finds the fixture value embedded inside a longer line', () => {
-    const hits = findHashMatches(`SUPABASE_DB_PASSWORD=${fixture}`, testHashes);
+    const { hits } = findHashMatches(`SUPABASE_DB_PASSWORD=${fixture}`, testHashes);
     expect(hits).toHaveLength(1);
     expect(hits[0].note).toBe('synthetic-fixture');
   });
 
   it('finds the fixture value when it IS the whole line', () => {
-    expect(findHashMatches(fixture, testHashes)).toHaveLength(1);
+    expect(findHashMatches(fixture, testHashes).hits).toHaveLength(1);
   });
 
   it('does not match a different string of the identical length', () => {
     const decoy = 'Zq9!fakeSecret2'; // same length, last char differs
     expect(decoy).toHaveLength(fixture.length);
-    expect(findHashMatches(decoy, testHashes)).toHaveLength(0);
+    expect(findHashMatches(decoy, testHashes).hits).toHaveLength(0);
   });
 
   it('never matches a line shorter than the window length', () => {
-    expect(findHashMatches(fixture.slice(0, -1), testHashes)).toHaveLength(0);
+    expect(findHashMatches(fixture.slice(0, -1), testHashes).hits).toHaveLength(0);
   });
 
   it('finds multiple independent hash families in the same line', () => {
     const other = 'AnotherFake99'; // 13 chars
     const multiHashes = [...testHashes, { length: other.length, sha256: sha256(other), note: 'second-fixture' }];
-    const hits = findHashMatches(`${fixture} and ${other}`, multiHashes);
+    const { hits } = findHashMatches(`${fixture} and ${other}`, multiHashes);
     expect(hits.map((h) => h.note).sort()).toEqual(['second-fixture', 'synthetic-fixture']);
+  });
+
+  it('finds the fixture inside a long line as long as no SINGLE token exceeds the cap ' +
+     '(assertion B is bounded per token, not per line)', () => {
+    const longButNormal = Array.from({ length: 400 }, (_, i) => `word${i}`).join(' '); // ~2800 chars, short tokens
+    const { hits, skipped } = findHashMatches(`${longButNormal} ${fixture}`, testHashes);
+    expect(hits).toHaveLength(1);
+    expect(skipped).toHaveLength(0);
+  });
+
+  it('skips (and reports) a single token that exceeds the token-length cap, without affecting other tokens', () => {
+    const giantToken = 'x'.repeat(20000); // over MAX_TOKEN_LENGTH (16384)
+    const { hits, skipped } = findHashMatches(`${giantToken} ${fixture}`, testHashes);
+    expect(hits).toHaveLength(1); // the fixture, in its own separate token, is still found
+    expect(skipped).toEqual([{ length: giantToken.length }]);
   });
 });
 
@@ -217,23 +260,52 @@ describe('evaluateFiles: end-to-end, both assertions, allowlist interplay', () =
     expect(result.violations[0].line).toBe(2);
   });
 
-  it('suppresses BOTH assertions entirely for a self-path file', () => {
+  it('suppresses assertion A for a self-path file (a fictional example in the guard\'s own comments)', () => {
     const files = [{
       path: 'scripts/lint/no-connection-string-literals-lint.mjs',
-      content: `const url = '${pgUrl('u', 'realsecretvalue', 'host/db')}';\n${fixture}`,
+      content: `const url = '${pgUrl('u', 'realsecretvalue', 'host/db')}';`,
     }];
     const result = evaluateFiles(files, { hashes: testHashes });
     expect(result.ok).toBe(true);
   });
 
-  it('skips a pathologically long line for both assertions (bounded-scan guard)', () => {
+  // F1 from an adversarial review of an earlier draft: evaluateFiles() used to `continue` past
+  // a self-path entirely, silently disabling assertion B too -- exactly the file (the guard's
+  // own test) a future maintainer is most likely to paste the real plaintext into.
+  it('does NOT suppress assertion B for a self-path file (F1 regression -- this must never ' +
+     'go back to `continue`-ing past self-paths entirely)', () => {
+    const files = [{
+      path: 'scripts/lint/no-connection-string-literals-lint.mjs',
+      content: fixture,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual([
+      { file: 'scripts/lint/no-connection-string-literals-lint.mjs', line: 1, assertion: 'B', detail: expect.stringContaining('synthetic-fixture') },
+    ]);
+  });
+
+  it('assertion A is not line-length-bounded -- a violation deep inside a long line is still caught', () => {
     const longPadding = 'x'.repeat(5000);
     const files = [{
       path: 'scripts/example.mjs',
-      content: `${longPadding}${pgUrl('u', 'realsecretvalue', 'host/db')} ${fixture}`,
+      content: `${longPadding} ${pgUrl('u', 'realsecretvalue', 'host/db')}`,
     }];
     const result = evaluateFiles(files, { hashes: testHashes });
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].assertion).toBe('A');
+  });
+
+  it('assertion B skips only a pathologically long TOKEN, not the whole line, and reports it via skippedTokens', () => {
+    const giantToken = 'y'.repeat(20000);
+    const files = [{
+      path: 'scripts/example.mjs',
+      content: `${giantToken} ${fixture}`,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(false); // fixture, in its own token, is still found
+    expect(result.violations[0].assertion).toBe('B');
+    expect(result.skippedTokens).toEqual([{ file: 'scripts/example.mjs', line: 1, length: giantToken.length }]);
   });
 
   it('reports correct file/line across multiple files evaluated together', () => {

--- a/tests/unit/hygiene/no-connection-string-literals.test.js
+++ b/tests/unit/hygiene/no-connection-string-literals.test.js
@@ -1,0 +1,298 @@
+// SD-LEO-FIX-STRIP-DEAD-DB-CREDENTIAL-LITERALS-001, FR-3/FR-4.
+//
+// Assertion B's fixtures are SYNTHETIC throwaway strings, never the real known-bad credential.
+// Each test computes its own fixture's sha256 at test time and injects it via the `hashes`
+// param that findHashMatches/evaluateFiles both accept -- the real SECRET_HASHES constant
+// (holding the actual incident's digests) is exercised only by its own shape-contract test
+// below, which checks {length, sha256-hex-format}, never a value that could satisfy it.
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  URL_SHAPE_RE,
+  SECRET_HASHES,
+  PATH_ALLOWLIST,
+  VALUE_ALLOWLIST_PATTERNS,
+  SELF_PATHS,
+  isAllowlistedValue,
+  isAllowlistedPath,
+  isSelfPath,
+  findUrlShapeMatches,
+  findHashMatches,
+  evaluateFiles,
+} from '../../../scripts/lint/no-connection-string-literals-lint.mjs';
+
+function sha256(value) {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+// Builds a fake connection-string fixture from parts so this file's own SOURCE never contains
+// the literal scheme://user:pass@ shape as a contiguous run. .husky/pre-commit's structural
+// secret scanner has no allowlist of its own (unlike the guard under test here) and correctly
+// flags ANY match in an added diff line, fictional test fixture or not.
+function pgUrl(user, password, hostPath, scheme = 'postgresql') {
+  return [scheme, '://', user, ':', password, '@', hostPath].join('');
+}
+
+describe('URL_SHAPE_RE / findUrlShapeMatches: assertion A shape detection', () => {
+  it('matches a postgresql:// URL with a credential-shaped password slot', () => {
+    const matches = findUrlShapeMatches(`psql '${pgUrl('postgres.ref', 'somesecret', 'host:5432/db')}'`);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].passwordSlot).toBe('somesecret');
+  });
+
+  it('matches a bare postgres:// scheme too', () => {
+    const matches = findUrlShapeMatches(pgUrl('user', 'pw', 'host/db', 'postgres'));
+    expect(matches).toHaveLength(1);
+    expect(matches[0].passwordSlot).toBe('pw');
+  });
+
+  it('does not match a URL with no password slot', () => {
+    expect(findUrlShapeMatches('postgresql://host:5432/db')).toHaveLength(0);
+  });
+
+  it('does not match plain prose mentioning "postgres" without a URL shape', () => {
+    expect(findUrlShapeMatches('We migrated postgres to the pooler last year.')).toHaveLength(0);
+  });
+
+  it('extracts the user:password separator, not the scheme "://" colon', () => {
+    const matches = findUrlShapeMatches(pgUrl('postgres.dedlbzhpgkmetvhbkyzq', 'Fake123', 'aws-1.pooler.supabase.com:5432/postgres'));
+    expect(matches[0].passwordSlot).toBe('Fake123');
+  });
+
+  it('URL_SHAPE_RE source contains no literal "://" run (self-exclusion by construction)', () => {
+    expect(URL_SHAPE_RE.source.includes('://')).toBe(false);
+  });
+});
+
+describe('isAllowlistedValue: the 6 documented marker families', () => {
+  it.each([
+    ['angle-bracket-marker', '<URL_ENCODED_PASSWORD>'],
+    ['square-bracket-marker', '[PASSWORD]'],
+    ['your-my-convention', 'YOUR_PASSWORD'],
+    ['env-var-reference (${...})', '${SUPABASE_DB_PASSWORD}'],
+    ['env-var-reference ($VAR)', '$SUPABASE_DB_PASSWORD'],
+    ['redaction-mask (***)', '****'],
+    ['redaction-mask (REDACTED)', 'REDACTED'],
+    ['bare-marker-word', 'PASSWORD'],
+  ])('recognizes %s: %s', (_label, value) => {
+    expect(isAllowlistedValue(value)).toBe(true);
+  });
+
+  it('does not allowlist an unwrapped fictional example password', () => {
+    expect(isAllowlistedValue('Pass!word!')).toBe(false);
+  });
+
+  it('does not allowlist an empty string', () => {
+    expect(isAllowlistedValue('')).toBe(false);
+  });
+
+  // Discovered via a live scan of this repo's full tracked tree (17.8k files), not guessed --
+  // ${encodeURIComponent(password)}-style expressions are live JS template-literal CODE
+  // interpolating a variable at runtime, never a literal credential. See scripts/lib/
+  // supabase-connection.js, src/services/pool-manager.js, and the scripts/archive/one-time/
+  // apply-*-migration.js family for real occurrences of this exact shape.
+  it.each([
+    '${encodeURIComponent(password)}',
+    '${process.env.SUPABASE_DB_PASSWORD}',
+    '${password}',
+  ])('recognizes a JS template-literal expression as code, not a value: %s', (value) => {
+    expect(isAllowlistedValue(value)).toBe(true);
+  });
+});
+
+describe('isAllowlistedPath / isSelfPath', () => {
+  it('recognizes a PATH_ALLOWLIST entry', () => {
+    expect(isAllowlistedPath('docs/guides/supabase-connectivity.md')).toBe(true);
+  });
+
+  it('does not allowlist an arbitrary path', () => {
+    expect(isAllowlistedPath('scripts/some-other-file.mjs')).toBe(false);
+  });
+
+  // Discovered via the same live scan: the scanner definition file and every *.test.* / tests/
+  // path are legitimate assertion-A exemptions (assertion B still covers them -- see the
+  // evaluateFiles test below proving the pattern-based tests/ exemption does NOT suppress B).
+  it.each([
+    '.husky/pre-commit',
+    'CONTRIBUTING.md',
+    'database/migrations/EXECUTION-GUIDE.md',
+    'docs/reference/session-summary-feature.md',
+    'tests/e2e/session-summary.test.js',
+    'tests/unit/checkin/resume-final-reads-holds.test.js',
+    'scripts/worker-signal.test.js',
+  ])('allowlists %s (exact path or tests/*.test.* pattern)', (path) => {
+    expect(isAllowlistedPath(path)).toBe(true);
+  });
+
+  it('recognizes the guard file and its own test as self-paths', () => {
+    expect(isSelfPath('scripts/lint/no-connection-string-literals-lint.mjs')).toBe(true);
+    expect(isSelfPath('tests/unit/hygiene/no-connection-string-literals.test.js')).toBe(true);
+  });
+});
+
+describe('findHashMatches: assertion B sliding-window hash detection (synthetic fixtures)', () => {
+  const fixture = 'Zq9!fakeSecret1'; // 15 chars, throwaway, never the real credential
+  const testHashes = [{ length: fixture.length, sha256: sha256(fixture), note: 'synthetic-fixture' }];
+
+  it('finds the fixture value embedded inside a longer line', () => {
+    const hits = findHashMatches(`SUPABASE_DB_PASSWORD=${fixture}`, testHashes);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].note).toBe('synthetic-fixture');
+  });
+
+  it('finds the fixture value when it IS the whole line', () => {
+    expect(findHashMatches(fixture, testHashes)).toHaveLength(1);
+  });
+
+  it('does not match a different string of the identical length', () => {
+    const decoy = 'Zq9!fakeSecret2'; // same length, last char differs
+    expect(decoy).toHaveLength(fixture.length);
+    expect(findHashMatches(decoy, testHashes)).toHaveLength(0);
+  });
+
+  it('never matches a line shorter than the window length', () => {
+    expect(findHashMatches(fixture.slice(0, -1), testHashes)).toHaveLength(0);
+  });
+
+  it('finds multiple independent hash families in the same line', () => {
+    const other = 'AnotherFake99'; // 13 chars
+    const multiHashes = [...testHashes, { length: other.length, sha256: sha256(other), note: 'second-fixture' }];
+    const hits = findHashMatches(`${fixture} and ${other}`, multiHashes);
+    expect(hits.map((h) => h.note).sort()).toEqual(['second-fixture', 'synthetic-fixture']);
+  });
+});
+
+describe('evaluateFiles: end-to-end, both assertions, allowlist interplay', () => {
+  const fixture = 'Zq9!fakeSecret1';
+  const testHashes = [{ length: fixture.length, sha256: sha256(fixture), note: 'synthetic-fixture' }];
+
+  it('flags a plain assertion-A violation in an ordinary tracked file', () => {
+    const files = [{ path: 'scripts/example.mjs', content: `const url = '${pgUrl('u', 'realsecretvalue', 'host/db')}';` }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].assertion).toBe('A');
+  });
+
+  it('suppresses assertion A when the password slot is an allowlisted marker', () => {
+    const files = [{ path: 'scripts/example.mjs', content: `const url = '${pgUrl('u', '[PASSWORD]', 'host/db')}';` }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(true);
+  });
+
+  it('suppresses assertion A for a PATH_ALLOWLIST file even with a non-marker password slot', () => {
+    const files = [{
+      path: 'docs/guides/supabase-connectivity.md',
+      content: `psql '${pgUrl('postgres.ref', 'Pass!word!', 'host/db')}'`,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(true);
+  });
+
+  it('suppresses assertion A for a pattern-matched test file (tests/ dir), non-marker password slot', () => {
+    const files = [{
+      path: 'tests/unit/example.test.js',
+      content: `const conn = '${pgUrl('admin', 's3cr3t', 'host/db')}';`,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(true);
+  });
+
+  it('does NOT suppress assertion B inside a pattern-matched test file either', () => {
+    const files = [{ path: 'tests/unit/example.test.js', content: fixture }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].assertion).toBe('B');
+  });
+
+  it('does NOT suppress assertion B inside a PATH_ALLOWLIST file (path-allowlist narrows A only)', () => {
+    const files = [{
+      path: 'docs/guides/supabase-connectivity.md',
+      content: `some unrelated line\n${fixture}\nanother line`,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].assertion).toBe('B');
+    expect(result.violations[0].line).toBe(2);
+  });
+
+  it('suppresses BOTH assertions entirely for a self-path file', () => {
+    const files = [{
+      path: 'scripts/lint/no-connection-string-literals-lint.mjs',
+      content: `const url = '${pgUrl('u', 'realsecretvalue', 'host/db')}';\n${fixture}`,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(true);
+  });
+
+  it('skips a pathologically long line for both assertions (bounded-scan guard)', () => {
+    const longPadding = 'x'.repeat(5000);
+    const files = [{
+      path: 'scripts/example.mjs',
+      content: `${longPadding}${pgUrl('u', 'realsecretvalue', 'host/db')} ${fixture}`,
+    }];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports correct file/line across multiple files evaluated together', () => {
+    const files = [
+      { path: 'a.mjs', content: 'clean line one\nclean line two' },
+      { path: 'b.mjs', content: `clean\nconst url = '${pgUrl('u', 'realsecretvalue', 'host/db')}';` },
+    ];
+    const result = evaluateFiles(files, { hashes: testHashes });
+    expect(result.violations).toEqual([
+      { file: 'b.mjs', line: 2, assertion: 'A', detail: expect.stringContaining('postgresql://') },
+    ]);
+  });
+
+  it('reports zero violations for an all-clean file set', () => {
+    const files = [{ path: 'a.mjs', content: 'nothing to see here\nreally, nothing' }];
+    expect(evaluateFiles(files, { hashes: testHashes }).ok).toBe(true);
+  });
+});
+
+describe('SECRET_HASHES contract (real constant — shape only, never a satisfying value)', () => {
+  it('has exactly 2 entries (fails loudly if silently grown)', () => {
+    expect(SECRET_HASHES).toHaveLength(2);
+  });
+
+  it('every entry is a well-formed 64-hex-char sha256 digest with a positive integer length', () => {
+    for (const entry of SECRET_HASHES) {
+      expect(entry.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(Number.isInteger(entry.length)).toBe(true);
+      expect(entry.length).toBeGreaterThan(0);
+      expect(typeof entry.note).toBe('string');
+      expect(entry.note.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the two entries cover distinct lengths (the two known encodings)', () => {
+    const lengths = SECRET_HASHES.map((e) => e.length);
+    expect(new Set(lengths).size).toBe(lengths.length);
+  });
+});
+
+describe('VALUE_ALLOWLIST_PATTERNS / PATH_ALLOWLIST / SELF_PATHS contracts', () => {
+  it('has exactly 6 marker families', () => {
+    expect(VALUE_ALLOWLIST_PATTERNS).toHaveLength(6);
+  });
+
+  it('every marker family has a name and a RegExp', () => {
+    for (const entry of VALUE_ALLOWLIST_PATTERNS) {
+      expect(typeof entry.name).toBe('string');
+      expect(entry.re).toBeInstanceOf(RegExp);
+    }
+  });
+
+  it('every PATH_ALLOWLIST entry has a non-empty rationale', () => {
+    for (const entry of PATH_ALLOWLIST) {
+      expect(entry.rationale.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('SELF_PATHS contains exactly the guard file and its own test', () => {
+    expect(SELF_PATHS.size).toBe(2);
+  });
+});

--- a/tests/unit/quarantine-manifest.test.js
+++ b/tests/unit/quarantine-manifest.test.js
@@ -92,4 +92,18 @@ describe('quarantine-manifest shape (debt register integrity)', () => {
   it('this test file itself is not quarantined (self-hosting guard)', () => {
     expect(manifest.quarantined.some(e => e.file.includes('quarantine-manifest.test.js'))).toBe(false);
   });
+
+  it('SD-LEO-FIX-STRIP-DEAD-DB-CREDENTIAL-LITERALS-001 guard + its test are never quarantined', () => {
+    // FR-5: the anti-quarantine self-check must live in a permanently-unquarantined host file
+    // (this one), not embedded in the guard itself -- vitest.config.js excludes
+    // quarantine-manifest-listed files from the unit project BEFORE loading, so a self-check
+    // embedded in a quarantinable file can never fire once quarantined.
+    const guardFiles = [
+      'scripts/lint/no-connection-string-literals-lint.mjs',
+      'tests/unit/hygiene/no-connection-string-literals.test.js',
+    ];
+    for (const f of guardFiles) {
+      expect(manifest.quarantined.some(e => e.file.includes(f))).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

PR 2 of 2 for SD-LEO-FIX-STRIP-DEAD-DB-CREDENTIAL-LITERALS-001. PR 1 (#7055, merged) removed the 3 dead scripts and redacted the 2 live docs carrying the incident's credential literal. This PR adds the regression guard so the class of defect can't silently reappear.

- `scripts/lint/no-connection-string-literals-lint.mjs` — two independent assertions over every git-tracked file:
  - **Assertion A** (structural): a `postgres(ql)://` URL shape with a non-marker password slot. Mirrors `.husky/pre-commit`'s own scanner pattern.
  - **Assertion B** (content, the real backstop): the actual rotated credential from this incident, in either encoding, via a length-bounded sliding-window SHA-256 comparison — never a literal string match, so the guard's own source is self-exclusion-safe by construction. **Never path-exempted for any file**, including the guard's own test.
- Allowlists (10-entry path list + 6 value marker families) tuned against a **live scan of the full 17.8k-file tracked tree**.

### Adversarial review (deep tier, per `/ship`'s risk gate)

An independent security-focused review agent found 7 real issues, all fixed in a follow-up commit and re-verified against the full tree:

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| F1 | High | `evaluateFiles()` silently disabled assertion B (not just A) for self-paths — exactly where a maintainer is most likely to paste the real secret "to check the hash" | Self-exclusion now narrows assertion A only |
| F2 | High | CI `paths:` filter silently skipped 745+ files by type (`.json`, `.env.example`, `.tsx`, `.pem`, ...); not yet a required branch-protection check despite the "blocking" claim | Removed the path filter (runs on every PR + push to main); reworded the claim; required-check registration flagged as a separate admin follow-up |
| F3 | Medium | Oversized files/lines silently skipped, no logging | Skip counts + paths now logged; assertion B bounded per-token (not per-line) so ordinary long lines are fully scanned |
| F4 | Medium-low | Password-slot extraction used the *last* colon before `@`, letting a real secret hide behind a trailing marker-shaped decoy; template-regex could span two `${...}` expressions with a secret sandwiched between | Switched to first-colon extraction; tightened regex to `[^{}]+` |
| F5 | Low | Marker-word allowlist was case-insensitive, exempting real lowercase weak credentials | Now case-sensitive (all-caps only) — surfaced 2 genuine pre-existing matches, verified as legitimate doc examples and allowlisted by path |
| F6 | Low | `git ls-files` (no `-z`) silently drops quoted special-char paths | Switched to `-z` |
| F7 | Low | Undocumented risk of hashing a still-live secret | Documented: rotated/dead values only |

Findings logged to `ship_review_findings` (PR #7060, tier=deep, verdict=pass).

### Perf note
An unbounded whole-line hash slide timed out past 3 minutes at repo scale; rewritten to scan within tokens only (~2m full-tree scan after all fixes, transparent skip-logging included).

**PR size note**: total diff exceeds the 400 LOC documented-justification ceiling in CLAUDE.md (new self-contained module, no existing callers, plus its comprehensive test suite — same shape as the `eol-renormalization-lint` precedent, scaled for 2 assertions + a 10-entry allowlist). The repo's LOC-threshold pre-commit hook auto-permitted this given the SD reference in the commit message.

## Test plan

- [x] `npx vitest run tests/unit/hygiene/no-connection-string-literals.test.js tests/unit/quarantine-manifest.test.js` — 68/68 passing
- [x] `node scripts/lint/no-connection-string-literals-lint.mjs` run live against the full tracked tree — 0 violations, all skips logged
- [x] Independent adversarial security review (deep tier) — all 7 findings fixed and re-verified
- [x] Pre-commit hooks (secret scanner, DB-test guard, smoke tests, LOC gate, workflow YAML lint) all passed locally on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)