### PR TITLE
docs(QF-20260815-748): correct field-name-is-a-claim.md — loop_state=awaiting_tick already fixed

### DIFF
--- a/docs/reference/field-name-is-a-claim.md
+++ b/docs/reference/field-name-is-a-claim.md
@@ -23,7 +23,7 @@ anyone reads them.
 | `commits_since_claim` | this seat's work | repository-wide commits since `claimed_at` (`git log --since`, no `--author`, no branch restriction) — rises when *other* workers commit |
 | `acknowledged_at` | the message was answered | a stamp written on the **sender's own row**, which the sender never reads |
 | `last_tool_at` | progress | activity — advances on any tool call, so a seat re-checking its own blocked state satisfies it forever |
-| `loop_state='awaiting_tick'` | a wakeup is pending and will clear when it fires | a one-way latch cleared ONLY by the `SessionStart` hook — a wakeup firing inside an already-running session produces no `SessionStart` and never clears it |
+| `loop_state='awaiting_tick'` | a wakeup is pending and will clear when it fires | ~~a one-way latch cleared ONLY by the `SessionStart` hook~~ — **fixed since** by `SD-LEO-INFRA-LOOP-STATE-AWAITING-001`: `scripts/hooks/loop-state-resume-clear.cjs`, a `UserPromptSubmit` hook (fires on every turn, including a wakeup that resumes an already-running session with no `SessionStart`) |
 | `delivered_at` | the SMS reached the handset | when a reconciler sweep happened to run — with delivery callbacks disabled, observed sent→delivered lag ranged from 906s to 42,362s (11.8h) |
 | `loop_state='exited'` | the worker's loop ended (a worker-side decision) | the sweep released this session during a cycle — conflates "coordinator released me" with "I deliberately wound down"; today nothing writes the deliberate-exit case at all |
 
@@ -43,7 +43,7 @@ truth.** One test per field:
 | `commits_since_claim` | Freeze "this seat" (zero commits since claiming); have a *different* author commit in the same window; assert the field stays 0. | **Implemented**, `it.fails` (live defect — companion fix QF-20260728-430, open) — `tests/unit/hooks/post-tool-clear-telemetry-commits-since-claim-negative.test.js` |
 | `acknowledged_at` | Never answer a signal/message; assert `acknowledged_at` does not stamp on the row a reader would actually query. | Recipe only — deferred. The write-site survey for this QF did not converge on a single canonical "was my message answered" read/write pair within scope; several legitimate same-row claim-marker usages of `acknowledged_at` exist (e.g. `lib/coordinator/relay-queue.cjs` drain-claim, `lib/coordinator/signal-router.cjs` route-ack) that are NOT instances of this defect. Follow-up: identify the specific sender-row-vs-reader-row mismatch before writing the test, rather than testing the wrong site. |
 | `last_tool_at` | Have a seat re-check its own blocked state; assert the "progress" reading does not advance. | **Recipe only, by design** — the QF's own text: "this one likely requires renaming the field rather than testing it." `last_tool_at` accurately measures activity; the mismatch is the NAME implying progress, not a code defect. Rename is a separate, larger, cross-consumer change (many readers), out of scope here. |
