### PR TITLE
fix(QF-20260728-720): negative tests for fields that measure something cheaper than their name asserts

### DIFF
--- a/docs/reference/field-name-is-a-claim.md
+++ b/docs/reference/field-name-is-a-claim.md
@@ -1,0 +1,75 @@
+---
+category: Reference
+status: Approved
+version: 1.0.0
+author: QF-20260728-720
+last_updated: 2026-08-15
+tags: [fleet-state, testing, reliability, observability]
+---
+
+# A Field's Name Is a Claim, and a Claim Needs a Negative Test
+
+**QF-20260728-720.** Six fleet-state fields were measured whose NAME asserts one thing
+and whose IMPLEMENTATION measures something cheaper that correlates with it under
+normal conditions — and **decouples exactly under the conditions the field was built
+to detect.** That is why several of these failed on the same evening rather than on
+an ordinary day: they are fine until something is wrong, which is the only time
+anyone reads them.
+
+## The class
+
+| Field | Name asserts | Implementation actually measures |
+|---|---|---|
+| `commits_since_claim` | this seat's work | repository-wide commits since `claimed_at` (`git log --since`, no `--author`, no branch restriction) — rises when *other* workers commit |
+| `acknowledged_at` | the message was answered | a stamp written on the **sender's own row**, which the sender never reads |
+| `last_tool_at` | progress | activity — advances on any tool call, so a seat re-checking its own blocked state satisfies it forever |
+| `loop_state='awaiting_tick'` | a wakeup is pending and will clear when it fires | a one-way latch cleared ONLY by the `SessionStart` hook — a wakeup firing inside an already-running session produces no `SessionStart` and never clears it |
+| `delivered_at` | the SMS reached the handset | when a reconciler sweep happened to run — with delivery callbacks disabled, observed sent→delivered lag ranged from 906s to 42,362s (11.8h) |
+| `loop_state='exited'` | the worker's loop ended (a worker-side decision) | the sweep released this session during a cycle — conflates "coordinator released me" with "I deliberately wound down"; today nothing writes the deliberate-exit case at all |
+
+## The executable form
+
+The first formulation — *"what would this field read if the thing it names were
+FALSE?"* — tests the **author's model**, not the field. An author who believes the
+thing works answers correctly under their own model and ships. It only fires for
+someone who already suspects the divergence, which is the population that doesn't
+need it.
+
+**The replacement: construct the false state and assert the field does not claim
+truth.** One test per field:
+
+| Field | Negative test recipe | Status |
+|---|---|---|
+| `commits_since_claim` | Freeze "this seat" (zero commits since claiming); have a *different* author commit in the same window; assert the field stays 0. | **Implemented**, `it.fails` (live defect — companion fix QF-20260728-430, open) — `tests/unit/hooks/post-tool-clear-telemetry-commits-since-claim-negative.test.js` |
+| `acknowledged_at` | Never answer a signal/message; assert `acknowledged_at` does not stamp on the row a reader would actually query. | Recipe only — deferred. The write-site survey for this QF did not converge on a single canonical "was my message answered" read/write pair within scope; several legitimate same-row claim-marker usages of `acknowledged_at` exist (e.g. `lib/coordinator/relay-queue.cjs` drain-claim, `lib/coordinator/signal-router.cjs` route-ack) that are NOT instances of this defect. Follow-up: identify the specific sender-row-vs-reader-row mismatch before writing the test, rather than testing the wrong site. |
+| `last_tool_at` | Have a seat re-check its own blocked state; assert the "progress" reading does not advance. | **Recipe only, by design** — the QF's own text: "this one likely requires renaming the field rather than testing it." `last_tool_at` accurately measures activity; the mismatch is the NAME implying progress, not a code defect. Rename is a separate, larger, cross-consumer change (many readers), out of scope here. |
+| `loop_state='awaiting_tick'` | Fire a wakeup inside an already-running session; assert `awaiting_tick` clears. | Investigated, not yet tested. Confirmed still live: `scripts/hooks/session-register.cjs`'s `SD-LEO-INFRA-LOOP-STATE-SIGNAL-001` block only clears `awaiting_tick` from the `SessionStart` hook path — unchanged in mechanism from the original finding. Companion fix tracked at QF-20260728-338 (status: escalated) and SD-LEO-INFRA-LOOP-STATE-AWAITING-001 (completed, but that SD addressed a different mechanism — verify before assuming it covers this). |
+| `delivered_at` | Disable delivery callbacks; send; assert `delivered_at` stays NULL (not "delivered early" via a stale reconciler read). | Recipe only — deferred. Requires mocking the Twilio/messaging-provider seam and the reconciler sweep together; the existing `sms_reply_matchable` work this session (SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001) touched an adjacent but distinct path (decision staging, not delivery-status reconciliation). |
+| `loop_state='exited'` | Have a worker end its loop WITHOUT the sweep releasing it; assert `loop_state` reads `'exited'`. Today nothing writes it on that path. | **Implemented**, structural census, passes today (honestly documents the gap) — `tests/unit/hooks/loop-state-exited-negative.test.js`. Asserts the ONLY write site repo-wide is the sweep's bulk release-update; a second writer appearing forces this test to be revisited. |
+
+## How to apply
+
+- **Never treat a name as a contract.** Read the writer before quoting the field.
+  Every row above was settled by reading the producing code, not by reasoning about
+  the schema or the column name.
+- **A missing value is not a negative result.** `delivered_at` reading NULL at 13
+  minutes is *below the observed minimum lag* and means nothing — measure the lag
+  distribution before treating an absence as a failure.
+- **A field with no negative test is a check that cannot fail, at the storage
+  layer.** A positive test ("after work happens, the field is non-empty") passes for
+  every field in this table and is what most of them have. Only the negative test
+  distinguishes a field that measures the named thing from one that merely
+  correlates with it under normal conditions.
+- **When a recipe is deferred, say why and where the ambiguity is** — "no test" and
+  "investigated, ambiguous, deferred with a specific open question" are different
+  states; only write the ledger to look like the former when it's actually the
+  latter.
+
+## Provenance
+
+Named after `delivered_at` made it five (2026-07-28); the executable form is a
+refutation-driven correction of the original introspective formulation. The sixth
+field (`loop_state='exited'`) was found live by a separate fleet seat the same
+evening, after three earlier candidates were rejected against this same test.
+Filed as QF-20260728-720; this document and its two implemented tests are that
+QF's "record the class" deliverable.

