### PR TITLE
FR-6: boundary-anchor CHAIRMAN_APPLY_VERIFICATION's SD-key file ownership match

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -14,6 +14,7 @@ import { branchBelongsToSd, loadKeySet, OWNER_REASON } from '../../../../../lib/
 import { resolveRepoPath, resolveGitHubRepo, ENGINEER_ROOT } from '../../../../../lib/repo-paths.js';
 import { getTierForSD } from '../../../sd-type-checker.js';
 import { getFilteredRetrospective } from '../../retro-filters.js';
+import { sdKeyOwnsFile } from './sd-key-file-ownership.js';
 
 // Core Protocol Gate - SD Start Gate (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
 import { createSdStartGate } from '../../gates/core-protocol-gate.js';
@@ -1405,7 +1406,14 @@ export function createChairmanApplyVerificationGate() {
         // metadata is a DATABASE WRITE, not part of any git diff, so that bypass would have
         // been invisible to review of the PR that introduced it. A declaration may only ever
         // ADD to what is checked; it can never subtract.
-        const owned = files.filter(f => declared.includes(f.file) || f.file.includes(sdKey));
+        // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-6, coordinator rulings #6/#7):
+        // a bare substring match here let an orchestrator PARENT's sd_key (a strict PREFIX of
+        // its CHILDREN's sd_keys) "own" a child's staged migration file -- measured live on -H
+        // (inheriting H1's DDL) and -C (inheriting C1..C4's). Boundary-anchored via
+        // sdKeyOwnsFile: matches the fallback case exactly as before EXCEPT when the character
+        // immediately following the matched key is alphanumeric (a longer, different key).
+        // declared.includes(f.file) is UNCHANGED -- an explicit declaration remains exact-match.
+        const owned = files.filter(f => declared.includes(f.file) || sdKeyOwnsFile(sdKey, f.file));
 
         // A declaration that names a file the corpus does not contain is itself unverifiable.
         // Without this, declaring ['real.sql','typo.sql'] checked only real.sql and silently

--- a/scripts/modules/handoff/executors/lead-final-approval/sd-key-file-ownership.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/sd-key-file-ownership.js
@@ -1,0 +1,40 @@
+/**
+ * Boundary-anchored SD-key-in-filename ownership predicate.
+ * SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-6, coordinator rulings #6/#7).
+ *
+ * gates.js's CHAIRMAN_APPLY_VERIFICATION gate falls back to a bare substring match
+ * (`f.file.includes(sdKey)`) when a migration is not explicitly declared. Because an
+ * orchestrator PARENT's sd_key is a strict PREFIX of its CHILDREN's sd_keys (e.g.
+ * 'SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-H' is a literal substring of
+ * '...-H1'), the parent's own gate run incorrectly "owns" -- and therefore blocks on --
+ * its child's staged, chairman-gated migration file. Measured live on TWO specimens by
+ * the coordinator (gates.js:1408): -H inheriting H1's DDL, -C inheriting C1..C4's.
+ *
+ * FIX: require a token boundary immediately after the matched sdKey -- the character that
+ * follows (if any) must NOT be alphanumeric. This still matches every genuine same-key
+ * substring occurrence (e.g. a filename containing the key followed by '_', '.', '-', or
+ * end-of-string) while rejecting a PREFIX-of-a-longer-key false positive.
+ *
+ * Declarations (metadata.migration_files) are UNCHANGED by this fix -- they remain an exact
+ * membership check and may only ever ADD to what is checked, never subtract (see gates.js's
+ * own comment above the `owned` filter). This module touches ONLY the substring-fallback half.
+ */
+
+/**
+ * @param {string} sdKey - the SD's own sd_key (e.g. 'SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-H')
+ * @param {string} filename - a migration filename to test
+ * @returns {boolean} true iff sdKey appears in filename at a genuine token boundary
+ */
+export function sdKeyOwnsFile(sdKey, filename) {
+  if (!sdKey || !filename) return false;
+  let fromIndex = 0;
+  while (true) {
+    const idx = filename.indexOf(sdKey, fromIndex);
+    if (idx === -1) return false;
+    const nextChar = filename[idx + sdKey.length];
+    if (!nextChar || !/[A-Za-z0-9]/.test(nextChar)) return true;
+    // Matched, but it's a prefix of a longer token (e.g. parent key inside a child key) --
+    // keep scanning in case sdKey ALSO appears elsewhere in the same filename at a real boundary.
+    fromIndex = idx + 1;
+  }
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/sd-key-file-ownership.test.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/sd-key-file-ownership.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { sdKeyOwnsFile } from './sd-key-file-ownership.js';
+
+describe('sdKeyOwnsFile', () => {
+  it('regression fixture (coordinator rulings #6/#7): parent -H does NOT own child H1\'s migration by prefix collision', () => {
+    const parentKey = 'SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-H';
+    const childFile = '20260814_SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-H1_wire_telemetry.sql';
+    expect(sdKeyOwnsFile(parentKey, childFile)).toBe(false);
+  });
+
+  it('regression fixture (coordinator confirmation, 2nd specimen): parent -C does NOT own child C4\'s migration by prefix collision', () => {
+    const parentKey = 'SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-C';
+    const childFile = '20260813_SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-C4_finalize.sql';
+    expect(sdKeyOwnsFile(parentKey, childFile)).toBe(false);
+  });
+
+  it('a child DOES own its own migration file', () => {
+    const childKey = 'SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-H1';
+    const childFile = '20260814_SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-H1_wire_telemetry.sql';
+    expect(sdKeyOwnsFile(childKey, childFile)).toBe(true);
+  });
+
+  it('matches at end-of-string (no trailing character at all)', () => {
+    expect(sdKeyOwnsFile('SD-FOO-001', 'migrations/SD-FOO-001')).toBe(true);
+  });
+
+  it('matches when followed by a non-alphanumeric separator (underscore, dot, dash)', () => {
+    expect(sdKeyOwnsFile('SD-FOO-001', 'SD-FOO-001_migration.sql')).toBe(true);
+    expect(sdKeyOwnsFile('SD-FOO-001', 'SD-FOO-001.sql')).toBe(true);
+    expect(sdKeyOwnsFile('SD-FOO-001', 'SD-FOO-001-final.sql')).toBe(true);
+  });
+
+  it('does NOT match when followed by an alphanumeric continuation (the exact bug class)', () => {
+    expect(sdKeyOwnsFile('SD-FOO-001', 'SD-FOO-0012_something.sql')).toBe(false);
+    expect(sdKeyOwnsFile('SD-FOO-001', 'SD-FOO-001A_something.sql')).toBe(false);
+  });
+
+  it('finds a genuine boundary-anchored match even when a false prefix match occurs first in the string', () => {
+    // The key appears twice: once as a prefix-of-longer-token (false), once at a real boundary (true).
+    const key = 'SD-FOO-001';
+    const filename = 'SD-FOO-0019_ignore/real/SD-FOO-001_actual.sql';
+    expect(sdKeyOwnsFile(key, filename)).toBe(true);
+  });
+
+  it('no match anywhere in the filename', () => {
+    expect(sdKeyOwnsFile('SD-FOO-001', 'SD-BAR-002_unrelated.sql')).toBe(false);
+  });
+
+  it('handles empty/null inputs without throwing', () => {
+    expect(sdKeyOwnsFile('', 'file.sql')).toBe(false);
+    expect(sdKeyOwnsFile('SD-FOO-001', '')).toBe(false);
+    expect(sdKeyOwnsFile(null, 'file.sql')).toBe(false);
+    expect(sdKeyOwnsFile('SD-FOO-001', null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Part 4 of SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001, per coordinator rulings #6/#7 (repeated 4x across an inbox-delivery gap).

`gates.js`'s `CHAIRMAN_APPLY_VERIFICATION` gate's owned-migration fallback used a bare substring match (`f.file.includes(sdKey)`), so an orchestrator **parent's** sd_key — a strict prefix of its **children's** sd_keys — incorrectly "owned" a child's staged, chairman-gated migration file.

Measured live by the coordinator on two real specimens (`gates.js:1408`): `-H` inheriting `H1`'s DDL, `-C` inheriting `C1..C4`'s. This is the actual root cause of both parents' `CHAIRMAN_APPLY_VERIFICATION` failures hit during this SD's own live validation runs earlier — previously misdiagnosed by me as a pooler-credential issue (it also happened to co-occur with a real, separate, since-explained credential rotation on my seat) and reported as chairman-facing/out-of-scope for `-H`. Both corrected per the coordinator's own gate-source read.

`sdKeyOwnsFile()` requires a token boundary immediately after the matched key — the following character (if any) must not be alphanumeric. Still matches every genuine occurrence (key followed by `_`, `.`, `-`, or end-of-string); rejects a prefix-of-a-longer-key false positive. `declared.includes(f.file)` (explicit `metadata.migration_files` declarations) is completely unchanged — this fix touches only the substring-fallback half, preserving "a declaration may only ever ADD, never subtract."

## Test plan
- [x] 9 new tests, including the coordinator's own named fixtures (`-H`/`H1` and `-C`/`C4` as real sd_key pairs) as regression cases
- [x] All 35 tests across this gate's existing + new coverage pass, no regressions
- [x] Boundary behavior verified for both directions: matches at real boundaries (`_`, `.`, `-`, end-of-string), rejects alphanumeric continuations
- [ ] Live re-run of `-H`/`-C` through the fixed gate post-merge — tracked as this SD's final acceptance step per the coordinator's standing "no bypass, both parents complete through the fixed gate" ruling

🤖 Generated with [Claude Code](https://claude.com/claude-code)