### PR TITLE
FR-5: sweep keys on LATEST PLAN-TO-LEAD handoff, not merely ever-accepted

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1536,22 +1536,45 @@ async function runQaFixtureScan(ctx) {
   // QF-20260423-909: Guard against resetting SDs that legitimately completed
   // PLAN-TO-LEAD and are resting in pending_approval awaiting LEAD-FINAL-APPROVAL.
   // sd_phase_handoffs.sd_id holds BOTH uuid- and sd_key-style values; check both.
+  //
+  // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-5): the original query checked "does ANY
+  // accepted PLAN-TO-LEAD row EVER exist for this SD" with no recency filter at all -- an old,
+  // superseded accepted row (e.g. from a prior cycle) permanently suppressed the reset AND kept
+  // emitting the misleading "awaiting LEAD-FINAL-APPROVAL" message even after the SD's state had
+  // since regressed (a real, live specimen: -H's own PLAN-TO-LEAD history). Fixed to check the
+  // LATEST PLAN-TO-LEAD handoff per SD (ordered by created_at DESC, never accepted_at -- TR-2:
+  // 476+ historically-accepted rows have accepted_at IS NULL) -- only THAT verdict decides whether
+  // "awaiting LEAD-FINAL-APPROVAL" is still true.
   const stuckApprovalIds = stuckApproval.flatMap(sd => [sd.id, sd.sd_key].filter(Boolean));
   let acceptedPlanToLeadSet = new Set();
   if (stuckApprovalIds.length > 0) {
     const { data: p2lHandoffs } = await supabase
       .from('sd_phase_handoffs')
-      .select('sd_id')
+      .select('sd_id, status, created_at')
       .eq('handoff_type', 'PLAN-TO-LEAD')
-      .eq('status', 'accepted')
-      .in('sd_id', stuckApprovalIds);
-    acceptedPlanToLeadSet = new Set((p2lHandoffs || []).map(h => h.sd_id));
+      .in('sd_id', stuckApprovalIds)
+      .order('created_at', { ascending: false });
+    // Latest-per-SD, resolving the dual-keying: a single logical SD may have handoff rows under
+    // EITHER its uuid or its sd_key across eras, so group by the LOGICAL sd_key, not raw h.sd_id.
+    const idToSdKey = new Map();
+    for (const sd of stuckApproval) {
+      if (sd.id) idToSdKey.set(sd.id, sd.sd_key);
+      if (sd.sd_key) idToSdKey.set(sd.sd_key, sd.sd_key);
+    }
+    const latestBySdKey = new Map();
+    for (const h of (p2lHandoffs || [])) {
+      const logicalKey = idToSdKey.get(h.sd_id);
+      if (logicalKey && !latestBySdKey.has(logicalKey)) latestBySdKey.set(logicalKey, h); // rows arrive created_at DESC -> first seen is latest
+    }
+    for (const [sdKey, h] of latestBySdKey) {
+      if (h.status === 'accepted') acceptedPlanToLeadSet.add(sdKey);
+    }
   }
 
   for (const sd of stuckApproval) {
-    // QF-20260423-909: Skip reset if PLAN-TO-LEAD handoff already accepted —
-    // SD is legitimately awaiting LEAD-FINAL-APPROVAL, not stuck.
-    if (acceptedPlanToLeadSet.has(sd.sd_key) || acceptedPlanToLeadSet.has(sd.id)) {
+    // QF-20260423-909: Skip reset if the LATEST PLAN-TO-LEAD handoff is accepted — SD is
+    // legitimately awaiting LEAD-FINAL-APPROVAL, not stuck. (FR-5: latest, not merely "ever".)
+    if (acceptedPlanToLeadSet.has(sd.sd_key)) {
       actions.push('QA: skipped reset on ' + sd.sd_key + ' — PLAN-TO-LEAD accepted, awaiting LEAD-FINAL-APPROVAL');
       continue;
     }
@@ -1576,7 +1599,17 @@ async function runQaFixtureScan(ctx) {
       // SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (FR-3, AC-4/AC-5): generalized
       // accepted-handoff override guard for the pending_approval reset path.
       // Tag: NEW-GUARD (pre-existing reset behavior preserved on allow).
+      //
+      // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-5): a refusal here previously only
+      // logged via isSweepResetAllowed's own bare console.log/console.warn -- invisible to
+      // anything reading the sweep's structured actions[] summary (dashboard, coordinator query).
+      // A live specimen (-C: accepted LEAD-TO-PLAN/PLAN-TO-EXEC/EXEC-TO-PLAN, latest PLAN-TO-LEAD
+      // 'blocked') is correctly protected from reset by this guard, but that correct decision was
+      // silent at the actions[] layer -- worse invisibility than the misleading-but-visible
+      // message this same FR fixes above. A refused reset is now surfaced explicitly, never a
+      // bare `continue`.
       if (!(await isSweepResetAllowed(sd.sd_key, 'LEAD', 'pending_approval-reset'))) {
+        actions.push('QA: reset refused on ' + sd.sd_key + ' — accepted handoff(s) past LEAD exist or gate error; see WARN/SKIP_RESET log for detail (see stale-session-sweep console output)');
         continue;
       }
       // QF-20260727-363: `.select()` added. Without it this update returned no rows and the code

--- a/tests/unit/pending-approval-guard-latest-handoff.test.js
+++ b/tests/unit/pending-approval-guard-latest-handoff.test.js
@@ -1,0 +1,85 @@
+/**
+ * SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-5) — the pending_approval reset guard must key
+ * on the LATEST PLAN-TO-LEAD handoff, not merely "does an accepted one EVER exist".
+ *
+ * BUG FIXED: the original query was `.eq('status','accepted')` with no recency filter at all --
+ * an OLD, superseded accepted PLAN-TO-LEAD row permanently suppressed the reset (and kept emitting
+ * a misleading "awaiting LEAD-FINAL-APPROVAL" message) even after the SD's state had since
+ * regressed to 'blocked'/'rejected'. Mirrors the SAME "replicate the gate rules here rather than
+ * stubbing supabase in production" pattern as tests/unit/pending-approval-guard.test.js (QF-20260423-909),
+ * updated for the new latest-per-SD resolution added by this SD.
+ */
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Mirrors scripts/stale-session-sweep.cjs's acceptedPlanToLeadSet construction: resolve dual-keyed
+ * (uuid or sd_key) handoff rows to their LOGICAL sd_key, take the latest (rows arrive created_at
+ * DESC), and include only those whose latest PLAN-TO-LEAD is genuinely 'accepted'.
+ */
+function buildAcceptedPlanToLeadSet(stuckApproval, p2lHandoffsDescByCreatedAt) {
+  const idToSdKey = new Map();
+  for (const sd of stuckApproval) {
+    if (sd.id) idToSdKey.set(sd.id, sd.sd_key);
+    if (sd.sd_key) idToSdKey.set(sd.sd_key, sd.sd_key);
+  }
+  const latestBySdKey = new Map();
+  for (const h of p2lHandoffsDescByCreatedAt) {
+    const logicalKey = idToSdKey.get(h.sd_id);
+    if (logicalKey && !latestBySdKey.has(logicalKey)) latestBySdKey.set(logicalKey, h);
+  }
+  const set = new Set();
+  for (const [sdKey, h] of latestBySdKey) {
+    if (h.status === 'accepted') set.add(sdKey);
+  }
+  return set;
+}
+
+describe('stale-session-sweep — pending_approval guard keys on the LATEST PLAN-TO-LEAD, not "ever accepted" (FR-5)', () => {
+  it('regression: an OLD accepted P2L followed by a LATER blocked P2L is correctly RESET-eligible (was incorrectly SKIPped before this fix)', () => {
+    const sd = { id: 'uuid-h', sd_key: 'SD-SPECIMEN-H' };
+    // Rows arrive created_at DESC (newest first), matching the real query's .order().
+    const handoffs = [
+      { sd_id: 'uuid-h', status: 'blocked', created_at: '2026-08-15T01:00:00Z' }, // latest
+      { sd_id: 'uuid-h', status: 'accepted', created_at: '2026-08-10T01:00:00Z' }, // older, superseded
+    ];
+    const set = buildAcceptedPlanToLeadSet([sd], handoffs);
+    expect(set.has('SD-SPECIMEN-H')).toBe(false); // latest wins -- NOT skipped
+  });
+
+  it('an SD whose LATEST P2L is accepted is still correctly skipped', () => {
+    const sd = { id: 'uuid-c', sd_key: 'SD-SPECIMEN-C' };
+    const handoffs = [
+      { sd_id: 'uuid-c', status: 'accepted', created_at: '2026-08-15T01:00:00Z' }, // latest
+      { sd_id: 'uuid-c', status: 'rejected', created_at: '2026-08-10T01:00:00Z' },
+    ];
+    const set = buildAcceptedPlanToLeadSet([sd], handoffs);
+    expect(set.has('SD-SPECIMEN-C')).toBe(true);
+  });
+
+  it('dual-keying: the latest row is keyed by UUID while an older row for the SAME logical SD is keyed by sd_key -- resolves to one logical SD, latest wins', () => {
+    const sd = { id: 'uuid-d', sd_key: 'SD-SPECIMEN-D' };
+    const handoffs = [
+      { sd_id: 'uuid-d', status: 'blocked', created_at: '2026-08-15T01:00:00Z' }, // latest, uuid-keyed
+      { sd_id: 'SD-SPECIMEN-D', status: 'accepted', created_at: '2026-08-10T01:00:00Z' }, // older, sd_key-keyed era
+    ];
+    const set = buildAcceptedPlanToLeadSet([sd], handoffs);
+    expect(set.has('SD-SPECIMEN-D')).toBe(false); // the genuinely-latest row (blocked) wins
+  });
+
+  it('no PLAN-TO-LEAD rows at all -- not in the set (falls through to the broader accepted-handoff-past-LEAD guard, not this one)', () => {
+    const sd = { id: 'uuid-e', sd_key: 'SD-SPECIMEN-E' };
+    const set = buildAcceptedPlanToLeadSet([sd], []);
+    expect(set.has('SD-SPECIMEN-E')).toBe(false);
+  });
+
+  it('multiple unrelated SDs resolve independently -- no cross-contamination', () => {
+    const sds = [{ id: 'uuid-x', sd_key: 'SD-X' }, { id: 'uuid-y', sd_key: 'SD-Y' }];
+    const handoffs = [
+      { sd_id: 'uuid-x', status: 'accepted', created_at: '2026-08-15T01:00:00Z' },
+      { sd_id: 'uuid-y', status: 'blocked', created_at: '2026-08-15T01:00:00Z' },
+    ];
+    const set = buildAcceptedPlanToLeadSet(sds, handoffs);
+    expect(set.has('SD-X')).toBe(true);
+    expect(set.has('SD-Y')).toBe(false);
+  });
+});

--- a/tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js
+++ b/tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js
@@ -98,7 +98,18 @@ describe('QF-20260727-363: QA FIXES reports applied repairs, never detections', 
   it('the guard the QF forbids weakening is untouched', () => {
     // The QF is explicit: the counter was wrong, isSweepResetAllowed was RIGHT. An SD with an
     // accepted PLAN-TO-LEAD handoff must not be reset out from under a pending LEAD-FINAL-APPROVAL.
-    expect(SRC).toMatch(/if \(!\(await isSweepResetAllowed\(sd\.sd_key, 'LEAD', 'pending_approval-reset'\)\)\) \{\s*\n\s*continue;/);
+    //
+    // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-5) added an actions[] visibility line
+    // between the `{` and `continue;` (a refusal was previously visible only via a bare
+    // console.log inside isSweepResetAllowed, invisible to the sweep's own structured summary) --
+    // the REGEX WAS OVER-STRICT (required byte-adjacency), not the guard: the invariant this test
+    // protects is "a refusal still `continue`s, unconditionally, within this if-block", which
+    // still holds. Widened to allow additional statements between `{` and `continue;` while still
+    // requiring `continue;` to be the block's actual, unconditional exit.
+    const ifIdx = SRC.indexOf("if (!(await isSweepResetAllowed(sd.sd_key, 'LEAD', 'pending_approval-reset')))");
+    expect(ifIdx).toBeGreaterThan(-1);
+    const guardBlock = SRC.slice(ifIdx, ifIdx + 400);
+    expect(guardBlock).toMatch(/\{[^}]*continue;[^}]*\}/);
     expect(SRC).toContain('QA: skipped reset on ');
   });
 });


### PR DESCRIPTION
## Summary
Part 3 of SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001, independent of #7066 (branched from main after #7063 merged).

- `stale-session-sweep.cjs`'s `pending_approval` reset guard checked `status='accepted'` with **no recency filter at all** — an old, superseded accepted PLAN-TO-LEAD row permanently suppressed the reset and kept emitting a misleading "awaiting LEAD-FINAL-APPROVAL" message even after the SD's state had since regressed to blocked/rejected. Fixed to resolve the **latest** PLAN-TO-LEAD handoff per SD (`created_at DESC`, never `accepted_at` — TR-2: 476+ historically-accepted rows have `accepted_at IS NULL`), correctly handling the dual-keying (a logical SD's handoff rows can be keyed by either uuid or sd_key across eras).
- Mirror-image visibility gap also fixed: when `isSweepResetAllowed` correctly refuses a reset, that refusal was previously visible only via a bare `console.log` inside the function — invisible to the sweep's own structured `actions[]` summary. Now surfaced explicitly.
- **Verified live** against -C (`SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-C`): its 3 accepted handoffs past LEAD (LEAD-TO-PLAN, PLAN-TO-EXEC, EXEC-TO-PLAN) correctly trigger the broader accepted-handoff-past-LEAD guard regardless of this fix — -C was never actually at risk of reset, only under-reported. Checked this explicitly before assuming either way, since a wrong assumption here could have meant either a false alarm or a missed live risk to this SD's own target specimen.

## Test plan
- [x] 5 new tests (`pending-approval-guard-latest-handoff.test.js`): the regression (old-accepted + newer-blocked → no longer incorrectly skipped), the correct-skip case, dual-keying resolution, no-handoffs, multi-SD independence
- [x] Updated one pre-existing regression test whose regex required byte-adjacency between the guard's `{` and `continue;` — the regex was over-strict, not the guard; widened to permit the new `actions[]` line while still requiring `continue;` as the block's unconditional exit
- [x] All 151 tests across this SD's work so far pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)