--- a/scripts/hooks/post-tool-clear-telemetry.cjs
+++ b/scripts/hooks/post-tool-clear-telemetry.cjs
@@ -23,7 +23,7 @@ const { resolveSessionId } = require('../../lib/hooks/session-id.cjs');
 const { drainAndExit } = require('../../lib/hooks/drain-undici.cjs'); // QF-20260719-890: drain before post-fetch exits
 
 // Never throw — the entire hook is wrapped.
-(async function main() {
+async function main() {
   try {
     // QF-20260504-765: stdin (Claude Code hook protocol) is canonical for
     // PostToolUse; env fallback covers manual node invocations and tests.
@@ -100,7 +100,14 @@ const { drainAndExit } = require('../../lib/hooks/drain-undici.cjs'); // QF-2026
       );
     }
   }
-})().then(() => drainAndExit(0)); // QF-20260509-199 exit kept; QF-20260719-890: drain first (post-fetch exit)
+}
+
+// QF-20260509-199 exit kept; QF-20260719-890: drain first (post-fetch exit).
+// require.main guard (QF-20260728-720): lets collectGitMetrics be required
+// for a negative test without triggering a live hook run as a side effect.
+if (require.main === module) {
+  main().then(() => drainAndExit(0));
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -226,3 +233,5 @@ async function fetchWithTimeout(url, init, timeoutMs) {
     clearTimeout(timer);
   }
 }
+
+module.exports = { collectGitMetrics };

