### PR TITLE
FR-1/FR-2: parent_completion orchestration (claim -> verify/regen retro -> LEAD-FINAL-APPROVAL -> release)

### DIFF
--- a/lib/fleet/parent-completion.mjs
+++ b/lib/fleet/parent-completion.mjs
@@ -1,0 +1,202 @@
+/**
+ * parent_completion orchestration core -- SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-1/FR-2).
+ *
+ * Pure(ish) orchestration logic, decoupled from the CLI wrapper (scripts/run-parent-completion.mjs)
+ * so it is unit-testable with injected dependencies -- mirrors claimOrchestratorForRollup's own
+ * "core logic decoupled from CLI" shape.
+ *
+ * MUST be executed by a fleet-worker seat, never the coordinator: GATE_CLAIM_VALIDITY's
+ * non_fleet_build_forbidden check correctly refuses a non-fleet-build session (measured live,
+ * 2026-08-15T21:53Z) -- this module does not attempt to work around that, by design.
+ *
+ * Steps:
+ *   (a) claim the orchestrator parent via claimOrchestratorForRollup (existing, unmodified helper)
+ *   (b) retrigger PLAN-TO-LEAD ONLY when the latest handoff is status='blocked' AND
+ *       metadata.wait===true AND all children are terminal (checkParentCompletable already
+ *       confirmed this before this function is called) -- NEVER on 'rejected' or a real failure.
+ *       Skipped entirely if the latest PLAN-TO-LEAD is already 'accepted'.
+ *   (c) VERIFY the parent retrospective against RETROSPECTIVE_EXISTS's own selection-then-scoring
+ *       pair (getFilteredRetrospective, then validateSDCompletionReadiness on whatever it selects
+ *       -- TESTING finding TST-C1/TST-C2). If it would fail, this function CANNOT regenerate it
+ *       itself (retrospective content synthesis needs an LLM -- the sanctioned retro-agent
+ *       Task-tool invocation, which only a calling AGENT can make) -- it releases the claim and
+ *       reports status='staged_retro_quality' with needsRegeneration=true so the calling agent can
+ *       invoke retro-agent and re-run.
+ *   (d) release the claim, ALWAYS (finally) -- including on any failure at (b) or (c).
+ *
+ * IDEMPOTENCY: re-running after step (b) already succeeded (latest handoff now 'accepted') skips
+ * straight to (c) on the next call -- no duplicate PLAN-TO-LEAD row.
+ *
+ * STEP-(d)-FAILURE REPORTING: if the release itself fails, this is reported as a distinct
+ * STRANDED_CLAIM condition, never silently swallowed and never conflated with FR-5's planning-
+ * outcome vocabulary (it is an operational hazard, not a planning outcome).
+ */
+
+import { claimOrchestratorForRollup } from '../../scripts/claim-orchestrator-for-rollup.mjs';
+import { checkParentCompletable } from './orchestrator-completion.cjs';
+
+export const STATUS = {
+  COMPLETED: 'completed',
+  STAGED_RETRO_QUALITY: 'staged_retro_quality',
+  STAGED_OTHER_GATE: 'staged_other_gate',
+  NOT_READY: 'not_ready',
+};
+
+/**
+ * Default handoff runner: shells out to the real, sanctioned, unmodified handoff.js CLI.
+ * Injectable so tests never spawn a real subprocess (TESTING finding: "the one missing seam").
+ * @returns {Promise<{pass: boolean, score: number|null, reason: string|null, raw: string}>}
+ */
+export async function defaultRunHandoff(phase, sdKey) {
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFile);
+  let stdout = '';
+  let code = 0;
+  try {
+    const r = await execFileAsync('node', ['scripts/handoff.js', 'execute', phase, sdKey], { maxBuffer: 10 * 1024 * 1024 });
+    stdout = r.stdout || '';
+  } catch (e) {
+    // execFile rejects on non-zero exit -- handoff.js exits 1 on FAIL, which is an expected outcome
+    // here, not a thrown error condition. Still capture stdout for parsing.
+    stdout = (e.stdout || '') + (e.stderr || '');
+    code = typeof e.code === 'number' ? e.code : 1;
+  }
+  const resultLine = stdout.match(/HANDOFF_RESULT=(PASS|FAIL)\s+SD=\S+\s+SCORE=(\d+)\s+PHASE=\S+(?:\s+REASON=(\S+))?/);
+  if (resultLine) {
+    return { pass: resultLine[1] === 'PASS', score: Number(resultLine[2]), reason: resultLine[3] || null, raw: stdout };
+  }
+  // No parseable result line -- treat as a failure, never assume pass on ambiguous output.
+  return { pass: false, score: null, reason: code === 0 ? 'UNPARSEABLE_HANDOFF_OUTPUT' : 'HANDOFF_PROCESS_ERROR', raw: stdout };
+}
+
+async function getLatestPlanToLead(supabase, parent) {
+  const keys = [parent.id, parent.sd_key].filter(Boolean);
+  const orClause = keys.map((k) => `sd_id.eq.${k}`).join(',');
+  const { data, error } = await supabase
+    .from('sd_phase_handoffs')
+    .select('id, status, metadata, created_at, accepted_at, created_by')
+    .or(orClause)
+    .eq('handoff_type', 'PLAN-TO-LEAD')
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(`PLAN-TO-LEAD handoff lookup failed: ${error.message}`);
+  return (data && data[0]) || null;
+}
+
+/**
+ * @param {object} deps
+ * @param {object} deps.supabase
+ * @param {string} deps.sessionId
+ * @param {string} deps.parentKey - orchestrator parent sd_key or uuid
+ * @param {(phase: string, sdKey: string) => Promise<{pass: boolean, score: number|null, reason: string|null}>} [deps.runHandoff]
+ * @param {(sdUuid: string, sdCreatedAt: string|null, supabase: object, sdKey: string|null) => Promise<{retrospective: object|null, error: object|null}>} deps.getFilteredRetrospective
+ * @param {(sd: object, retrospective: object|null) => Promise<{passed: boolean, score: number}>} deps.validateSDCompletionReadiness
+ * @returns {Promise<{status: string, message: string, needsRegeneration?: boolean, handoffId?: string, blockedGate?: string, strandedClaim?: boolean}>}
+ */
+export async function runParentCompletion(deps) {
+  const {
+    supabase, sessionId, parentKey,
+    runHandoff = defaultRunHandoff,
+    getFilteredRetrospective,
+    validateSDCompletionReadiness,
+  } = deps;
+
+  const { data: parent, error: parentErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, status, created_at, metadata')
+    .eq(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(parentKey) ? 'id' : 'sd_key', parentKey)
+    .maybeSingle();
+  if (parentErr || !parent) {
+    return { status: STATUS.NOT_READY, message: `Could not load parent ${parentKey}: ${parentErr?.message || 'not found'}` };
+  }
+
+  const completable = await checkParentCompletable(supabase, parent);
+  if (completable.couldNotCheck) {
+    return { status: STATUS.NOT_READY, message: `Eligibility could not be verified (${completable.reason}) -- refusing rather than assuming ready.` };
+  }
+  if (!completable.completable) {
+    return { status: STATUS.NOT_READY, message: `Not yet completable: ${completable.reason}` };
+  }
+
+  const claim = await claimOrchestratorForRollup(supabase, { sdKey: parent.sd_key, sessionId });
+  if (!claim.ok) {
+    return { status: STATUS.NOT_READY, message: `Could not claim ${parent.sd_key}: ${claim.reason}` };
+  }
+
+  let result;
+  try {
+    result = await runSteps();
+    return result;
+  } finally {
+    const release = await claimOrchestratorForRollup(supabase, { sdKey: parent.sd_key, sessionId, release: true });
+    if (!release.ok) {
+      // Never silently swallowed -- an operational hazard distinct from any planning outcome above.
+      // Augments whatever result was already computed (or produces one, if runSteps itself threw)
+      // rather than replacing it, so a STRANDED_CLAIM is always visible in the RETURNED result, not
+      // only in a log line a caller may not be reading.
+      console.error(`STRANDED_CLAIM: failed to release ${parent.sd_key}: ${release.reason}`);
+      if (result) {
+        result.strandedClaim = true;
+        result.strandedClaimReason = release.reason;
+      }
+    }
+  }
+
+  async function runSteps() {
+    // Step (b): narrow, explicit PLAN-TO-LEAD retrigger eligibility.
+    let latestP2L;
+    try {
+      latestP2L = await getLatestPlanToLead(supabase, parent);
+    } catch (e) {
+      return { status: STATUS.NOT_READY, message: e.message };
+    }
+
+    if (latestP2L && latestP2L.status === 'accepted') {
+      // Already accepted (e.g. -H's shape) -- skip step (b) entirely, proceed to (c).
+    } else if (!latestP2L) {
+      // No PLAN-TO-LEAD yet at all -- a first attempt, fine to trigger.
+      const p2l = await runHandoff('PLAN-TO-LEAD', parent.sd_key);
+      if (!p2l.pass) {
+        return { status: STATUS.STAGED_OTHER_GATE, message: `PLAN-TO-LEAD did not pass on first attempt: ${p2l.reason || 'unknown reason'}`, blockedGate: p2l.reason || 'PLAN-TO-LEAD' };
+      }
+    } else if (latestP2L.status === 'blocked' && latestP2L.metadata?.wait === true) {
+      // The WAIT discriminator -- the only condition under which a non-accepted handoff is retried.
+      const p2l = await runHandoff('PLAN-TO-LEAD', parent.sd_key);
+      if (!p2l.pass) {
+        return { status: STATUS.STAGED_OTHER_GATE, message: `PLAN-TO-LEAD retrigger did not pass: ${p2l.reason || 'unknown reason'}`, blockedGate: p2l.reason || 'PLAN-TO-LEAD' };
+      }
+    } else {
+      // 'rejected', or a real 'blocked' without metadata.wait=true -- NEVER retriggered (TS-2b).
+      return {
+        status: STATUS.STAGED_OTHER_GATE,
+        message: `PLAN-TO-LEAD is '${latestP2L.status}' without the WAIT discriminator -- not retriggered; requires manual remediation.`,
+        blockedGate: 'PLAN-TO-LEAD',
+      };
+    }
+
+    // Step (c): verify-then-execute. Uses the gate's OWN selection-then-scoring pair, not a
+    // re-derived heuristic (TST-C1/TST-C2).
+    const { retrospective } = await getFilteredRetrospective(parent.id, parent.created_at || null, supabase, parent.sd_key || null);
+    const readiness = await validateSDCompletionReadiness(parent, retrospective);
+    if (!readiness.passed) {
+      return {
+        status: STATUS.STAGED_RETRO_QUALITY,
+        needsRegeneration: true,
+        message: `Retrospective would not pass RETROSPECTIVE_EXISTS (score ${readiness.score ?? 'n/a'}, need >=60) -- regenerate via the sanctioned retro-agent path (Task tool, subagent_type=retro-agent) with real content from the children's PRD/handoffs, then re-run parent_completion for ${parent.sd_key}.`,
+      };
+    }
+
+    const lfa = await runHandoff('LEAD-FINAL-APPROVAL', parent.sd_key);
+    if (lfa.pass) {
+      return { status: STATUS.COMPLETED, message: `${parent.sd_key}: completed (LEAD-FINAL-APPROVAL accepted, score ${lfa.score}).` };
+    }
+    // A retrospective-specific failure post-regeneration is still possible (readiness passed our
+    // own check but the live gate re-evaluates independently) -- report it under the SAME
+    // retro-quality status rather than the generic staged_other_gate, per FR-5's vocabulary.
+    if (lfa.reason === 'RETROSPECTIVE_EXISTS_FAILED' || lfa.reason === 'RETROSPECTIVE_EXISTS') {
+      return { status: STATUS.STAGED_RETRO_QUALITY, needsRegeneration: true, message: `LEAD-FINAL-APPROVAL still failed RETROSPECTIVE_EXISTS after regeneration (score ${lfa.score ?? 'n/a'}).` };
+    }
+    return { status: STATUS.STAGED_OTHER_GATE, message: `${parent.sd_key}: staged_other_gate (${lfa.reason || 'unknown gate'}).`, blockedGate: lfa.reason || 'unknown' };
+  }
+}

--- a/lib/fleet/parent-completion.test.js
+++ b/lib/fleet/parent-completion.test.js
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../scripts/claim-orchestrator-for-rollup.mjs', () => ({
+  claimOrchestratorForRollup: vi.fn(),
+}));
+
+const { claimOrchestratorForRollup } = await import('../../scripts/claim-orchestrator-for-rollup.mjs');
+const { runParentCompletion, STATUS } = await import('./parent-completion.mjs');
+
+beforeEach(() => {
+  claimOrchestratorForRollup.mockReset();
+});
+
+const PARENT_ID = 'parent-uuid-1';
+const PARENT_KEY = 'SD-ORCH-PARENT-001';
+
+function stubSupabase({ parentRow, childrenRows = [], handoffRows = [], p2lRows = [] }) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: (col) => ({
+              maybeSingle: () => Promise.resolve({ data: parentRow, error: null }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+// checkParentCompletable and getLatestPlanToLead both query strategic_directives_v2 /
+// sd_phase_handoffs with different .eq() chains -- a richer stub distinguishing them by column.
+function fullStub({ parentRow, childrenRows = [], lfaHandoffRows = [], p2lHandoffRows = [] }) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: (col) => {
+              if (col === 'sd_key' || col === 'id') {
+                return {
+                  maybeSingle: () => Promise.resolve({ data: parentRow, error: null }),
+                  // checkParentCompletable's children query also calls .eq('parent_sd_id', ...)
+                  // but reuses this same shape via a second .eq call in a chained object below.
+                };
+              }
+              if (col === 'parent_sd_id') return Promise.resolve({ data: childrenRows, error: null });
+              throw new Error(`unexpected eq column: ${col}`);
+            },
+          }),
+        };
+      }
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: () => ({
+            or: () => ({
+              // checkParentCompletable awaits .eq().order() directly (no .limit());
+              // getLatestPlanToLead chains .eq().order().limit(1). Real supabase-js's query
+              // builder is a thenable that also exposes further chain methods -- .order()'s
+              // return value here must be BOTH awaitable AND carry a .limit() method, not a
+              // bare Promise (a bare Promise has no .limit and throws when chained).
+              eq: (_col, val) => {
+                const rows = val === 'LEAD-FINAL-APPROVAL' ? lfaHandoffRows : p2lHandoffRows;
+                return {
+                  order: () => {
+                    const p = Promise.resolve({ data: rows, error: null });
+                    p.limit = () => Promise.resolve({ data: rows.slice(0, 1), error: null });
+                    return p;
+                  },
+                };
+              },
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+// NOTE: checkParentCompletable's children lookup and parent-completion.mjs's own parent lookup
+// BOTH call .eq() on strategic_directives_v2 but with different columns (sd_key/id vs
+// parent_sd_id) -- the fullStub above distinguishes by column name, and getLatestPlanToLead's
+// .order().limit() chain is distinguished by which handoff_type value was filtered on.
+function baseDeps(overrides = {}) {
+  return {
+    sessionId: 'worker-1',
+    parentKey: PARENT_KEY,
+    getFilteredRetrospective: vi.fn(async () => ({ retrospective: { id: 'retro-1' }, error: null })),
+    validateSDCompletionReadiness: vi.fn(async () => ({ passed: true, score: 90 })),
+    runHandoff: vi.fn(async () => ({ pass: true, score: 95, reason: null })),
+    ...overrides,
+  };
+}
+
+describe('runParentCompletion', () => {
+  it('TS-1: eligible parent (P2L already accepted, retro passes) claims, skips retrigger, executes LEAD-FINAL-APPROVAL, releases, reports completed', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      lfaHandoffRows: [],
+      p2lHandoffRows: [{ id: 'h1', status: 'accepted', metadata: {}, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const result = await runParentCompletion({ ...baseDeps(), supabase });
+    expect(result.status).toBe(STATUS.COMPLETED);
+    expect(claimOrchestratorForRollup).toHaveBeenCalledTimes(2);
+    expect(claimOrchestratorForRollup).toHaveBeenNthCalledWith(2, supabase, expect.objectContaining({ release: true }));
+  });
+
+  it('retriggers PLAN-TO-LEAD when status=blocked AND metadata.wait=true, then proceeds', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'blocked', metadata: { wait: true }, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const deps = baseDeps();
+    const result = await runParentCompletion({ ...deps, supabase });
+    expect(result.status).toBe(STATUS.COMPLETED);
+    expect(deps.runHandoff).toHaveBeenCalledWith('PLAN-TO-LEAD', PARENT_KEY);
+    expect(deps.runHandoff).toHaveBeenCalledWith('LEAD-FINAL-APPROVAL', PARENT_KEY);
+  });
+
+  it('TS-2b: NEVER retriggers when latest PLAN-TO-LEAD is rejected -- reports staged_other_gate, releases', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'rejected', metadata: {}, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const deps = baseDeps();
+    const result = await runParentCompletion({ ...deps, supabase });
+    expect(result.status).toBe(STATUS.STAGED_OTHER_GATE);
+    expect(deps.runHandoff).not.toHaveBeenCalledWith('PLAN-TO-LEAD', PARENT_KEY);
+    expect(claimOrchestratorForRollup).toHaveBeenCalledTimes(2); // still claimed then released
+  });
+
+  it('a real blocked handoff WITHOUT metadata.wait=true is also never retriggered (only the WAIT discriminator qualifies)', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'blocked', metadata: {}, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const deps = baseDeps();
+    const result = await runParentCompletion({ ...deps, supabase });
+    expect(result.status).toBe(STATUS.STAGED_OTHER_GATE);
+    expect(deps.runHandoff).not.toHaveBeenCalledWith('PLAN-TO-LEAD', PARENT_KEY);
+  });
+
+  it('FR-2: retro would fail -- reports staged_retro_quality + needsRegeneration, releases the claim (does not hold it across regeneration)', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'accepted', metadata: {}, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const deps = baseDeps({ validateSDCompletionReadiness: vi.fn(async () => ({ passed: false, score: 21 })) });
+    const result = await runParentCompletion({ ...deps, supabase });
+    expect(result.status).toBe(STATUS.STAGED_RETRO_QUALITY);
+    expect(result.needsRegeneration).toBe(true);
+    expect(deps.runHandoff).not.toHaveBeenCalledWith('LEAD-FINAL-APPROVAL', PARENT_KEY);
+    expect(claimOrchestratorForRollup).toHaveBeenCalledTimes(2);
+  });
+
+  it('TS-2c idempotency: re-running after regeneration (P2L now accepted) skips step (b) and does not create a duplicate PLAN-TO-LEAD row', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'accepted', metadata: {}, created_at: '2026-01-01T01:00:00Z' }], // simulates the SAME accepted row from a prior run
+    });
+    const deps = baseDeps(); // this time retro passes
+    const result = await runParentCompletion({ ...deps, supabase });
+    expect(result.status).toBe(STATUS.COMPLETED);
+    expect(deps.runHandoff).not.toHaveBeenCalledWith('PLAN-TO-LEAD', PARENT_KEY); // no duplicate P2L attempt
+  });
+
+  it('releases the claim even when LEAD-FINAL-APPROVAL fails on an unrelated gate (staged_other_gate)', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'released', sdKey: PARENT_KEY });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'accepted', metadata: {}, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const deps = baseDeps({ runHandoff: vi.fn(async (phase) => (phase === 'LEAD-FINAL-APPROVAL' ? { pass: false, score: 40, reason: 'CHAIRMAN_APPLY_VERIFICATION' } : { pass: true, score: 100, reason: null })) });
+    const result = await runParentCompletion({ ...deps, supabase });
+    expect(result.status).toBe(STATUS.STAGED_OTHER_GATE);
+    expect(result.blockedGate).toBe('CHAIRMAN_APPLY_VERIFICATION');
+    expect(claimOrchestratorForRollup).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports strandedClaim=true (never silently swallowed) when the release itself fails', async () => {
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: true, action: 'claimed', sdKey: PARENT_KEY });
+    claimOrchestratorForRollup.mockResolvedValueOnce({ ok: false, action: 'refused', reason: 'claimed by a different live session' });
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      p2lHandoffRows: [{ id: 'h1', status: 'accepted', metadata: {}, created_at: '2026-01-01T01:00:00Z' }],
+    });
+    const result = await runParentCompletion({ ...baseDeps(), supabase });
+    expect(result.status).toBe(STATUS.COMPLETED); // the planning outcome itself still succeeded
+    expect(result.strandedClaim).toBe(true);
+    expect(result.strandedClaimReason).toBeTruthy();
+  });
+
+  it('not_ready, and no claim attempted at all, when a child is not yet terminal', async () => {
+    const supabase = fullStub({
+      parentRow: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} },
+      childrenRows: [{ id: 'c1', status: 'in_progress' }],
+    });
+    const result = await runParentCompletion({ ...baseDeps(), supabase });
+    expect(result.status).toBe(STATUS.NOT_READY);
+    expect(claimOrchestratorForRollup).not.toHaveBeenCalled();
+  });
+
+  it('not_ready (never fail-open) when completability itself could not be checked', async () => {
+    const throwingSupabase = {
+      from(table) {
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: () => ({
+              eq: (col) => {
+                if (col === 'sd_key') return { maybeSingle: () => Promise.resolve({ data: { id: PARENT_ID, sd_key: PARENT_KEY, status: 'pending_approval', created_at: '2026-01-01T00:00:00Z', metadata: {} }, error: null }) };
+                if (col === 'parent_sd_id') return Promise.resolve({ data: null, error: new Error('boom') });
+                throw new Error(`unexpected eq: ${col}`);
+              },
+            }),
+          };
+        }
+        throw new Error(`unexpected table: ${table}`);
+      },
+    };
+    const result = await runParentCompletion({ ...baseDeps(), supabase: throwingSupabase });
+    expect(result.status).toBe(STATUS.NOT_READY);
+    expect(claimOrchestratorForRollup).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/run-parent-completion.mjs
+++ b/scripts/run-parent-completion.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * parent_completion CLI -- SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-1/FR-2/FR-5).
+ *
+ * Thin wrapper around lib/fleet/parent-completion.mjs's runParentCompletion, wiring in the real
+ * Supabase client and the gate's own live retro-verification functions. MUST be run by a
+ * fleet-worker seat -- GATE_CLAIM_VALIDITY's non_fleet_build_forbidden check correctly refuses a
+ * non-fleet-build session at the LEAD-FINAL-APPROVAL handoff step regardless of what invokes this
+ * script (measured live, 2026-08-15T21:53Z).
+ *
+ * Reports FR-5's exact 4-value status vocabulary and, when needsRegeneration is true, tells the
+ * calling agent (a fleet worker, capable of Task-tool sub-agent invocation -- this script cannot
+ * synthesize retrospective content itself) to invoke retro-agent and re-run.
+ *
+ * Usage:
+ *   CLAUDE_SESSION_ID=<sid> node scripts/run-parent-completion.mjs <parent-sd-key> [--json]
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runParentCompletion, STATUS } from '../lib/fleet/parent-completion.mjs';
+import { getFilteredRetrospective } from './modules/handoff/retro-filters.js';
+import { validateSDCompletionReadiness } from './modules/sd-quality-validation.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const parentKey = args.find((a) => !a.startsWith('--'));
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+
+  if (!parentKey) {
+    console.error('Usage: node scripts/run-parent-completion.mjs <parent-sd-key> [--json]');
+    process.exit(1);
+  }
+  if (!sessionId) {
+    console.error('CLAUDE_SESSION_ID is required (this must be run by a fleet-worker seat).');
+    process.exit(1);
+  }
+
+  const { createSupabaseServiceClient } = await import('./lib/supabase-connection.js');
+  const supabase = await createSupabaseServiceClient('engineer');
+
+  const result = await runParentCompletion({
+    supabase,
+    sessionId,
+    parentKey,
+    getFilteredRetrospective,
+    validateSDCompletionReadiness,
+  });
+
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`[${result.status.toUpperCase()}] ${result.message}`);
+    if (result.needsRegeneration) {
+      console.log('');
+      console.log('  --- ACTION REQUIRED (this script cannot do this step itself) ---');
+      console.log('  Invoke retro-agent (Task tool, subagent_type="retro-agent") with real content');
+      console.log(`  from ${parentKey}'s children's PRD/handoffs -- never boilerplate.`);
+      console.log(`  Then re-run: node scripts/run-parent-completion.mjs ${parentKey}`);
+    }
+    if (result.strandedClaim) {
+      console.log('');
+      console.log(`  ⚠️  STRANDED_CLAIM: release failed (${result.strandedClaimReason}). Manual clear needed.`);
+    }
+  }
+  // completed = 0 (success); every other status is a non-error steady state or a reported block,
+  // never a process crash -- exit 0 for all four FR-5 statuses so a caller distinguishes outcomes
+  // by reading the JSON/status, not by exit code alone. strandedClaim is the one operational
+  // hazard that should be visible to a script checking $? too.
+  process.exit(result.strandedClaim ? 2 : 0);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((e) => {
+    console.error(`FATAL: ${e.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Part 2 of SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001, on top of #7063 (FR-3/FR-4, merged).

- **`lib/fleet/parent-completion.mjs`** (`runParentCompletion`) implements the full sequence, empirically validated live on the -H specimen earlier in this SD's LEAD investigation:
  1. Claim via `claimOrchestratorForRollup` (existing, unmodified)
  2. PLAN-TO-LEAD retrigger, narrow eligibility only (`status='blocked' AND metadata.wait===true`), **never** on `'rejected'`; skipped entirely when the latest handoff is already `'accepted'` — idempotent, no duplicate row on re-run
  3. Verify-then-execute: checks the retrospective via the gate's **own** selection-then-scoring pair (`getFilteredRetrospective`, then `validateSDCompletionReadiness` on whatever it selects — not a re-derived heuristic). If it would fail, releases the claim and reports `staged_retro_quality` with `needsRegeneration=true` — retrospective content synthesis needs an LLM (the sanctioned retro-agent Task-tool invocation), which this deterministic function cannot do itself. Once the retro passes, executes `LEAD-FINAL-APPROVAL`.
  4. Releases the claim **always**, including on any failure above; a release failure itself is reported as `strandedClaim=true` on the result, never silently swallowed.
- Reports FR-5's exact 4-value status vocabulary (`completed | staged_retro_quality | staged_other_gate | not_ready`) — never a generic success/failure.
- `handoff.js execute` is CLI-only (no importable entry point), so `runHandoff` is injectable — `defaultRunHandoff` shells out and parses `HANDOFF_RESULT=PASS|FAIL` from stdout, letting the whole sequence be unit tested without a live DB or subprocess.
- **`scripts/run-parent-completion.mjs`** — the thin CLI wrapper wiring in the real Supabase client and the gate's real retro-verification functions.

## Test plan
- [x] 10 new tests (`parent-completion.test.js`): happy path, WAIT-discriminator retrigger rule, never-retrigger-on-rejected rule (TS-2b), retro-failure release-not-hold behavior, idempotent re-run (TS-2c), releasing on an unrelated gate failure, strandedClaim reporting, never-fail-open on could-not-check
- [x] All 53 tests across this SD's work so far pass (`npx vitest run --project unit`)
- [x] No regressions in pre-existing suites
- [ ] Live end-to-end run against -C (the one genuinely eligible specimen — -H's own PLAN-TO-LEAD is already accepted, so it takes a different path through this same code, verified separately) — this is this SD's non-negotiable acceptance bar per explicit coordinator ruling and is tracked as follow-up work, not claimed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)