### PR TITLE
feat(SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001): widen leg1's landed corpus to any commit subject

### DIFF
--- a/lib/drive-loop/score/drive-score-legs.js
+++ b/lib/drive-loop/score/drive-score-legs.js
@@ -24,6 +24,12 @@
  * widening. Coordinator scope ruling ac704cbd narrowed this SD's wiring to leg2; leg1's git-runner
  * CI work is split to SD-LEO-INFRA-DRIVE-SCORE-LEG1-001. leg4_capacity is ratified but stays
  * fail-closed until belt_capacity_verdicts applies (APPLY-STATE-002).
+ *
+ * LEG1's OWN internal rule has since been separately amended: decision dc828e43 (2026-08-15,
+ * chairman answer "A") amends leg1's A-LOCAL landed-corpus ruling c8ad4998 — see the `amendment`
+ * field on the leg1_landed entry below and lib/drive-loop/score/leg1-landed-alocal.js for detail.
+ * This is a rule-content amendment, not a denominator change: leg1_landed's `ratified_by` marker
+ * (d50b9f12, the leg-SET ratification) is untouched by it — SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001.
  */
 
 /** The ratification token for this SD's denominator — the chairman-accepted Adam ruling. A leg
@@ -39,7 +45,17 @@ export const RATIFICATION = Object.freeze({
  * a leg without one is a phantom (assertLegSetRatified throws).
  */
 export const DRIVE_SCORE_LEGS = Object.freeze([
-  Object.freeze({ id: 'leg1_landed', ratified_by: RATIFICATION.ruling }),
+  Object.freeze({
+    id: 'leg1_landed',
+    ratified_by: RATIFICATION.ruling,
+    amendment: Object.freeze({
+      amends: 'c8ad4998',
+      by: 'dc828e43',
+      at: '2026-08-15',
+      note: 'Landed corpus widened from merge-commit subjects only to ANY commit subject on main '
+        + '— squash-merges made most items measure unlanded (chairman answer "A").',
+    }),
+  }),
   Object.freeze({ id: 'leg2_uptake', ratified_by: RATIFICATION.ruling }),
   Object.freeze({ id: 'leg4_capacity', ratified_by: RATIFICATION.ruling }),
 ]);