--- a/scripts/hooks/post-tool-clear-telemetry.cjs
+++ b/scripts/hooks/post-tool-clear-telemetry.cjs
@@ -171,8 +171,16 @@ async function clearToolState(sessionId, nowMs) {
   });
 }
 
+// QF-20260728-720 (adversarial review): claimedAtIso is interpolated unescaped into
+// a shell command below. Every real caller (the DB-sourced claude_sessions.claimed_at
+// column, and this file's own tests) always passes a timestamp matching this shape, so
+// the check changes nothing for valid input — it only closes the reachable surface that
+// exporting collectGitMetrics widened, by fail-closed rejecting anything else BEFORE
+// it reaches execSync.
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
+
 function collectGitMetrics(worktreePath, claimedAtIso) {
-  if (!claimedAtIso) return null;
+  if (!claimedAtIso || !ISO_TIMESTAMP_RE.test(claimedAtIso)) return null;
   const cwd = worktreePath && isAbsolute(worktreePath) ? worktreePath : process.cwd();
   const opts = { cwd, timeout: 2000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] };
 

--- a/tests/unit/hooks/loop-state-exited-negative.test.js
+++ b/tests/unit/hooks/loop-state-exited-negative.test.js
@@ -24,7 +24,19 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 
 const SCAN_DIRS = ['scripts', 'lib'];
 const EXCLUDE_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive'];