-| `loop_state='awaiting_tick'` | Fire a wakeup inside an already-running session; assert `awaiting_tick` clears. | Investigated, not yet tested. Confirmed still live: `scripts/hooks/session-register.cjs`'s `SD-LEO-INFRA-LOOP-STATE-SIGNAL-001` block only clears `awaiting_tick` from the `SessionStart` hook path — unchanged in mechanism from the original finding. Companion fix tracked at QF-20260728-338 (status: escalated) and SD-LEO-INFRA-LOOP-STATE-AWAITING-001 (completed, but that SD addressed a different mechanism — verify before assuming it covers this). |
+| `loop_state='awaiting_tick'` | Fire a wakeup inside an already-running session; assert `awaiting_tick` clears. | **Already implemented, passes** — `tests/unit/hooks/loop-state-resume-clear.test.js` (12 tests, including one literally titled "the hook is REGISTERED on the event that actually fires per turn... in the UserPromptSubmit group, not SessionStart"). **Correction to an earlier version of this doc**: a first pass here checked only `scripts/hooks/session-register.cjs` (the `SessionStart`-only clearer) and concluded the gap was still live — it missed that `SD-LEO-INFRA-LOOP-STATE-AWAITING-001` had already shipped a second, `UserPromptSubmit`-registered clearer (`scripts/hooks/loop-state-resume-clear.cjs`) specifically to close this exact gap. Lesson: checking one writer/clearer site is not the same as checking whether the gap has a fix anywhere — verify against current `main` and the SD's own completion, not just the mechanism named in the original finding. QF-20260728-338 (a separate, narrower fix) remains escalated/unfixed, but is superseded for this specific negative test by the SD above. |
 | `delivered_at` | Disable delivery callbacks; send; assert `delivered_at` stays NULL (not "delivered early" via a stale reconciler read). | Recipe only — deferred. Requires mocking the Twilio/messaging-provider seam and the reconciler sweep together; the existing `sms_reply_matchable` work this session (SD-LEO-INFRA-SMS-DECIDE-REPLY-MATCHABLE-001) touched an adjacent but distinct path (decision staging, not delivery-status reconciliation). |
 | `loop_state='exited'` | Have a worker end its loop WITHOUT the sweep releasing it; assert `loop_state` reads `'exited'`. Today nothing writes it on that path. | **Implemented**, structural census, passes today (honestly documents the gap) — `tests/unit/hooks/loop-state-exited-negative.test.js`. Asserts the ONLY write site repo-wide is the sweep's bulk release-update; a second writer appearing forces this test to be revisited. |
 
@@ -64,6 +64,14 @@ truth.** One test per field:
   "investigated, ambiguous, deferred with a specific open question" are different
   states; only write the ledger to look like the former when it's actually the
   latter.
+- **A single confirmed writer/clearer is not proof there is only one.** The
+  `awaiting_tick` row in this table was first marked "confirmed still live" after
+  reading exactly one clearer (`session-register.cjs`, `SessionStart`-only) and
+  concluding the gap was unchanged — without checking whether a *different* fix had
+  landed elsewhere. It had (`loop-state-resume-clear.cjs`, `UserPromptSubmit`).
+  Grep for every write site before asserting a gap is still open, the same way this
+  document already asks you to grep for every write site before trusting a field's
+  name.
 
 ## Provenance
 


### PR DESCRIPTION
## Summary
- Corrects a factual error in `docs/reference/field-name-is-a-claim.md` (published by QF-20260728-720 a few hours ago): the `loop_state='awaiting_tick'` row claimed the field was "confirmed still live" broken, checking only `scripts/hooks/session-register.cjs`'s `SessionStart`-only clearer.
- It missed that `SD-LEO-INFRA-LOOP-STATE-AWAITING-001` already shipped a second clearer, `scripts/hooks/loop-state-resume-clear.cjs`, registered on `UserPromptSubmit` (fires on every turn, including a wakeup resuming an already-running session with no `SessionStart`) — with 12 passing tests, one of which pins the hook's own registration on the correct event.
- Adds a "How to apply" lesson: a single confirmed writer/clearer is not proof there is only one — grep for every write site before asserting a gap is still open.
- Narrows QF-20260815-748's remaining scope from 4 fields to 3 (`acknowledged_at`, `last_tool_at`, `delivered_at`).

## Test plan
- [x] Docs-only change
- [x] Verified the claim directly: `npx vitest run tests/unit/hooks/loop-state-resume-clear.test.js` — 12 passed
- [x] Confirmed the hook is actually wired: `grep loop-state-resume-clear .claude/settings.json` shows it registered under `UserPromptSubmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)