--- a/lib/drive-loop/score/leg1-landed-alocal.js
+++ b/lib/drive-loop/score/leg1-landed-alocal.js
@@ -103,6 +103,13 @@ export function anchoredKeyPattern(sdKey) {
  * around this args shape (see drive-report-sweep.mjs CLI wiring); exported so a test can assert
  * WHICH command was built, matching the old file's ancestryArgs precedent.
  *
+ * TRADE-OFF, stated plainly (ADVERSARIAL REVIEW, /ship deep-tier pass): widening from
+ * merge-commit-only to ANY commit subject WIDENS the false-positive surface, not just the
+ * true-positive one — an ordinary non-merge commit whose subject merely MENTIONS an SD key in
+ * prose (not a landing) now also end-anchor-matches. This is the same trade the chairman
+ * approved (decision dc828e43): fewer false negatives at the cost of a few more false
+ * positives, disclosed in scoreLeg1ALocal's own `limitation` citation on every measured result.
+ *
  * @param {object} o
  * @param {string} [o.sinceIso] bound the log to commits at/after this ISO timestamp — UNUSED by
  *   any production caller today. SECURITY/TESTING review (evidence 7b22c9ee) found binding this
@@ -118,8 +125,18 @@ export function landedLogArgs({ sinceIso } = {}) {
   return args;
 }
 
-/** Back-compat alias — pre-amendment (dc828e43) name, same function, kept so any external import
- *  of the old name still resolves rather than breaking silently. */
+/**
+ * Back-compat NAME alias only — NOT a behavior-preserving shim. `mergeLogArgs` and
+ * `landedLogArgs` are the exact same function reference, so calling `mergeLogArgs()` returns
+ * the NEW (post-amendment, no --merges) args shape, not the old merge-only one. This is
+ * deliberate: the whole point of amendment dc828e43 is that the RULE changed, and a caller
+ * still importing the old name should get the current, chairman-ratified behavior — not a
+ * silently-frozen pre-amendment copy that would itself become a second, drifting source of
+ * truth. Kept only so an old import path still resolves to a function at all, rather than
+ * throwing on a missing export; ADVERSARIAL REVIEW (SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001
+ * /ship deep-tier pass): flagged this as a possible source of confusion if the comment implied
+ * otherwise, hence this explicit callout.
+ */
 export const mergeLogArgs = landedLogArgs;
 
 /**

--- a/lib/drive-loop/score/leg1-landed-alocal.js
+++ b/lib/drive-loop/score/leg1-landed-alocal.js
@@ -5,7 +5,22 @@
  * SD-LEO-INFRA-DRIVE-SCORE-LEG1-001 measured unearnable in this repo's delete-branch-on-merge
  * flow (evidence ab82da6b: 7/111 = 6.3%). Ratified alternative (chairman "I agree" SMS
  * 2026-08-10T23:26Z, ruling capture c8ad4998): an item is landed iff its SD-key appears,
- * END-ANCHORED, in a merge-commit subject in main's history.
+ * END-ANCHORED, in a commit subject in main's history.
+ *
+ * ── AMENDMENT dc828e43 (2026-08-15), amends c8ad4998 ──────────────────────────────────────
+ * c8ad4998 originally scoped the corpus to MERGE-COMMIT subjects only (`git log --merges`). This
+ * repo ships by squash-merge for most PRs (no merge commit), so that corpus made 5 of 6 sampled
+ * COMPLETED items measure unlanded even though they are on main: SD-LEO-INFRA-FLEET-VIEW-BADGES-001,
+ * SD-LEO-INFRA-LEO-APP-LAUNCHER-001, SD-LEO-INFRA-FLEET-WATCHDOG-001,
+ * SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001, SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001 each
+ * end-anchor-match a SQUASH-commit subject and ZERO merge-commit subjects (independently
+ * re-measured against this repo's live history, 2026-08-15); the 6th named item,
+ * SD-LEO-FEAT-CHAIRMAN-ROADMAP-TAB-001, end-anchor-matches NEITHER corpus — genuinely landed in a
+ * different repo, out of scope for this file (multi-repo corpus is a separate, later item).
+ * Measured by Solomon (0f127ce4, 2026-08-15, re-derived per key on main) and chairman-approved
+ * (SMS 6fe51a0c, decision dc828e43, answer "A"): the corpus widens to EVERY commit subject on
+ * main, not merge commits only. Everything else in the rule below — end-anchored key match both
+ * directions, empty-corpus-is-never-a-zero, fetch-once — is UNCHANGED by this amendment.
  *
  * ── WHY END-ANCHORED, AND WHY BOTH DIRECTIONS ─────────────────────────────────────────────
  * A naive substring grep reports a PARENT SD as landed off a CHILD's merge, because child keys
@@ -28,6 +43,22 @@
  * fetched ONCE (also closes a real N+1 perf issue TESTING measured: 20 keys = 20 unbounded
  * spawns, ~9.9s) and an empty or errored fetch degrades to unavailable(), never a score.
  *
+ * ── BUFFER SAFETY: THE dc828e43 WIDENING NEEDS EXPLICIT HEADROOM ──────────────────────────
+ * SECURITY review of the ORIGINAL merge-only rule (evidence in
+ * scripts/one-off/store-security-evidence-leg1-alocal-001-exec.mjs, finding S5, Q3) measured the
+ * corpus at 309,323 bytes — 29.5% of Node spawnSync's 1MB DEFAULT maxBuffer — and judged the
+ * overflow risk a NON-ISSUE only because of that headroom, while explicitly recommending an
+ * EXPLICIT maxBuffer as unfinished hardening. Overflow is FAIL-LOUD in the good sense (status:null
+ * -> the runner throws -> caught above -> unavailable(), never a false zero) but it is still a
+ * silent-in-practice degradation of a chairman-facing gauge with no alarm distinguishing it from
+ * any other transient git failure. Amendment dc828e43 (this file's own widening) measured the ANY-
+ * SUBJECT corpus at 1,182,055 bytes on 2026-08-15/16 — ALREADY 112.7% of that 1MB default, i.e.
+ * S5's deferred recommendation is no longer optional hardening, it is required for this leg to
+ * measure at all. LANDED_LOG_MAX_BUFFER_BYTES below is the fix; drive-report-sweep.mjs's CLI
+ * wiring imports it rather than hand-copying a literal, so the one number stays a single
+ * representation. See tests/unit/drive-loop/score/leg1-landed-alocal.test.js for the live-corpus
+ * canary that re-measures this margin against real history.
+ *
  * ── WHY THE INJECTED RUNNER RETURNS TEXT, NOT A BOOLEAN ───────────────────────────────────
  * The OLD leg1-landed.js's runGit convention returns only {ok:boolean} — sufficient for
  * `merge-base --is-ancestor`, whose exit code IS the answer. A `git log --grep` query's exit
@@ -40,6 +71,15 @@ import { unavailable } from '../report-posture.js';
 
 export const LEG_ID = 'leg1_landed';
 export const LEG_POINTS = 2;
+
+/**
+ * The maxBuffer budget the CLI wiring (drive-report-sweep.mjs) must pass to runHardenedGit for
+ * the landed-corpus fetch. 32MB against a measured-live 1.18MB corpus (2026-08-15/16, amendment
+ * dc828e43) — ~27x headroom. A single exported constant, not a literal hand-copied at the call
+ * site, so the CLI wiring and the live-corpus canary test can never drift from each other. See
+ * the file header's "BUFFER SAFETY" section for why this exists.
+ */
+export const LANDED_LOG_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
 
 /** Charset a real SD key is built from — measured, not assumed (TESTING evidence 8606170f). */
 const KEY_CHAR = 'A-Za-z0-9._@-';
@@ -58,10 +98,10 @@ export function anchoredKeyPattern(sdKey) {
 }
 
 /**
- * The git question this rule asks: merge-commit SUBJECT LINES only, main branch only. Callers
- * construct the real runGitLog around this args shape (see drive-report-sweep.mjs CLI wiring);
- * exported so a test can assert WHICH command was built, matching the old file's ancestryArgs
- * precedent.
+ * The git question this rule asks: EVERY commit SUBJECT LINE on main (amendment dc828e43 —
+ * previously merge-commit subjects only, see file header). Callers construct the real runGitLog
+ * around this args shape (see drive-report-sweep.mjs CLI wiring); exported so a test can assert
+ * WHICH command was built, matching the old file's ancestryArgs precedent.
  *
  * @param {object} o
  * @param {string} [o.sinceIso] bound the log to commits at/after this ISO timestamp — UNUSED by
@@ -72,11 +112,15 @@ export function anchoredKeyPattern(sdKey) {
  *   caller with a genuinely different bound; the cost of leaving history unbounded is the N+1 fix
  *   below, not a --since clause.
  */
-export function mergeLogArgs({ sinceIso } = {}) {
-  const args = ['log', 'main', '--merges', '--format=%s'];
+export function landedLogArgs({ sinceIso } = {}) {
+  const args = ['log', 'main', '--format=%s'];
   if (sinceIso) args.push(`--since=${sinceIso}`);
   return args;
 }
+
+/** Back-compat alias — pre-amendment (dc828e43) name, same function, kept so any external import
+ *  of the old name still resolves rather than breaking silently. */
+export const mergeLogArgs = landedLogArgs;
 
 /**
  * Pure match: does ANY of the given already-fetched subject lines end-anchor-match this SD key?
@@ -84,13 +128,14 @@ export function mergeLogArgs({ sinceIso } = {}) {
  * once and reuses it, rather than re-shelling out per key.
  *
  * @param {string} sdKey
- * @param {string[]} subjects merge-commit subject lines, already fetched
+ * @param {string[]} subjects commit subject lines, already fetched (any commit on main since
+ *   amendment dc828e43 — not merge-commits only)
  */
 export function isSdLandedInMainHistory(sdKey, subjects) {
   if (typeof sdKey !== 'string' || sdKey.length === 0) return false;
   if (!Array.isArray(subjects)) {
     throw new Error(
-      'isSdLandedInMainHistory(): subjects must be an array of merge-commit subject lines — '
+      'isSdLandedInMainHistory(): subjects must be an array of commit subject lines — '
       + 'fetch via fetchMergeSubjects({runGitLog}) at the caller; this function is pure',
     );
   }
@@ -99,9 +144,9 @@ export function isSdLandedInMainHistory(sdKey, subjects) {
 }
 
 /**
- * Fetch the merge-subject corpus via the injected runner. Separated from
- * isSdLandedInMainHistory so a caller checking many keys fetches once — see scoreLeg1ALocal,
- * which is the only production caller.
+ * Fetch the commit-subject corpus (every commit on main, amendment dc828e43 — see file header)
+ * via the injected runner. Separated from isSdLandedInMainHistory so a caller checking many keys
+ * fetches once — see scoreLeg1ALocal, which is the only production caller.
  *
  * @param {object} o
  * @param {(args:string[]) => string[]} o.runGitLog injected; returns raw subject lines
@@ -113,7 +158,7 @@ export function fetchMergeSubjects({ runGitLog } = {}) {
       + 'question it asks and needs the matched TEXT, not just an exit code',
     );
   }
-  const raw = runGitLog(mergeLogArgs());
+  const raw = runGitLog(landedLogArgs());
   if (!Array.isArray(raw)) return [];
   // VALIDATION evidence dbc5d211 (V2): a genuinely empty `git log` stdout is the STRING '', and
   // ''.split('\n') is ['''] — LENGTH 1, not 0. Without filtering here, scoreLeg1ALocal's
@@ -194,14 +239,14 @@ export function scoreLeg1ALocal({ items = [], runGitLog } = {}) {
 
   if (!Array.isArray(subjects) || subjects.length === 0) {
     // THE FIX for the shallow-clone false-zero (see file header). A shallow checkout
-    // (fetch-depth:1, GitHub Actions' default) makes `git log main --merges` exit 0 with ZERO
-    // subjects — indistinguishable from "read cleanly, nothing merged" unless treated as a
+    // (fetch-depth:1, GitHub Actions' default) makes `git log main --format=%s` exit 0 with ZERO
+    // subjects — indistinguishable from "read cleanly, nothing landed" unless treated as a
     // measurement failure explicitly. Never scored as "0 landed".
     return {
       leg: LEG_ID,
       unavailable: unavailable(
-        'scoreLeg1ALocal: git log main --merges returned zero subject lines — this is '
-        + 'indistinguishable from a shallow clone that cannot see merge history and is never '
+        'scoreLeg1ALocal: git log main returned zero subject lines — this is '
+        + 'indistinguishable from a shallow clone that cannot see commit history and is never '
         + 'read as "0 landed". Treated as a measurement failure.',
       ),
     };
@@ -237,26 +282,30 @@ export function scoreLeg1ALocal({ items = [], runGitLog } = {}) {
       table: 'roadmap_wave_items',
       row_ids: landedItemIds,
       predicate: `${LEG_POINTS} points * (landed/denominator), where landed = unique sd_key values `
-        + '(deduplicated, null-excluded) whose merge-commit subject in main\'s history end-anchor-matches '
-        + 'the key (git log main --merges, fetched once, JS-side anchor check — see anchoredKeyPattern). '
+        + '(deduplicated, null-excluded) whose commit subject in main\'s history end-anchor-matches '
+        + 'the key (git log main, ANY commit subject — not merges-only since decision dc828e43 '
+        + 'amended c8ad4998 on 2026-08-15 — fetched once, JS-side anchor check — see '
+        + 'anchoredKeyPattern). '
         + `Rounded to 2 decimals. ${items.length - denominator} item(s) excluded from the denominator for `
         + 'lacking a resolvable sd_key (not counted as failures). Deliberately proportional, not '
-        + 'all-or-nothing: a known false-negative tail (squash-merges with no merge commit; '
-        + 'renamed/abbreviated landed keys) would otherwise zero the whole leg even when most of the '
+        + 'all-or-nothing: a known false-negative tail (renamed/abbreviated landed keys; items '
+        + 'landed in a different repo) would otherwise zero the whole leg even when most of the '
         + 'population honestly measures.',
-      limitation: 'The predicate can also register a FALSE POSITIVE: a revert-shaped merge subject '
-        + '(e.g. \'Revert "feat(<KEY>): ..."\') or a merge whose subject merely MENTIONS the key in '
+      limitation: 'The predicate can also register a FALSE POSITIVE: a revert-shaped commit subject '
+        + '(e.g. \'Revert "feat(<KEY>): ..."\') or any commit whose subject merely MENTIONS the key in '
         + "prose — not necessarily the key's own feature branch landing — also end-anchor-matches. "
-        + 'The chairman-ratified rule (c8ad4998) measures merge-subject PRESENCE, not verified '
-        + 'code-level landing; this is a disclosed limitation, not silently absorbed (SECURITY '
-        + 'evidence f84884eb).',
+        + 'Amendment dc828e43 widens this surface (not just narrows it): since the corpus is now '
+        + 'ANY commit subject, not merges only, an ordinary non-merge commit that mentions a key in '
+        + 'prose now also qualifies. The chairman-ratified rule (c8ad4998, amended by dc828e43 '
+        + '2026-08-15) measures commit-subject PRESENCE, not verified code-level landing; this is a '
+        + 'disclosed limitation, not silently absorbed (SECURITY evidence f84884eb).',
       source: 'lib/drive-loop/score/leg1-landed-alocal.js scoreLeg1ALocal',
     }),
     landed_count: cite({
       value: landedKeys.length,
       table: 'roadmap_wave_items',
       row_ids: landedItemIds,
-      predicate: 'unique sd_key values whose merge-commit subject end-anchor-matches, out of the '
+      predicate: 'unique sd_key values whose commit subject end-anchor-matches, out of the '
         + `deduplicated, null-excluded denominator of ${denominator}`,
       source: 'lib/drive-loop/score/leg1-landed-alocal.js scoreLeg1ALocal',
     }),

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -49,7 +49,7 @@ import { SECTION_ID as STALL_ID } from '../../lib/drive-loop/sections/stall-delt
 import { LEG_ID as LEG1_ID } from '../../lib/drive-loop/score/leg1-landed.js';
 // SD-LEO-INFRA-DRIVE-SCORE-LEG1-ALOCAL-001: the chairman-ratified live rule. leg1-landed.js
 // (imported above for LEG_ID only) is reference-only now — see its header amendment.
-import { scoreLeg1ALocal } from '../../lib/drive-loop/score/leg1-landed-alocal.js';
+import { scoreLeg1ALocal, LANDED_LOG_MAX_BUFFER_BYTES } from '../../lib/drive-loop/score/leg1-landed-alocal.js';
 import { runHardenedGit } from '../../lib/git/hardened-runner.cjs';
 import { LEG_ID as LEG2_ID, CLAIM_WINDOW_MS as LEG2_CLAIM_WINDOW_MS, scoreLeg2 } from '../../lib/drive-loop/score/leg2-uptake.js';
 // SD-LEO-INFRA-DRIVE-SCORE-LEG2-001 (FR-2): the cohort reader is imported here for the CLI wiring
@@ -511,8 +511,16 @@ if (isMainModule(import.meta.url)) {
       capacityRunId: windowKey(cliNowMs),
       // SD-LEO-INFRA-DRIVE-SCORE-LEG1-ALOCAL-001 (FR-2): the hardened runner (lib/git/hardened-runner.cjs)
       // is THE published shell-injection-safe git invocation — reused rather than re-derived. Only
-      // ever asked `log main --merges --format=%s [--since=...]`, never a caller-controlled ref.
-      runGitLog: (args) => runHardenedGit(args, { cwd: process.cwd() }).split('\n').filter(Boolean),
+      // ever asked `log main --format=%s [--since=...]` (every commit subject, not merges-only —
+      // amendment dc828e43, SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001), never a caller-controlled ref.
+      // maxBuffer is EXPLICIT, not left at spawnSync's 1MB default: the any-subject corpus this
+      // amendment introduces measured 1.18MB live (2026-08-15/16) — already OVER the default —
+      // where the old merge-only corpus was 29.5% of it (SECURITY finding S5, previously deferred
+      // as a non-issue precisely because of that headroom; the headroom is gone). See
+      // LANDED_LOG_MAX_BUFFER_BYTES's own doc for the single-source-of-truth rationale.
+      runGitLog: (args) => runHardenedGit(args, {
+        cwd: process.cwd(), maxBuffer: LANDED_LOG_MAX_BUFFER_BYTES, timeout: 30000,
+      }).split('\n').filter(Boolean),
       // SD-LEO-INFRA-DRIVE-SCORE-LEG2-001 (FR-2): supabase pre-bound at this CLI edge, same
       // shape as gatherCapacity/persistVerdict above.
       readLeg2Cohort: (nowMsArg, windowMsArg) => readRankedTop5Cohort(supabase, nowMsArg, windowMsArg),

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -518,6 +518,10 @@ if (isMainModule(import.meta.url)) {
       // where the old merge-only corpus was 29.5% of it (SECURITY finding S5, previously deferred
       // as a non-issue precisely because of that headroom; the headroom is gone). See
       // LANDED_LOG_MAX_BUFFER_BYTES's own doc for the single-source-of-truth rationale.
+      // timeout: 30000 (ADVERSARIAL REVIEW, /ship deep-tier pass — flagged as an ungrounded magic
+      // number alongside the well-evidenced maxBuffer): measured live, `git log main --format=%s`
+      // against this repo's real history (13584 lines, 1.18MB) completes in ~610ms — 30s is ~49x
+      // that measured cost, generous headroom for history growth without masking a genuine hang.
       runGitLog: (args) => runHardenedGit(args, {
         cwd: process.cwd(), maxBuffer: LANDED_LOG_MAX_BUFFER_BYTES, timeout: 30000,
       }).split('\n').filter(Boolean),

--- a/tests/unit/drive-loop/score/drive-score-legs.test.js
+++ b/tests/unit/drive-loop/score/drive-score-legs.test.js
@@ -25,6 +25,27 @@ describe('DRIVE_SCORE_LEGS — the ratified SSOT', () => {
   });
 });
 
+describe('leg1_landed — amendment dc828e43 provenance (SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001)', () => {
+  it('cites c8ad4998 amended by dc828e43 (2026-08-15) on the leg1_landed entry only', () => {
+    const leg1 = DRIVE_SCORE_LEGS.find((l) => l.id === 'leg1_landed');
+    expect(leg1.amendment).toBeDefined();
+    expect(leg1.amendment.amends).toBe('c8ad4998');
+    expect(leg1.amendment.by).toBe('dc828e43');
+    expect(leg1.amendment.at).toBe('2026-08-15');
+    // The amendment is leg1-specific — the leg-SET ratification (d50b9f12) is untouched by it,
+    // and the other two legs carry no amendment field at all.
+    expect(leg1.ratified_by).toBe(RATIFICATION.ruling);
+    const leg2 = DRIVE_SCORE_LEGS.find((l) => l.id === 'leg2_uptake');
+    const leg4 = DRIVE_SCORE_LEGS.find((l) => l.id === 'leg4_capacity');
+    expect(leg2.amendment).toBeUndefined();
+    expect(leg4.amendment).toBeUndefined();
+  });
+
+  it('the amendment field does not break the ratified-marker guard (still every leg has ratified_by)', () => {
+    expect(() => assertLegSetRatified()).not.toThrow();
+  });
+});
+
 describe('FR-3 assertLegSetRatified — a phantom leg (no marker) fails loud', () => {
   it('[POSITIVE CONTROL] fires on a leg minted WITHOUT a ratified_by marker', () => {
     const withPhantom = [...DRIVE_SCORE_LEGS, { id: 'leg3_phantom' }]; // no ratified_by

--- a/tests/unit/drive-loop/score/leg1-landed-alocal.test.js
+++ b/tests/unit/drive-loop/score/leg1-landed-alocal.test.js
@@ -29,9 +29,12 @@ import {
   scoreLeg1ALocal,
   anchoredKeyPattern,
   mergeLogArgs,
+  landedLogArgs,
   LEG_ID,
   LEG_POINTS,
+  LANDED_LOG_MAX_BUFFER_BYTES,
 } from '../../../../lib/drive-loop/score/leg1-landed-alocal.js';
+import { runHardenedGit } from '../../../../lib/git/hardened-runner.cjs';
 
 describe('isSdLandedInMainHistory — end-anchored match against an already-fetched corpus', () => {
   it('[TS-1, positive] a subject containing the exact key, end-anchored, measures landed', () => {
@@ -77,10 +80,28 @@ describe('isSdLandedInMainHistory — end-anchored match against an already-fetc
     expect(() => isSdLandedInMainHistory('SD-X-001', undefined)).toThrow(/subjects must be an array/);
   });
 
-  it('the permitted git question is fixed and inspectable', () => {
-    expect(mergeLogArgs()).toEqual(['log', 'main', '--merges', '--format=%s']);
-    expect(mergeLogArgs({ sinceIso: '2026-01-01T00:00:00Z' }))
-      .toEqual(['log', 'main', '--merges', '--format=%s', '--since=2026-01-01T00:00:00Z']);
+  it('[AMENDMENT dc828e43] the permitted git question is ANY commit subject on main — no --merges', () => {
+    expect(landedLogArgs()).toEqual(['log', 'main', '--format=%s']);
+    expect(landedLogArgs({ sinceIso: '2026-01-01T00:00:00Z' }))
+      .toEqual(['log', 'main', '--format=%s', '--since=2026-01-01T00:00:00Z']);
+  });
+
+  it('mergeLogArgs is kept as a back-compat alias of landedLogArgs, not a divergent duplicate', () => {
+    expect(mergeLogArgs).toBe(landedLogArgs);
+    expect(mergeLogArgs()).toEqual(['log', 'main', '--format=%s']);
+  });
+
+  it('[AMENDMENT dc828e43, squash-subject fixture] a key appearing ONLY in a squash-merge subject (real shape, no merge commit) still measures landed', () => {
+    // Real squash-commit subjects sampled from this repo's own history (2026-08-16) — the exact
+    // shape `git log main --merges` cannot see, which is the entire premise of this amendment.
+    const subjects = [
+      'feat(SD-LEO-INFRA-FLEET-VIEW-BADGES-001): capacity chip + status badge + DB-only attention strip (#6357)',
+      'docs(SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001): mark Satellite 3.6 build shape shipped (#6109)',
+    ];
+    expect(isSdLandedInMainHistory('SD-LEO-INFRA-FLEET-VIEW-BADGES-001', subjects)).toBe(true);
+    expect(isSdLandedInMainHistory('SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001', subjects)).toBe(true);
+    // A key with no matching subject at all (e.g. landed in a different repo) still measures NOT landed.
+    expect(isSdLandedInMainHistory('SD-LEO-FEAT-CHAIRMAN-ROADMAP-TAB-001', subjects)).toBe(false);
   });
 });
 
@@ -226,6 +247,57 @@ describe('scoreLeg1ALocal — fetches ONCE, proportional scoring, never a false 
     expect(r.points.value).toBe(LEG_POINTS);
     expect(r.points.predicate).toMatch(/excluded from the denominator/);
   });
+
+  it('[AMENDMENT dc828e43] a corpus with ZERO merge-commit-shaped lines (pure squash-merge history) still lands its keys — the full pipeline, not just the pure match fn', () => {
+    // No "Merge pull request" line anywhere — the exact shape a squash-merge-only history
+    // produces, and the exact shape the OLD (--merges) rule measured as an empty corpus.
+    const runGitLog = () => [
+      'feat(SD-LANDED-001): implement the thing (#123)',
+      'fix(SD-LANDED-001): correct an edge case (#124)',
+      'docs(SD-OTHER-001): unrelated docs update (#125)',
+    ];
+    const r = scoreLeg1ALocal({ items: [{ item_id: 'a', sd_key: 'SD-LANDED-001' }], runGitLog });
+    expect(r.unavailable, 'a squash-only corpus is a real, non-empty corpus — never unavailable').toBeUndefined();
+    expect(r.points.value).toBe(LEG_POINTS);
+    expect(r.landed_count.value).toBe(1);
+  });
+
+  it('[SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001, 08-15 population fixture] 16 of 17 land = 1.88 points (was 11/17 = 1.29 under the pre-amendment merge-only rule)', () => {
+    // The 6 items named in this SD's measured premise (Solomon 0f127ce4, re-derived 2026-08-15):
+    // 5 land ONLY via a squash subject (invisible under --merges), 1 (CHAIRMAN-ROADMAP-TAB) is
+    // absent from EITHER corpus — genuinely landed in a different repo, out of scope here.
+    const squashOnlyLanded = [
+      'feat(SD-LEO-INFRA-FLEET-VIEW-BADGES-001): capacity chip + status badge (#6357)',
+      'fix(SD-LEO-INFRA-LEO-APP-LAUNCHER-001): launcher fix (#6201)',
+      'feat(SD-LEO-INFRA-FLEET-WATCHDOG-001): watchdog heartbeat (#6180)',
+      'feat(SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001): manifest registry (#6155)',
+      'docs(SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001): mark Satellite 3.6 build shape shipped (#6109)',
+    ];
+    // 11 more items that already landed under the OLD merge-only rule (real merge-commit shape) —
+    // rounds the population out to 17 items / 16 landed total, matching the cited premise exactly.
+    const preExistingMergeLanded = Array.from({ length: 11 }, (_, i) =>
+      `Merge pull request #${7000 + i} from rickfelix/feat/SD-WAVE1-FILLER-${String(i + 1).padStart(3, '0')}`);
+    const subjects = [...squashOnlyLanded, ...preExistingMergeLanded];
+    const runGitLog = () => subjects;
+
+    const items = [
+      { item_id: 'i1', sd_key: 'SD-LEO-INFRA-FLEET-VIEW-BADGES-001' },
+      { item_id: 'i2', sd_key: 'SD-LEO-INFRA-LEO-APP-LAUNCHER-001' },
+      { item_id: 'i3', sd_key: 'SD-LEO-INFRA-FLEET-WATCHDOG-001' },
+      { item_id: 'i4', sd_key: 'SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001' },
+      { item_id: 'i5', sd_key: 'SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001' },
+      { item_id: 'i6', sd_key: 'SD-LEO-FEAT-CHAIRMAN-ROADMAP-TAB-001' }, // NOT landed here — different repo
+      ...Array.from({ length: 11 }, (_, i) => ({
+        item_id: `f${i + 1}`,
+        sd_key: `SD-WAVE1-FILLER-${String(i + 1).padStart(3, '0')}`,
+      })),
+    ];
+    expect(items).toHaveLength(17);
+
+    const r = scoreLeg1ALocal({ items, runGitLog });
+    expect(r.landed_count.value).toBe(16);
+    expect(r.points.value).toBe(1.88); // 2 * 16/17 = 1.8823... -> rounded 1.88
+  });
 });
 
 /**
@@ -285,5 +357,27 @@ describe('[TS-8] the done[]-shaped test fixture is bound to the REAL computePlan
     // The exact contract scoreLeg1ALocal reads.
     const scored = scoreLeg1ALocal({ items: status.done, runGitLog: () => ['Merge pull request #1 from rickfelix/feat/SD-X-001'] });
     expect(scored.points.value).toBe(LEG_POINTS);
+  });
+});
+
+describe('[BUFFER SAFETY canary, amendment dc828e43] the REAL production wiring against THIS repo\'s live history', () => {
+  // SD-LEO-INFRA-DRIVE-SCORE-LEG1-ANY-SUBJECT-001: widening the corpus from merge-only to any
+  // commit subject measured 1.18MB live on 2026-08-15/16 — already OVER spawnSync's unconfigured
+  // 1MB default (see leg1-landed-alocal.js's "BUFFER SAFETY" header section and
+  // LANDED_LOG_MAX_BUFFER_BYTES). This test runs the EXACT same call the CLI wiring makes — real
+  // git, real repo, real hardened runner — so a future corpus-size regression (or a maxBuffer
+  // value that drifts out of sync with reality) fails loud in CI, not silently in production.
+  it('runHardenedGit(landedLogArgs(), {maxBuffer: LANDED_LOG_MAX_BUFFER_BYTES}) succeeds, with healthy margin below the budget', () => {
+    const raw = runHardenedGit(landedLogArgs(), {
+      cwd: process.cwd(), maxBuffer: LANDED_LOG_MAX_BUFFER_BYTES, timeout: 30000,
+    });
+    expect(typeof raw).toBe('string');
+    const bytes = Buffer.byteLength(raw, 'utf8');
+    expect(
+      bytes,
+      `live any-subject corpus is ${bytes} bytes against a ${LANDED_LOG_MAX_BUFFER_BYTES}-byte `
+      + 'budget (spawnSync\'s unconfigured default is 1,048,576) — if this creeps past half the '
+      + 'budget, widen LANDED_LOG_MAX_BUFFER_BYTES before it silently degrades leg1 to unavailable().',
+    ).toBeLessThan(LANDED_LOG_MAX_BUFFER_BYTES / 2);
   });
 });

--- a/tests/unit/drive-loop/score/leg1-landed-alocal.test.js
+++ b/tests/unit/drive-loop/score/leg1-landed-alocal.test.js
@@ -22,7 +22,8 @@
  *   NEVER THROWS and NEVER scores an empty/errored corpus as "0 landed".
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execSync } from 'node:child_process';
 import {
   isSdLandedInMainHistory,
   fetchMergeSubjects,
@@ -367,6 +368,23 @@ describe('[BUFFER SAFETY canary, amendment dc828e43] the REAL production wiring 
   // LANDED_LOG_MAX_BUFFER_BYTES). This test runs the EXACT same call the CLI wiring makes — real
   // git, real repo, real hardened runner — so a future corpus-size regression (or a maxBuffer
   // value that drifts out of sync with reality) fails loud in CI, not silently in production.
+  //
+  // CI-CHECKOUT GOTCHA (found live, PR #7069, unit-tier.yml): a pull_request-triggered job checks
+  // out the PR's merge ref with fetch-depth:0 (full HISTORY), but that does NOT create a LOCAL
+  // branch literally named `main` — only `origin/main`. landedLogArgs() deliberately hardcodes the
+  // literal ref `main` (never a caller-controlled ref — see its own docs), which is always true in
+  // the REAL production job (drive-report-cron.yml checks out main directly), but is NOT guaranteed
+  // in every CI job that happens to run this test suite. Ensuring `main` resolves locally is an
+  // environment fix scoped to THIS TEST ONLY — it does not touch landedLogArgs's fixed-ref
+  // contract, which is exactly what this canary exists to exercise unmodified.
+  beforeAll(() => {
+    try {
+      execSync('git rev-parse --verify --quiet main', { cwd: process.cwd(), stdio: 'ignore' });
+    } catch {
+      execSync('git branch main origin/main', { cwd: process.cwd(), stdio: 'ignore' });
+    }
+  });
+
   it('runHardenedGit(landedLogArgs(), {maxBuffer: LANDED_LOG_MAX_BUFFER_BYTES}) succeeds, with healthy margin below the budget', () => {
     const raw = runHardenedGit(landedLogArgs(), {
       cwd: process.cwd(), maxBuffer: LANDED_LOG_MAX_BUFFER_BYTES, timeout: 30000,


### PR DESCRIPTION
## Summary
- Chairman decision dc828e43 (amending ruling c8ad4998): drive-score leg1_landed's git-log corpus widens from merge-commit subjects only to every commit subject on main -- this repo ships mostly by squash-merge, so 5 of 6 sampled completed items measured unlanded even though they are on main.
- `landedLogArgs` (renamed from `mergeLogArgs`, kept as a back-compat alias) drops `--merges`; amendment provenance recorded on `leg1_landed` in the ratified-leg SSOT (`drive-score-legs.js`).
- **Found and fixed during implementation, not in the original proposal**: the widened corpus measures 1.18MB live, already over Node spawnSync's unconfigured 1MB default `maxBuffer` -- a risk the original SD's own SECURITY review (finding S5) explicitly measured and deferred as a non-issue only because the merge-only corpus was 29.5% of that budget. Fixed with an explicit `LANDED_LOG_MAX_BUFFER_BYTES` (32MB) wired into the CLI's `runHardenedGit` call, plus a live buffer-safety canary test.
- Live-verified against real git history + real DB population (post-fix): 13/14 landed, 1.86 points (was silently failing to `unavailable()` before the fix).

## Test plan
- [x] `npx vitest run tests/unit/drive-loop tests/unit/cron/drive-report-sweep.test.js` -- 368/368 passing
- [x] New squash-subject landing test, squash-only-corpus pipeline test, 16/17 population fixture (matches the SD's cited 08-15 snapshot: 1.88 points), amendment-field provenance guard tests, live buffer-safety canary
- [x] Live smoke check: real `runHardenedGit` + real 720h DB population -> 13/14 landed, 1.86 points, non-`unavailable()`
- [x] Verified `actions/checkout` `fetch-depth: 0` already present in both drive-report cron workflows (unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)