-const WRITE_PATTERN = /loop_state\s*:\s*(LOOP_STATE_EXITED\b|['"]exited['"])/;
+const EXITED_VALUE = /LOOP_STATE_EXITED\b|['"]exited['"]/.source;
+// Two established write idioms in this codebase (confirmed via
+// scripts/hooks/post-tool-loop-state.cjs and scripts/hooks/stop-loop-wakeup-reminder.cjs,
+// both of which write LOOP_STATE_AWAITING_TICK via setLoopState(sessionId, ...)):
+//   1. object-literal:  .update({ loop_state: LOOP_STATE_EXITED })
+//   2. call-style:      setLoopState(sessionId, LOOP_STATE_EXITED)
+// A future writer that assigns the value to an intermediate variable before either
+// form (data-flow, not textual) would still slip past a regex census — that residual
+// gap is why the assertion below is a deliberate, human-reviewed equality check
+// rather than a "some site exists" boolean.
+const WRITE_PATTERN = new RegExp(
+  `loop_state\\s*:\\s*(${EXITED_VALUE})|setLoopState\\s*\\([^)]*,\\s*(${EXITED_VALUE})`
+);
 const EXCLUDE_FILE_RE = /\.test\.js$/i;
 
 function walk(dir, out) {

--- a/tests/unit/hooks/loop-state-exited-negative.test.js
+++ b/tests/unit/hooks/loop-state-exited-negative.test.js
@@ -1,0 +1,67 @@
+/**
+ * QF-20260728-720, 6th field: loop_state='exited' NAME asserts "the worker's loop
+ * ended" (a worker-side decision). The only programmatic writer today is the sweep's
+ * bulk release-update (scripts/stale-session-sweep.cjs), which fires on ANY session
+ * this cycle released — including one that simply got swept, not one that
+ * deliberately wound its own loop down. The two are opposite in agency and
+ * identical in storage.
+ *
+ * Negative test (the QF's own suggested form): "have a worker end its loop WITHOUT
+ * the sweep releasing it, and assert loop_state reads 'exited'. Today nothing
+ * writes it on that path." This is a structural census, not a runtime fixture,
+ * because there is currently no dedicated "I deliberately exited" writer to call —
+ * that absence IS the finding. If a second writer is ever added without addressing
+ * the semantic conflation (see docs/reference/field-name-is-a-claim.md), this test
+ * must be updated deliberately, not silently pass through.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+const SCAN_DIRS = ['scripts', 'lib'];
+const EXCLUDE_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive'];
+const WRITE_PATTERN = /loop_state\s*:\s*(LOOP_STATE_EXITED\b|['"]exited['"])/;
+const EXCLUDE_FILE_RE = /\.test\.js$/i;
+
+function walk(dir, out) {
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDE_SEGMENTS.includes(entry)) continue;
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (/\.(js|cjs|mjs)$/i.test(entry) && !EXCLUDE_FILE_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function findWriteSites() {
+  const files = [];
+  for (const dir of SCAN_DIRS) walk(path.join(REPO_ROOT, dir), files);
+  const sites = [];
+  for (const file of files) {
+    const content = readFileSync(file, 'utf8');
+    if (WRITE_PATTERN.test(content)) {
+      sites.push(path.relative(REPO_ROOT, file).replace(/\\/g, '/'));
+    }
+  }
+  return sites.sort();
+}
+
+describe("loop_state='exited' write-site census (QF-20260728-720)", () => {
+  it('is written ONLY by the sweep bulk-release path — no dedicated deliberate-self-exit writer exists', () => {
+    const sites = findWriteSites();
+
+    // Today's honest state: exactly the sweep. If this list grows, a human must
+    // decide whether the new writer distinguishes deliberate-exit from
+    // swept-release (the whole point of this field's negative test) — update
+    // this assertion deliberately, do not just add the new path to the array.
+    expect(sites).toEqual(['scripts/stale-session-sweep.cjs']);
+  });
+});

--- a/tests/unit/hooks/post-tool-clear-telemetry-commits-since-claim-negative.test.js
+++ b/tests/unit/hooks/post-tool-clear-telemetry-commits-since-claim-negative.test.js
@@ -1,0 +1,101 @@
+/**
+ * QF-20260728-720: commits_since_claim's NAME asserts "this seat's work"; the
+ * implementation (collectGitMetrics -> `git log --since=<claimed_at>`, no
+ * --author, no branch restriction) measures repository-wide commits instead.
+ *
+ * Negative test: construct the false state (this seat made ZERO commits since
+ * claiming, but ANOTHER author committed in the same window) and assert the
+ * field does not claim work this seat did not do. A field with no negative
+ * test is a check that cannot fail at the storage layer — see
+ * docs/reference/field-name-is-a-claim.md.
+ *
+ * A companion fix is tracked separately at QF-20260728-430 (open as of this
+ * writing) — this test is expected to FAIL until that fix lands, and is the
+ * regression pin that proves it when it does.
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { collectGitMetrics } from '../../../scripts/hooks/post-tool-clear-telemetry.cjs';
+
+let tmpDir;
+
+afterEach(() => {
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  }
+});
+
+// Git commit dates have 1-second granularity. Rather than relying on real
+// wall-clock gaps (slow, flaky), commits are stamped with explicit
+// GIT_AUTHOR_DATE/GIT_COMMITTER_DATE far apart so `--since` boundaries are
+// unambiguous regardless of how fast the test itself runs.
+const BASELINE_DATE = '2020-01-01T00:00:00Z';
+const CLAIMED_AT = '2020-01-01T00:10:00Z';
+const AFTER_CLAIM_DATE = '2020-01-01T00:20:00Z';
+
+function commitAt({ cwd, dateIso, email, name, file, message }) {
+  fs.writeFileSync(path.join(cwd, file), `${message}\n`);
+  execSync(`git add ${file}`, { cwd });
+  execSync(
+    `git -c user.email=${email} -c user.name="${name}" commit -q -m "${message}"`,
+    {
+      cwd,
+      env: { ...process.env, GIT_AUTHOR_DATE: dateIso, GIT_COMMITTER_DATE: dateIso },
+    }
+  );
+}
+
+function makeTempRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf720-commits-'));
+  execSync('git init -q', { cwd: dir });
+  commitAt({
+    cwd: dir, dateIso: BASELINE_DATE, email: 'seat@example.com', name: 'This Seat',
+    file: 'baseline.txt', message: 'baseline',
+  });
+  return dir;
+}
+
+describe('commits_since_claim negative test (QF-20260728-720)', () => {
+  // it.fails: this pins a LIVE, currently-true defect (companion fix tracked
+  // at QF-20260728-430, open). Under it.fails, vitest reports GREEN while the
+  // assertion inside keeps failing (the honest state today) and reports RED
+  // the moment it starts passing — i.e. this test alerts, rather than stays
+  // silently green, the moment someone fixes the field. Do not "fix" this
+  // test by weakening the assertion; when QF-20260728-430 lands, convert
+  // this to a plain `it` instead.
+  it.fails('reads 0 when THIS SEAT made no commits since claiming, even though another author committed in the window', () => {
+    tmpDir = makeTempRepo();
+
+    // Simulate a DIFFERENT worker landing a commit in the SAME repo/branch
+    // window, after claimed_at — this is work the current seat did not do.
+    commitAt({
+      cwd: tmpDir, dateIso: AFTER_CLAIM_DATE, email: 'other@example.com', name: 'Other Worker',
+      file: 'other-worker.txt', message: 'other worker commit',
+    });
+
+    const metrics = collectGitMetrics(tmpDir, CLAIMED_AT);
+
+    // TRUE state: this seat's own commit count since claiming is 0.
+    // collectGitMetrics has no --author filter, so it currently reports the
+    // OTHER worker's commit as if it were this seat's — the false claim the
+    // field's name makes. This assertion documents the honest value and is
+    // expected to fail until QF-20260728-430 adds author scoping.
+    expect(metrics.commits).toBe(0);
+  });
+
+  it('correctly reads 1 when this seat itself is the sole committer since claiming (sanity check, should pass today)', () => {
+    tmpDir = makeTempRepo();
+
+    commitAt({
+      cwd: tmpDir, dateIso: AFTER_CLAIM_DATE, email: 'seat@example.com', name: 'This Seat',
+      file: 'this-seat.txt', message: 'this seat commit',
+    });
+
+    const metrics = collectGitMetrics(tmpDir, CLAIMED_AT);
+    expect(metrics.commits).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Six fleet-state fields' NAMEs assert one thing while their implementation measures something cheaper that correlates under normal conditions and decouples exactly when the field matters. Records the class in `docs/reference/field-name-is-a-claim.md` with an exact negative-test recipe per field.
- Implements 2 negative tests concretely:
  - `commits_since_claim`: `it.fails` test proving the live defect (repo-wide `git log`, no `--author` filter) — companion re-implementation fix tracked separately at QF-20260728-430 (open). Requires a `require.main` guard on `post-tool-clear-telemetry.cjs` so `collectGitMetrics` is importable for testing without triggering a live hook run — zero behavior change when invoked as a script.
  - `loop_state='exited'`: structural census proving no dedicated deliberate-self-exit writer exists repo-wide — only the sweep's bulk release path writes this value today.
- The remaining 4 fields (`acknowledged_at`, `last_tool_at`, `loop_state='awaiting_tick'`, `delivered_at`) are documented with their exact recipe and current investigation status rather than rushed into an incorrect fixture for a live, async, multi-subsystem mechanism — see the doc's status table for the specific open question on each.

## Test plan
- [x] `npx vitest run tests/unit/hooks/post-tool-clear-telemetry-commits-since-claim-negative.test.js` — 1 passed, 1 expected-fail (by design)
- [x] `npx vitest run tests/unit/hooks/loop-state-exited-negative.test.js` — passes
- [x] `npx vitest run scripts/hooks/__tests__/post-tool-clear-telemetry.test.js tests/unit/hooks/post-tool-telemetry-degraded-reason.test.js tests/unit/fleet/claim-boundary-probe.test.js tests/unit/hooks/stop-loop-park-recoverable.test.js` — all green (no regressions from the `require.main` guard)
- [x] `npx eslint` clean on all touched/new files
- [x] Broader `tests/unit/hooks/ scripts/hooks/__tests__/ tests/unit/fleet/` sweep: 2461 passed, 1 expected-fail, 2 unrelated timing-test failures under heavy concurrent-session load (signaled separately as harness-bug `59bb1d9c`, not caused by this change — confirmed via a clean re-run under the same load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)