### PR TITLE
fix(SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001): unify successor-Adam mail forwarding onto one verified predicate

### DIFF
--- a/lib/adam/inbound-backlog-watchdog.js
+++ b/lib/adam/inbound-backlog-watchdog.js
@@ -22,6 +22,7 @@
  *     alarm rather than bound it. See MAX_ESCALATIONS_PER_TICK for the ceiling that replaces it.
  */
 
+import { createRequire } from 'node:module';
 import { emitFeedback } from '../governance/emit-feedback.js';
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
 import {
@@ -31,6 +32,12 @@ import {
   UNACKED_BREACH_MS,
   EVIDENCE_FLOOR_MS,
 } from './inbound-backlog.js';
+
+// SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-7): shared with lib/coordinator/adam-identity.cjs
+// (CJS) via createRequire, matching this repo's existing ESM-requires-CJS pattern, so the retired-role
+// value cannot drift between the movers and this watchdog.
+const require = createRequire(import.meta.url);
+const { ADAM_RETIRED_ROLE } = require('../fleet/worker-status.cjs');
 
 export const ESCALATION_KIND = 'adam_inbound_backlog';
 export const SCOPE_BACKLOG = 'backlog';
@@ -87,7 +94,12 @@ export function descriptionFor(scope) {
 }
 
 /**
- * IO: resolve EVERY historical role=adam session id (not just the live-elected one).
+ * IO: resolve EVERY historical Adam session id — live (role='adam') AND retired
+ * (role=ADAM_RETIRED_ROLE, SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 FR-7). Previously
+ * filtered role='adam' only, which silently dropped a seat the moment it retired (role flips to
+ * ADAM_RETIRED_ROLE via the live JS-merge fallback) — exactly the class of stranding gap this SD
+ * closes for the movers; this watchdog's own population must stay consistent with what they now
+ * inherit from, or its "historical ids" reads stop matching reality the same way.
  *
  * Paginated, not a bare read: this module's own contract forbids bare limits, and an unpaginated
  * select here would be the same PostgREST-cap defect one layer up (testing-agent 61d1a6e2). The
@@ -98,7 +110,7 @@ export async function resolveAdamSessionIds(supabase) {
     const rows = await fetchAllPaginated(() => supabase
       .from('claude_sessions')
       .select('session_id')
-      .eq('metadata->>role', 'adam'));
+      .in('metadata->>role', ['adam', ADAM_RETIRED_ROLE]));
     return { ids: (rows || []).map((r) => r.session_id).filter(Boolean), error: null };
   } catch (e) {
     return { ids: [], error: e && e.message ? e.message : String(e) };

--- a/lib/coordinator/adam-identity.cjs
+++ b/lib/coordinator/adam-identity.cjs
@@ -22,10 +22,18 @@
  * this module owns the read/election/decision layer.
  */
 
+const { ADAM_EXCLUDED_KINDS, ADAM_RETIRED_ROLE } = require('../fleet/worker-status.cjs');
+
 const ADAM_ROLE = 'adam';
 /** Freshness window: an Adam session whose heartbeat is within this is "live". Matches the
  *  coordinator/detector 10-min convention (detectors.cjs DEFAULT_COORDINATOR_FRESH_MS). */
 const ADAM_FRESH_MS = 10 * 60 * 1000;
+
+// SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001: the shared successor-inherit horizon. NOT
+// exported from lib/retention/session-coordination-ack-convergence.js (ACK_TTL_DAYS=14, ESM) —
+// this module and its CJS callers stay sync; a cross-module-system export would force an async
+// dynamic import() here. Kept in sync by a source-pin test (AC-14) against the ESM literal.
+const ADAM_MAIL_TTL_DAYS = 14;
 
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6: role-session reads feed the single-Adam
 // guard (a retire/refuse decision) — a read silently capped at the PostgREST 1000-row max could
@@ -165,24 +173,88 @@ async function resolveAdamReplyTarget(supabase, originatorSession, opts = {}) {
 }
 
 /**
- * FR-2: recover messages already stuck at a stale originator. Re-point any UNREAD coordinator->Adam
- * rows still targeted at the stale originator to the current live Adam. Only unread rows move
- * (acknowledged ones are settled). Best-effort + REPORTED — returns the re-targeted count; an error
- * is surfaced, never silently swallowed. No-op when there is nothing to move.
+ * SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-1): the population of "retired seats a
+ * successor must inherit from" — every claude_sessions row whose metadata.role is
+ * ADAM_RETIRED_ROLE ('adam_retired', the value the JS-merge retire fallback in
+ * scripts/adam-register.cjs sets today; the atomic clear_adam_flag RPC is unapplied).
+ * Paginated (a truncated read would silently under-inherit). FAIL-OPEN: [] + error on failure,
+ * never throws — callers treat an error as "verify nothing" (fail CLOSED on the safety check
+ * that consumes this), not as "everything is retired".
+ * @returns {Promise<{ids:string[], error:(string|null)}>}
+ */
+async function resolveRetiredAdamSeats(supabase) {
+  if (!supabase) return { ids: [], error: 'no supabase client' };
+  try {
+    const rows = await fapPaginate(() => supabase
+      .from('claude_sessions')
+      .select('session_id')
+      .eq('metadata->>role', ADAM_RETIRED_ROLE));
+    return { ids: (rows || []).map((r) => r.session_id).filter(Boolean), error: null };
+  } catch (e) {
+    return { ids: [], error: e && e.message ? e.message : String(e) };
+  }
+}
+
+/**
+ * SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-1): the shared successor-inherit predicate,
+ * applied identically by both movers (drainAdamOutbound in scripts/adam-advisory.cjs and
+ * retargetStaleAdamInbound below) so they cannot diverge again. Null-safe kind exclusion modeled
+ * verbatim on scripts/coordinator-hourly-review.cjs:622 (a bare NOT IN would silently drop
+ * kind-less rows). Callers still add their own target_session scoping.
+ * @param {object} query a supabase-js query builder already scoped with .from()/.select()/.update()
+ * @returns {object} the same query builder with acknowledged_at/kind/horizon filters applied
+ */
+function applySuccessorInheritFilters(query) {
+  const cutoff = new Date(Date.now() - ADAM_MAIL_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  return query
+    .is('acknowledged_at', null)
+    .or('payload->>kind.is.null,payload->>kind.not.in.(' + ADAM_EXCLUDED_KINDS.join(',') + ')')
+    .gte('created_at', cutoff);
+}
+
+/**
+ * FR-4: recover messages already stuck at a stale originator, at reply time. Re-points every
+ * unacked, non-handler-owned row (any sender, per the shared FR-1 predicate) from staleOriginator
+ * to liveAdam — but ONLY once staleOriginator is independently VERIFIED as a retired Adam seat via
+ * resolveRetiredAdamSeats. This verification is a safety precondition, not a nicety: with the
+ * sender_type='coordinator' filter dropped (widened per FR-1/DOES-3), an unverified staleOriginator
+ * would let the update sweep every unacked row at that target_session from ANY sender — a
+ * mis-resolved or spoofed originator becomes a silent inbox hijack. FAIL CLOSED: an unverified or
+ * unresolvable staleOriginator moves 0 rows, same shape as the pre-existing no-op guards.
+ * Select-then-per-row-update (jsonb payload cannot be partially merged in one chained .update()),
+ * re-asserting the safety predicate at update time (not just at select time) so a row acknowledged
+ * or moved by another process between select and update is neither double-moved nor miscounted.
  * @returns {Promise<{retargeted:number, error:(string|null)}>}
  */
 async function retargetStaleAdamInbound(supabase, { staleOriginator, liveAdam }) {
   if (!staleOriginator || !liveAdam || staleOriginator === liveAdam) return { retargeted: 0, error: null };
+  const { ids: retiredIds, error: resolveError } = await resolveRetiredAdamSeats(supabase);
+  if (resolveError) return { retargeted: 0, error: resolveError };
+  if (!retiredIds.includes(staleOriginator)) return { retargeted: 0, error: null };
   try {
-    const { data, error } = await supabase
-      .from('session_coordination')
-      .update({ target_session: liveAdam })
-      .eq('target_session', staleOriginator)
-      .eq('sender_type', 'coordinator')
-      .is('acknowledged_at', null)
-      .select('id');
-    if (error) return { retargeted: 0, error: error.message };
-    return { retargeted: Array.isArray(data) ? data.length : 0, error: null };
+    const selectQuery = applySuccessorInheritFilters(
+      supabase.from('session_coordination').select('id, payload, target_session').eq('target_session', staleOriginator),
+    );
+    const { data: candidates, error: selectError } = await selectQuery;
+    if (selectError) return { retargeted: 0, error: selectError.message };
+    if (!Array.isArray(candidates) || !candidates.length) return { retargeted: 0, error: null };
+    const nowIso = new Date().toISOString();
+    let retargeted = 0;
+    for (const row of candidates) {
+      const { data, error } = await supabase
+        .from('session_coordination')
+        .update({
+          target_session: liveAdam,
+          payload: { ...(row.payload || {}), retargeted_from: row.target_session, retargeted_at: nowIso },
+        })
+        .eq('id', row.id)
+        .is('acknowledged_at', null)
+        .eq('target_session', row.target_session)
+        .select('id');
+      if (error) return { retargeted, error: error.message };
+      if (Array.isArray(data) && data.length) retargeted += 1;
+    }
+    return { retargeted, error: null };
   } catch (e) {
     return { retargeted: 0, error: e && e.message ? e.message : String(e) };
   }
@@ -254,4 +326,8 @@ module.exports = {
   resolveAdamReplyTarget,
   retargetStaleAdamInbound,
   verifyReplyDelivered,
+  resolveRetiredAdamSeats,
+  applySuccessorInheritFilters,
+  ADAM_RETIRED_ROLE,
+  ADAM_MAIL_TTL_DAYS,
 };

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -191,6 +191,13 @@ const PRIORITY_EXEMPT_DIRECTIVE_KINDS = Object.freeze(['fence_notice']);
 // the same "mechanical, never authored" rationale as canary_request/comms_check.
 const ADAM_EXCLUDED_KINDS = Object.freeze(['canary_request', 'comms_check', 'ack', 'coordinator_ack', 'cross_party_ping']);
 
+// SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001: the metadata.role value a retired Adam seat
+// carries today (set by the clear_adam_flag JS-merge fallback in scripts/adam-register.cjs,
+// since the atomic RPC is unapplied). Canonical home here alongside ADAM_EXCLUDED_KINDS so
+// both CJS (lib/coordinator/adam-identity.cjs) and ESM (lib/adam/inbound-backlog-watchdog.js,
+// via createRequire) consumers share one literal instead of hand-rolling 'adam_retired'.
+const ADAM_RETIRED_ROLE = 'adam_retired';
+
 // SD-LEO-INFRA-COORDINATION-LANE-DRAIN-001 / FR-3: INFORMATIONAL kinds — deliberately undrained,
 // their lifecycle owned by RETENTION rather than by an ack path.
 //
@@ -484,6 +491,7 @@ module.exports = {
   ADVISORY_KINDS,
   PRIORITY_EXEMPT_DIRECTIVE_KINDS,
   ADAM_EXCLUDED_KINDS,
+  ADAM_RETIRED_ROLE,
   DRAIN_SETS,
   // SD-LEO-INFRA-COORDINATION-LANE-DRAIN-001 / FR-3: the actionable-vs-informational classification.
   INFORMATIONAL_KINDS,

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -1341,34 +1341,56 @@ async function main() {
 }
 
 /**
- * FR-4 (SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-C): on an Adam (re)register/restart, re-target
- * UNREAD session_coordination rows destined for an OLD Adam session to the NEW Adam session, so a
- * restarted Adam receives replies/directives the prior session never consumed. Mirrors the
- * coordinator broadcast-drain (lib/coordinator/resolve.cjs:233-238). IDEMPOTENT: gates on
- * read_at IS NULL and re-targets old->new, so a re-run matches nothing (no loop, no duplicate).
- * FAIL-OPEN: returns { moved:0, error? } on any error, never throws. Invoked unconditionally by
- * adam-register's registerAdam() whenever a stale prior Adam was retired.
+ * FR-4 (SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-C), widened by
+ * SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-1-FR-3): on an Adam (re)register/restart,
+ * re-target every UNACKED, non-handler-owned session_coordination row destined for an OLD Adam
+ * session to the NEW Adam session, so a restarted Adam receives replies/directives the prior
+ * session never consumed — including rows that were READ (auto-stamped or genuine) but never
+ * ACKED, and rows older than the old 24h window. IDEMPOTENT: gates on acknowledged_at IS NULL
+ * (an acked row never moves) and re-targets old->new via the shared FR-1 predicate
+ * (applySuccessorInheritFilters), so a re-run over the same rows matches nothing. Stamps
+ * payload.retargeted_from/retargeted_at on every moved row. FAIL-OPEN: returns
+ * { moved:0, byKind:{}, error? } on any error, never throws.
  * @param {object} supabase
  * @param {{ newSessionId: string, oldSessionIds: string[] }} p
- * @returns {Promise<{ moved: number, error?: string }>}
+ * @returns {Promise<{ moved: number, byKind: Object<string,number>, error?: string }>}
  */
 async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {}) {
-  if (!supabase || !newSessionId || !Array.isArray(oldSessionIds)) return { moved: 0 };
+  if (!supabase || !newSessionId || !Array.isArray(oldSessionIds)) return { moved: 0, byKind: {} };
   const olds = oldSessionIds.filter((s) => typeof s === 'string' && s && s !== newSessionId);
-  if (!olds.length) return { moved: 0 };
+  if (!olds.length) return { moved: 0, byKind: {} };
+  const { applySuccessorInheritFilters } = require('../lib/coordinator/adam-identity.cjs');
   try {
-    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-    const { data, error } = await supabase
-      .from('session_coordination')
-      .update({ target_session: newSessionId })
-      .in('target_session', olds)
-      .is('read_at', null)            // only UNREAD rows → idempotent (consumed rows never re-move)
-      .gte('created_at', cutoff)
-      .select('id');
-    if (error) return { moved: 0, error: error.message };
-    return { moved: Array.isArray(data) ? data.length : 0 };
+    const selectQuery = applySuccessorInheritFilters(
+      supabase.from('session_coordination').select('id, payload, target_session').in('target_session', olds),
+    );
+    const { data: candidates, error: selectError } = await selectQuery;
+    if (selectError) return { moved: 0, byKind: {}, error: selectError.message };
+    if (!Array.isArray(candidates) || !candidates.length) return { moved: 0, byKind: {} };
+    const nowIso = new Date().toISOString();
+    let moved = 0;
+    const byKind = {};
+    for (const row of candidates) {
+      const { data, error } = await supabase
+        .from('session_coordination')
+        .update({
+          target_session: newSessionId,
+          payload: { ...(row.payload || {}), retargeted_from: row.target_session, retargeted_at: nowIso },
+        })
+        .eq('id', row.id)
+        .is('acknowledged_at', null)
+        .eq('target_session', row.target_session)
+        .select('id');
+      if (error) return { moved, byKind, error: error.message };
+      if (Array.isArray(data) && data.length) {
+        moved += 1;
+        const kind = (row.payload && row.payload.kind) || 'unknown';
+        byKind[kind] = (byKind[kind] || 0) + 1;
+      }
+    }
+    return { moved, byKind };
   } catch (e) {
-    return { moved: 0, error: e && e.message ? e.message : String(e) };
+    return { moved: 0, byKind: {}, error: e && e.message ? e.message : String(e) };
   }
 }
 

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -41,7 +41,7 @@ const { contractReadVerdict, contractLineCount, singleReadFit } = require('../li
 // fetchAllAdamsStrict (not fetchFreshAdams) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
 // discipline review): a FAILED prior read must REFUSE registration, never read as "no priors".
-const { fetchAllAdamsStrict, decideSingleAdamGuard, isFresh } = require('../lib/coordinator/adam-identity.cjs');
+const { fetchAllAdamsStrict, decideSingleAdamGuard, isFresh, resolveRetiredAdamSeats } = require('../lib/coordinator/adam-identity.cjs');
 // FR-4: re-target a retired prior Adam's unread inbound to the new session (comms survive a restart).
 const { drainAdamOutbound } = require('./adam-advisory.cjs');
 
@@ -213,13 +213,19 @@ async function registerAdam(supabase, sessionId, opts = {}) {
     }
   }
   if (retired.length) action = action === 'tagged_fallback' ? 'tagged_after_retire_fallback' : 'tagged_after_retire';
-  // FR-4: re-target the retired prior Adam(s)' unread inbound to this new session (comms survive
-  // the handoff) — including priors retired via the JS-merge fallback above. Fail-open + idempotent;
-  // a drain error never fails the registration.
+  // FR-4, widened by SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-2): re-target every retired
+  // Adam seat's stranded inbound to this new session, not only priors retired IN THIS CALL — a
+  // seat's backlog is otherwise only ever attempted once, at the moment it retires, and anything
+  // the predicate missed then was orphaned forever. Decoupled from `retired.length` on purpose:
+  // the common register call retires nobody locally but may still have historical backlog to sweep.
+  // Fail-open + idempotent; a drain error never fails the registration.
   let drained = 0;
-  if (retired.length) {
-    const d = await drainAdamOutbound(supabase, { newSessionId: sessionId, oldSessionIds: retired });
+  let inherited = {};
+  const { ids: allRetiredSeatIds, error: retiredSeatsError } = await resolveRetiredAdamSeats(supabase);
+  if (!retiredSeatsError && allRetiredSeatIds.length) {
+    const d = await drainAdamOutbound(supabase, { newSessionId: sessionId, oldSessionIds: allRetiredSeatIds });
     drained = (d && d.moved) || 0;
+    inherited = (d && d.byKind) || {};
   }
 
   // FR-2: mandatory fail-loud readback. A write that silently didn't land (RLS, CHECK constraint,
@@ -237,10 +243,10 @@ async function registerAdam(supabase, sessionId, opts = {}) {
     return { ok: false, action: 'error', error: `readback verification failed after registration write (action=${action}): tag not confirmed on the row.` };
   }
 
-  return { ok: true, action, session_id: sessionId, role: ADAM_ROLE, non_fleet: true, retired, drained,
+  return { ok: true, action, session_id: sessionId, role: ADAM_ROLE, non_fleet: true, retired, drained, inherited,
     retire_fallback_used: retireFallbackUsed.length ? retireFallbackUsed : undefined,
     retire_blocked: retireBlocked || undefined,
-    message: `Registered as the single Adam${retired.length ? ` (retired stale prior(s): ${retired.join(', ')}; re-targeted ${drained} inbound row(s))` : ''}${retireFallbackUsed.length ? ` [clear_adam_flag RPC absent — retired via JS-merge fallback; apply the chairman-gated migration for atomic clears]` : ''}${retireBlocked ? ' — WARNING: a stale prior could NOT be retired (see retire_blocked)' : ''}${fallbackReason ? ` — fail-soft JS merge (set_adam_flag RPC ${fallbackReason}; apply the chairman-gated migration for atomic writes)` : ' via atomic set_adam_flag'}.` };
+    message: `Registered as the single Adam${retired.length ? ` (retired stale prior(s): ${retired.join(', ')})` : ''}${drained ? ` — inherited ${drained} row(s) from retired seat(s) (${Object.entries(inherited).map(([k, n]) => `${k}:${n}`).join(', ')})` : ''}${retireFallbackUsed.length ? ` [clear_adam_flag RPC absent — retired via JS-merge fallback; apply the chairman-gated migration for atomic clears]` : ''}${retireBlocked ? ' — WARNING: a stale prior could NOT be retired (see retire_blocked)' : ''}${fallbackReason ? ` — fail-soft JS merge (set_adam_flag RPC ${fallbackReason}; apply the chairman-gated migration for atomic writes)` : ' via atomic set_adam_flag'}.` };
 }
 
 /**

--- a/scripts/one-off/_testing-write-result-sd-leo-infra-adam-handoff-mail-forwarding-001-plan-to-exec.mjs
+++ b/scripts/one-off/_testing-write-result-sd-leo-infra-adam-handoff-mail-forwarding-001-plan-to-exec.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * One-off: TESTING sub-agent PLAN-TO-EXEC verdict (test STRATEGY / plan review) for
+ * SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001.
+ *
+ * Canonical evidence path per CLAUDE.md prologue rule 11:
+ * resolveSubAgentRepo + applySubAgentRepoVerdict (metadata.repo_path / executed_from_cwd),
+ * then storeSubAgentResults. No hand-rolled INSERT, no top-level repo_path column.
+ *
+ * Run FROM the worktree so executed_from_cwd stamps the worktree.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = 'ae41dc6c-42fe-4d63-b9c5-c6b40c7f91f8';
+const SD_KEY = 'SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001';
+
+const findings = [
+  {
+    id: 'T-1-PRD-misattributes-makeSb-there-are-SIX-filter-blind-doubles-not-one',
+    severity: 'HIGH',
+    summary: 'INDEPENDENTLY VERIFIED BY FULL SOURCE READ, NOT BY TRUSTING THE PRD. The PRD FR-6 says "The shared `makeSb` test helper (tests/unit/coordination/adam-singleton.test.js)". BOTH the location and the word "shared" are WRONG. makeSb is defined at tests/unit/coordinator/adam-reply-target-integrity.test.js:17-50. tests/unit/coordination/adam-singleton.test.js contains NO makeSb; it defines two DIFFERENT inline helpers, `stub` (:40-56) and `regStub` (:153-205), plus a third anonymous inline `sb` literal inside the drainAdamOutbound describe (:298-303). There is NO shared helper anywhere — every double is inline and per-file. The PRD SUBSTANTIVE claim is nonetheless CONFIRMED for all of them: .eq()/.is()/.gte()/.filter()/.in() are pure `return chain` passthroughs that record nothing and filter nothing; the canned fixture array is resolved regardless of any predicate. COMPLETE INVENTORY of filter-blind doubles this SD must touch (SIX across FIVE files, not one): (1) makeSb — tests/unit/coordinator/adam-reply-target-integrity.test.js:17; (2) stub — tests/unit/coordination/adam-singleton.test.js:40; (3) regStub — tests/unit/coordination/adam-singleton.test.js:153; (4) inline sb — tests/unit/coordination/adam-singleton.test.js:298; (5) stub — scripts/adam-register.test.js:41; (6) fakeSupabase — tests/unit/adam/inbound-backlog-watchdog.test.js:61. EXEC MUST NOT go looking for makeSb in adam-singleton.test.js and conclude the PRD premise is false; it is true, just misfiled.'
+  },
+  {
+    id: 'T-2-baseline-established-163-of-163-green',
+    severity: 'INFO',
+    summary: 'PRE-CHANGE BASELINE CAPTURED IN THE WORKTREE (branch feat/SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001, HEAD 6e8bdb01bf50c9ce16382dad031b9dfdb8218908). The three files named in the task: `npx vitest run tests/unit/coordination/adam-singleton.test.js tests/unit/coordinator/adam-reply-target-integrity.test.js tests/unit/coordinator-ack-adam-reply-ordering.test.js` => 3 files / 48 tests / 48 passed / 0 failed (adam-singleton 29, adam-reply-target-integrity 10, coordinator-ack-adam-reply-ordering 9). THE TASK COMMAND UNDER-COVERS THE BLAST RADIUS. A grep for the symbols this SD changes (drainAdamOutbound|retargetStaleAdamInbound|resolveAdamSessionIds|registerAdam|inbound-backlog-watchdog|ADAM_EXCLUDED_KINDS) returns TWELVE test files. Extended baseline over all twelve: 12 files / 163 tests / 163 passed / 0 failed. The twelve are: scripts/adam-register.test.js, tests/static-guards/drain-set-registry-readers.test.js, tests/unit/adam-inbox-surface-not-stamp.test.js, tests/unit/adam/inbound-backlog-watchdog.test.js, tests/unit/adam/inbound-backlog.test.js, tests/unit/coordination/adam-singleton.test.js, tests/unit/coordination/adam-solomon-lane-probe.test.js, tests/unit/coordinator-ack-adam-reply-ordering.test.js, tests/unit/coordinator/adam-reply-target-integrity.test.js, tests/unit/escalation/aggregate.test.js, tests/unit/fleet/drain-sets-adam-excluded-kinds.test.js, tests/unit/sourcing-engine/adam-direct-registry.test.js. EXEC SHOULD RUN THE TWELVE-FILE SET, not the three-file set, as its regression gate.'
+  },
+  {
+    id: 'T-3-worktree-vitest-was-UNRUNNABLE-truncated-rolldown-binding-repaired',
+    severity: 'HIGH',
+    summary: 'ENVIRONMENT DEFECT FOUND AND FIXED BEFORE THE BASELINE COULD BE TAKEN — EXEC MUST KNOW THIS. The first baseline attempt failed at vitest STARTUP, not at any test: "Cannot find native binding ... rolldown-binding.win32-x64-msvc.node is not a valid Win32 application" (ERR_DLOPEN_FAILED). Root cause measured: the worktree node_modules carried a TRUNCATED native binding — 6,616,064 bytes at .worktrees/SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001/node_modules/@rolldown/binding-win32-x64-msvc/rolldown-binding.win32-x64-msvc.node versus 24,350,208 bytes for the same file in the main repo (a partial/interrupted npm install in the worktree, dated Aug 15 20:24). REPAIRED by copying the intact 24,350,208-byte binding from the main repo into the worktree; vitest then started and ran clean. THIS IS A WORKTREE-LOCAL INSTALL DEFECT, NOT A CODE DEFECT — nothing in the SD caused it. Recorded because (a) a fresh worktree for this SD may reproduce it and EXEC would otherwise read "0 tests ran" as a code problem, and (b) a startup error yields NO test output at all, which is indistinguishable from a suite that does not exist. If EXEC sees it again: copy the binding from the main repo rather than a full reinstall.'
+  },
+  {
+    id: 'T-4-CRITICAL-FR-2-does-not-remove-the-if-retired-length-guard-so-it-achieves-nothing',
+    severity: 'CRITICAL',
+    summary: 'THE ONE FINDING THAT DECIDES WHETHER FR-2 WORKS AT ALL. scripts/adam-register.cjs gates the entire drain on `if (retired.length) { const d = await drainAdamOutbound(...); drained = (d && d.moved) || 0; }` (the block immediately after the retire loop, around :220-224). FR-2 changes WHAT is passed as oldSessionIds (full resolved retired-seat list instead of the local retired[] array) but says NOTHING about the enclosing guard. WITH THE GUARD LEFT IN PLACE, FR-2 IS A NO-OP IN THE COMMON CASE: the overwhelmingly normal register path has no stale prior to retire, so decision.retire is empty, retired[] stays empty, the guard is false, and drainAdamOutbound is NEVER CALLED — no matter how many retired seats resolveRetiredAdamSeats would have found. FR-2 stated purpose is verbatim "a seat leftover backlog is now retried on EVERY FUTURE REGISTER, not abandoned after one narrow attempt"; that purpose is defeated by the guard, because the only registers that would drain are exactly the ones that already drained under the old behaviour. Resolving the full population is useless if the call site is still conditioned on this call having retired someone. REQUIRED PRD AMENDMENT: FR-2 must explicitly state the `if (retired.length)` guard is REPLACED by a guard on the RESOLVED list being non-empty (drain whenever resolveRetiredAdamSeats returns seats, regardless of whether this invocation retired anyone). COMPOUNDING: NO test scenario covers this. TS-2 asserts inheritance across all retired seats at the drainAdamOutbound unit level, and TS-7 exercises the register JSON over a multi-seat fixture — but neither pins the ZERO-LOCAL-RETIREMENTS case, which is the only shape that catches the guard. See T-11(a) for the exact test to add.'
+  },
+  {
+    id: 'T-5-nine-existing-tests-WILL-break-by-design-enumerated-so-EXEC-does-not-mistake-them-for-regressions',
+    severity: 'HIGH',
+    summary: 'EXACT PRE-COMPUTED BREAKAGE LIST, DERIVED BY READING EACH DOUBLE METHOD SURFACE AGAINST THE NEW PREDICATE CHAINS. These are LEGITIMATE breakages (the tests pin the OLD predicate/update shape) and MUST be rewritten against the fixture-filtering double — they must NOT be "fixed" by loosening assertions or by adding no-op methods to the old stubs, which would silently restore filter-blindness. (A) tests/unit/coordination/adam-singleton.test.js :294-315, describe "drainAdamOutbound (FR-4 idempotent re-target)", 2 tests. Its inline sb.select() RESOLVES A PROMISE DIRECTLY, so FR-3 select-first chain .from().select(...).in(...) calls .in() on a Promise => TypeError. Additionally `expect(captured.patch).toEqual({target_session:"new"})` pins the single-bulk-update shape FR-3 replaces with select-then-per-row-update, and `toEqual({moved:0})` on the short-circuit paths breaks if the early return gains byKind (see T-10 note on return shape). (B) tests/unit/coordination/adam-singleton.test.js :232-260, 2 registerAdam tests asserting `drained: 2` / `drained: 1` and `calls.drainSelect === 1`. regStub TOP-LEVEL chain (:158-192) has NO .in() method (only the update sub-chain has one), so the FR-3 select-first drain TypeErrors. (C) tests/unit/coordinator/adam-reply-target-integrity.test.js :79-108, describe "FR-2 retargetStaleAdamInbound", 4 tests. makeSb builder method surface is exactly {select,gte,filter,eq,is,order,range,update,maybeSingle,then} — THERE IS NO .or(). FR-4 adds .or() => "builder.or is not a function". Independently, FR-4 retired-seat gate will resolve "stale" as NOT retired (freshAdams fixture carries role:"adam"), so the count assertions (retargeted 2, and the error-surfacing test) fail on the verdict too. (D) scripts/adam-register.test.js :41-77, `stub` chain is {select,eq,filter,order,range,maybeSingle,update,insert} — no .in(), no .is(), no .gte(), no .or(); it breaks as soon as the register path calls resolveRetiredAdamSeats and/or the select-first drain. EXPECTED TOTAL: ~8-9 of the 163 baseline tests. EVERYTHING ELSE (~154) MUST STAY GREEN. DELIBERATE KEEPER: the pin at adam-reply-target-integrity.test.js:102-107 `expect(patch).toEqual({target_session:"live"})` SURVIVES under the PRD as written (FR-4 adds no payload stamping) — but see T-9, which recommends a change that would deliberately break it. NOT AFFECTED: tests/unit/adam/inbound-backlog-watchdog.test.js fakeSupabase already has no-op .in()/.or(), so FR-7 will not crash it — which is precisely the problem, see T-8.'
+  },
+  {
+    id: 'T-6-ANSWER-yes-.or-is-mandatory-and-the-PRD-method-list-is-materially-incomplete',
+    severity: 'CRITICAL',
+    summary: 'DIRECT ANSWER TO THE FR-6 DESIGN QUESTION: YES, .or() IS MANDATORY, AND THE PRD FIVE-METHOD LIST (.eq/.is/.in/.gte/.or) IS NOT SUFFICIENT TO RUN THE TESTS IT SPECIFIES. Both FR-3 and FR-4 add .or("payload->>kind.is.null,payload->>kind.not.in.(...)") modelled on scripts/coordinator-hourly-review.cjs:622 (confirmed verbatim at source). Without a REAL .or(), TS-3 ("never moves any of the 5 ADAM_EXCLUDED_KINDS") is UNPROVABLE — it would pass identically whether or not EXEC wrote the exclusion filter, reproducing the exact blindness FR-6 exists to cure, one layer up. MEASURED FULL REQUIREMENT, beyond the PRD five: (1) .order() + .range(from,to) WITH SHORT-PAGE-EXIT SEMANTICS — non-optional, because FR-1 resolveRetiredAdamSeats is specified as a PAGINATED select (lib/db/fetch-all-paginated.mjs ends every page .order(...).range(from,to)); without range the resolver test cannot execute at all. (2) POSTGREST JSON-PATH COLUMN ACCESSORS — `metadata->>role` for the resolver and `payload->>kind` for both movers. A plain row[col] lookup RESOLVES NEITHER; the double needs a getCol() that splits on "->>" and walks the nested object (and String-coerces, since ->> yields text). (3) .or() must parse the PostgREST FILTER-STRING GRAMMAR, not just accept the string: comma-separated col.op.val clauses, the `is.null` form, and the `not.in.(a,b,c)` parenthesised-list form. (4) THE UPDATE PATH must support .update(patch).eq(...).is(...).select("id") and return ONLY GENUINELY-AFFECTED ROWS — this is the sole way TR-5 (re-assert the safety predicate at write time) becomes testable; if the double returns the patch unconditionally, TR-5 is unobservable and EXEC could ship .eq("id", row.id) alone with every test green. (5) `payload: null` must not throw in the accessor (see T-11c). STRONG DESIGN DIRECTIVE: THE DOUBLE MUST THROW ON ANY FILTER EXPRESSION IT DOES NOT UNDERSTAND, never silently pass rows through. A permissive fallback re-creates filter-blindness inside the fixture built to cure it — the obvious fix for a blind guard is usually blind too. IN-REPO PRECEDENT TO COPY: tests/unit/qf-claim-cas.test.js makeFakeSupabase THROWS on any unrecognised .or() shape as an explicit anti-drift measure. That is the pattern.'
+  },
+  {
+    id: 'T-7-reuse-survey-NO-reusable-filtering-double-exists-three-patterns-to-lift-build-it-ONCE',
+    severity: 'HIGH',
+    summary: 'ANSWER TO "DOES SUCH A DOUBLE ALREADY EXIST": NO. Searched tests/, lib/, scripts/, __tests__, tests/helpers, tests/fixtures, tests/factories, tests/support for real row-filtering query builders (grep over rows.filter(, applyFilter, fakeSupabase, makeSupabase, createFakeSb, fixtureDb, memoryDb, queryBuilder, _rows, and stubs defining .or(). THE REPO BLESSED SHARED HELPER IS NOT REUSABLE: tests/helpers/supabase-chain-mock.js createSupabaseChainMock() is a pure vi.fn(() => chain) passthrough with ZERO filtering — it is the same defect class, already centralised. Same for tests/factories/validator-context-factory.js createMockSupabase(), tests/fixtures/stage-worker-io-recorder.js makeRecordingSupabase(), tests/unit/foresight/workflow/test-helpers.js. Roughly sixty INLINE doubles do partial real filtering, but not one covers the required matrix (eq/is/in/gte + ->> JSON path + .or() filter-string + .order().range() + affected-rows update). THREE PATTERNS TO LIFT FROM, and what to take from each: (1) tests/unit/worker-checkin-ranked-window.test.js makeStub (:25) — BEST FILTER ENGINE: real eq/neq/is(null-aware)/in/gte/lte/gt/lt via a preds[] array applied at read time, AND real "->>" handling in getCol() with quote-stripping and String coercion. Take the preds[] engine and getCol(). Its .or() is a DELIBERATE NO-OP at :97 and .range() is a no-op — do not inherit those. (2) tests/unit/chairman/sms-outbound-reconcile.test.js parseOrFilter/matchesOrClause/applyFilters (:39-120) — THE ONLY GENUINE POSTGREST .or() STRING PARSER APPLIED TO ROWS IN THIS REPO, plus real not(col,"in","(a,b)") literal-list parsing, applied to BOTH select and update paths. Take the or-parser. It has no ->> and no range. (3) tests/unit/roadmap/plan-check-uncapped-pagination.test.js makeRangeAwareSupabase — BEST .order().range(f,t) semantics including a honorRange:false mode modelling the PostgREST 1000-row cap. Take range. ALSO RELEVANT: tests/unit/adam/adam-coordinator-health.test.js makeFakeSupabase (:48) already combines ->> jsonbPath eq + not(col,op,val) + cap modelling and is in the SAME adam test directory; scripts/three-way-comms-drill.mjs makeMemoryDb (:88) is the only EXPORTED double combining ->> with .order().range(), but is hard-wired to session_coordination + claude_sessions and does eq only. NOTE lib/db/fetch-all-paginated.mjs own test (tests/unit/db/fetch-all-paginated.test.js makeRelation) models pagination with NO filter methods at all, by design. PROCESS RECOMMENDATION, AND IT IS THE SINGLE-REPRESENTATION CALL: this SD touches SIX filter-blind doubles across FIVE files (T-1). BUILD THE FILTERING DOUBLE ONCE AS AN EXPORTED HELPER (e.g. tests/helpers/filtering-supabase-mock.js) rather than authoring a sixth inline copy. The repo already demonstrates the cost of not doing this — worker-checkin-ranked-window / -newest-window / -fleet-critical-window each carry a near-identical COPY-PASTED engine that must now be maintained in triplicate. Cheap now, expensive later. This modestly increases the test LOC beyond TR-3 250-350 estimate; PLAN should accept that rather than trim the double.'
+  },
+  {
+    id: 'T-8-TS-8-and-AC-13-are-FALSE-GREEN-as-specified-the-SD-commits-its-own-defect-class',
+    severity: 'CRITICAL',
+    summary: 'TS-8 AND AC-13 CANNOT OBSERVE THEIR SUBJECT AND WOULD PASS EVEN IF FR-7 WERE NEVER IMPLEMENTED. Read at source: tests/unit/adam/inbound-backlog-watchdog.test.js fakeSupabase (:61-92) implements select/eq/in/is/or/order as `return builder` NO-OPS, and BOTH its resolution paths — range(from,to) at :76-79 and then() at :85-89 — return the injected adamIds array VERBATIM, with no reference to any role filter. So TS-8 ("fixture with both role=adam and role=adam_retired rows => both are returned") is satisfied by the FIXTURE, not by the code: seed adamIds with two ids and it passes whether FR-7 changed .eq("metadata->>role","adam") to .in("metadata->>role",[LIVE,RETIRED]) or left it untouched. Worse, the fixture as currently shaped does not even CARRY roles — it maps ids to {session_id} objects with no metadata at all, so a role-bearing fixture cannot be expressed without changing the fake. AND FR-6 DOES NOT SCOPE THIS FILE: FR-6 enumerates exactly four new/updated test groups (resolveRetiredAdamSeats, drainAdamOutbound, retargetStaleAdamInbound, adam-register JSON) — the watchdog is not among them. As written the SD therefore ships AC-13 behind a test that runs but cannot see what it asserts, which is the SAME DEFECT CLASS THE SD EXISTS TO CLOSE, committed by the SD itself. REQUIRED FIX, either: (a) add tests/unit/adam/inbound-backlog-watchdog.test.js to FR-6 scope and seed fakeSupabase with role-bearing claude_sessions rows filtered for real, or (b) reuse the new shared filtering double (T-7) there. Option (b) is strictly better and is a further argument for building the double once.'
+  },
+  {
+    id: 'T-9-FR-4-carries-the-only-HIGH-risk-and-is-the-ONLY-mover-with-no-forensic-breadcrumb',
+    severity: 'HIGH',
+    summary: 'THE PROVENANCE ASYMMETRY IS BACKWARDS. FR-3/AC-5 stamps payload.retargeted_from + payload.retargeted_at on every row drainAdamOutbound moves, and FR-3 rollback plan explicitly DEPENDS on it: "every row it moved is identifiable afterward via payload.retargeted_from/retargeted_at for manual remediation". FR-4 stamps NOTHING — yet FR-4 carries the PRD ONLY severity:high risk (the sender_type widening / inbox-hijack blast radius, inherited from VALIDATION V-6), and its rollback plan offers NO means of identifying what it moved: "revert this one commit" restores the filter but leaves already-moved rows unattributable. So the SAFE mover is forensically traceable and the DANGEROUS one is not. RECOMMENDATION: FR-4 should stamp the same retargeted_from/retargeted_at provenance. HONEST COST, so PLAN can decide with it in view: (1) it converts retargetStaleAdamInbound from a single bulk .update() into the same select-then-per-row-update shape as FR-3, because jsonb cannot be partially merged in a chained update — the PRD already establishes exactly this constraint for FR-3, so the machinery is being built anyway and reuse is cheap; (2) it DELIBERATELY BREAKS the regression pin at tests/unit/coordinator/adam-reply-target-integrity.test.js:102-107, `expect(patch).toEqual({target_session:"live"})`, placed by SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-3. That pin INTENT was "never widen the patch to sender_session/created_at" — adding retargeted_from/at is consistent with the intent but violates the literal assertion, so it must be updated DELIBERATELY with a comment naming this SD, never silently relaxed. This is a PLAN decision, not an EXEC one. Flagged as a strong recommendation, NOT a go/no-go blocker.'
+  },
+  {
+    id: 'T-10-PRD-internally-contradicts-itself-on-exporting-ACK_TTL_DAYS',
+    severity: 'MEDIUM',
+    summary: 'CONTRADICTION EXEC WILL HIT ON STEP 1. FR-3 says verbatim "DO NOT export ACK_TTL_DAYS from lib/retention/session-coordination-ack-convergence.js" and TR-4 is titled "ACK_TTL_DAYS stays local to each module (no cross CJS/ESM export)" — both directing a locally-duplicated ADAM_MAIL_TTL_DAYS with a comment cross-reference. BUT implementation_approach.steps[0] says "Add ADAM_RETIRED_ROLE to lib/fleet/worker-status.cjs; EXPORT ACK_TTL_DAYS from lib/retention/session-coordination-ack-convergence.js", and risks[3] is entirely premised on that export existing ("FR-3 requires exporting ACK_TTL_DAYS ... crossing a module boundary that previously kept this constant local/unexported"). RESOLUTION FOR EXEC: follow FR-3 + TR-4 (the normative requirement sections); treat implementation_approach.steps[0] and risks[3] as STALE drafting residue from an earlier design. VERIFIED AT SOURCE: lib/retention/session-coordination-ack-convergence.js:21 is `const ACK_TTL_DAYS = 14;` with NO export keyword, in an ESM module whose two would-be consumers (scripts/adam-advisory.cjs, lib/coordinator/adam-identity.cjs) are both CJS — TR-4 reasoning is correct on the merits. CONSEQUENCE FOR AC-14: because the constant is not exported, the consistency test CANNOT import it; it must read the FILE TEXT and regex the literal. GUIDANCE: anchor on /const\\s+ACK_TTL_DAYS\\s*=\\s*(\\d+)/ and assert the PARSED NUMBER equals the parsed ADAM_MAIL_TTL_DAYS literal from each CJS mover — never a fixed character slice, because a positional source slice is a guard whose subject moves the first time a line is added above it. SECOND-ORDER: also assert the regex MATCHED at all (a non-matching regex yields null and a null===null comparison passes vacuously), and fail loudly if either file stops containing the constant.'
+  },
+  {
+    id: 'T-11-eight-test-scenario-gaps-four-of-them-leave-a-named-requirement-with-zero-coverage',
+    severity: 'HIGH',
+    summary: 'TS-1..TS-8 GAP ANALYSIS. (a) MISSING, AND IT IS THE ONE THAT CATCHES T-4: register invoked with ZERO local retirements while retired seats EXIST in the fixture => drainAdamOutbound must STILL run and still move rows. No current scenario has this shape (TS-2 is unit-level on the mover; TS-7 exercises the register JSON but over a fixture that presumably retires). Without it the `if (retired.length)` guard survives untested and FR-2 ships as a no-op. (b) MISSING — MULTIPLE RETIRED SEATS IN ONE REGISTER CALL (explicitly asked): TS-2 says "ALL retired seats" and TS-7 says "multi-seat" but nothing pins that oldSessionIds actually CONTAINS more than one id and that rows at EACH seat move. Add: 3 retired seats, rows at each, all move, byKind aggregates ACROSS seats (not per-seat). (c) MISSING — A ROW WITH payload.kind ABSENT ENTIRELY (explicitly asked), and this is the HIGHEST-VALUE missing case. The .or() is specifically NULL-TOLERANT (payload->>kind.is.null) precisely because, in the words of the comment above the reference implementation at scripts/coordinator-hourly-review.cjs:620, "a bare NOT IN would silently drop kind-less rows". TS-3 only covers the 5 named excluded kinds, so a bare .not.in() regression would pass every scenario. Add TWO rows: payload:{} (kind key absent) and payload:null (payload column null) — BOTH MUST MOVE. The payload:null case additionally proves the double accessor does not throw. (d) MISSING — TR-5 CONCURRENT-UPDATE RACE (explicitly asked): TR-5 is a NAMED TECHNICAL REQUIREMENT WITH NO TEST SCENARIO AT ALL. Add: the double returns a row in the initial select, but by update time that row acknowledged_at is non-null (and a second variant where target_session has changed) => the per-row update affects ZERO rows => the row is NOT counted in moved and NOT counted in byKind. This is the only way to prove the re-assert actually re-asserts; without it EXEC can write .eq("id", row.id) alone and every other test stays green. (e) UNDER-SPECIFIED — TS-6: it names the unverified originator as "live role=adam or unrelated session" but OMITS THE REALISTIC MIDDLE CASE — a genuinely stale Adam that has NOT YET been marked adam_retired (went stale by heartbeat; no register has run to retire it). Under FR-4 fail-closed gate this now recovers ZERO rows where TODAY it recovers them. That is a REAL FUNCTIONAL NARROWING of the recovery path — deliberate and defensible, but currently undocumented and untested. Add a scenario pinning it so the tradeoff is visible in CI rather than discovered in production. (f) UNDER-SPECIFIED — TS-4 IDEMPOTENCY IS VACUOUS UNLESS THE DOUBLE IS STATEFUL: "a second run moves 0" passes trivially if the double never applied the FIRST run target_session mutation to its in-memory rows. The double MUST persist writes so the second run .in("target_session", olds) genuinely no longer matches. State this explicitly in the scenario or the test proves nothing. (g) MISSING — FAIL-OPEN / FAIL-CLOSED ERROR PATHS: both movers are contractually fail-open ({moved:0,error} / {retargeted:0,error}) and resolveRetiredAdamSeats is brand new, yet NO scenario covers "resolver returns an error". This is safety-relevant and asymmetric: a resolver ERROR must NOT be read as "no retired seats, proceed" and must NOT be read as "everything is retired" — both movers must FAIL CLOSED (move 0) and surface the error. Add it. (h) MISSING — AC-10 HAS NO TEST: AC-10 is phrased as "grep shows ... no independent hand-rolled lists", i.e. a manual check, not an executable assertion. Recommend a static-guard test asserting neither mover file contains a hand-rolled kind-array literal and both reference the shared constant. There is already an established home for exactly this pattern: tests/static-guards/drain-set-registry-readers.test.js (in the baseline set and currently green).'
+  },
+  {
+    id: 'T-12-drainAdamOutbound-short-circuit-return-shape-is-under-specified',
+    severity: 'LOW',
+    summary: 'MINOR BUT WILL CAUSE AN AVOIDABLE TEST CHURN. AC-6 requires drainAdamOutbound to return byKind alongside moved/error, and FR-3 states "moved/error keep their existing shape so scripts/adam-register.cjs (d && d.moved) || 0 keeps working unchanged". Neither says whether the EARLY-RETURN paths carry byKind. Today those paths return the bare object {moved: 0} (verified at scripts/adam-advisory.cjs, the three guards: no supabase / no newSessionId / non-array oldSessionIds, and the empty-olds guard), and the existing test asserts toEqual({moved:0}) EXACTLY. GUIDANCE: return {moved: 0, byKind: {}} CONSISTENTLY from every path including the short-circuits, and update the assertion deliberately. A byKind that is sometimes undefined forces every consumer — including FR-5 adam-register `inherited` field — to defend against it, which is how an optional field becomes a permanent conditional.'
+  }
+];
+
+const warnings = [
+  'The task-supplied baseline command covers 3 files / 48 tests. The measured blast radius is 12 files / 163 tests. Using the 3-file command as the regression gate would leave scripts/adam-register.test.js (which WILL break under FR-2/FR-3, see T-5D) and tests/unit/adam/inbound-backlog-watchdog.test.js (FR-7 target, see T-8) entirely outside the gate.',
+  'vitest could not START in this worktree before intervention (truncated rolldown native binding, 6.6MB vs 24.3MB). It was repaired by copying the intact binary from the main repo. A startup error produces no test output at all, which is indistinguishable from an empty suite — if EXEC sees zero results, check the binding before suspecting the code.',
+  'The PRD asserts makeSb lives in tests/unit/coordination/adam-singleton.test.js. It does not; it is in tests/unit/coordinator/adam-reply-target-integrity.test.js. The filter-blindness claim itself is CONFIRMED, but EXEC following the PRD path will not find the helper and may wrongly conclude the premise is false.',
+  'FR-6 scopes four test groups and omits the watchdog, yet TS-8/AC-13 target the watchdog. As specified, AC-13 would be satisfied by a test that cannot observe whether FR-7 was implemented.',
+  'PRD implementation_approach.steps[0] and risks[3] both assume ACK_TTL_DAYS is exported; FR-3 and TR-4 both forbid exporting it. EXEC must follow FR-3/TR-4 and ignore the stale approach/risk text.',
+  'TR-3 estimates 250-350 LOC. Building the filtering double ONCE as a shared exported helper (recommended, T-7) plus the eight added scenarios in T-11 will push the test portion higher. The test portion is the part that must not be trimmed — it is the entire mechanism by which this SD can demonstrate its own fix.'
+];
+
+const recommendations = [
+  'GO — EXEC may proceed. The baseline is green and reproducible (12 files / 163 tests), the PRD test strategy is directionally sound, and no finding blocks starting implementation.',
+  'RESOLVE BEFORE EXEC WRITES TESTS (T-4): amend FR-2 to state that the `if (retired.length)` guard at the adam-register.cjs drain call site is REPLACED by a guard on the RESOLVED retired-seat list. Without this one-line scope clarification FR-2 is a no-op on every register that does not itself retire a prior — which is the common case, and precisely the "orphan forever" gap FR-2 claims to close.',
+  'RESOLVE BEFORE EXEC WRITES TESTS (T-8): add tests/unit/adam/inbound-backlog-watchdog.test.js to FR-6 scope, or reuse the new shared double there. As specified, TS-8/AC-13 pass whether or not FR-7 is implemented.',
+  'BUILD THE FILTERING DOUBLE ONCE, AS AN EXPORTED HELPER (T-7), not as a sixth inline copy. Lift the preds[] engine + getCol() "->>" handling from tests/unit/worker-checkin-ranked-window.test.js:25, the PostgREST or-string parser from tests/unit/chairman/sms-outbound-reconcile.test.js:39-120, and .order().range() from tests/unit/roadmap/plan-check-uncapped-pagination.test.js. No reusable filtering double exists today; the repo blessed helper (tests/helpers/supabase-chain-mock.js) is itself a no-op passthrough.',
+  'THE DOUBLE MUST THROW ON ANY UNRECOGNISED FILTER EXPRESSION rather than passing rows through (T-6). Copy the anti-drift stance of tests/unit/qf-claim-cas.test.js makeFakeSupabase. A permissive fallback rebuilds filter-blindness inside the fixture built to cure it.',
+  'THE DOUBLE MUST SUPPORT MORE THAN THE FIVE METHODS THE PRD LISTS (T-6): add .order()+.range() with short-page-exit (FR-1 resolver is paginated and cannot otherwise run), PostgREST "->>" JSON-path accessors for metadata->>role and payload->>kind, a real .or() grammar parser (is.null and not.in.(a,b,c) forms), and an update path returning only genuinely-affected rows (the only way TR-5 becomes observable).',
+  'ADD THE EIGHT MISSING/UNDER-SPECIFIED SCENARIOS IN T-11. Four of them leave a named requirement with zero coverage: (a) zero-local-retirements register [catches T-4], (c) payload.kind absent / payload null [the null-tolerance the .or() exists for], (d) TR-5 concurrent-update race [TR-5 currently has NO scenario at all], (g) resolver-error fail-closed.',
+  'STRONGLY CONSIDER stamping retargeted_from/retargeted_at in FR-4 as well (T-9). Today the SAFE mover is forensically traceable and the one carrying the only HIGH risk is not. Accept that this converts FR-4 to select-then-per-row-update and deliberately breaks the pin at adam-reply-target-integrity.test.js:102-107 — update that pin with a comment naming this SD, never silently.',
+  'EXEC REGRESSION GATE: run the 12-file set, not the 3-file set. Expect ~8-9 deliberate breakages (enumerated in T-5) and ~154 tests that MUST stay green. Do NOT repair a T-5 breakage by adding a no-op method to the old stub — that restores the exact blindness this SD exists to remove.',
+  'Follow FR-3/TR-4 (no ACK_TTL_DAYS export) and implement AC-14 as a source-text regex pin anchored on /const\\s+ACK_TTL_DAYS\\s*=\\s*(\\d+)/, asserting the regex MATCHED before comparing (T-10).'
+];
+
+const summary = 'PLAN-TO-EXEC TESTING (test-strategy / plan review, pre-implementation): GO / CONDITIONAL_PASS (confidence 90) for SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001. BASELINE ESTABLISHED AND GREEN: the three files named in the task run 48/48 pass, but the measured blast radius is TWELVE files / 163 tests (163/163 pass) — EXEC should gate on the twelve. Taking the baseline first required repairing a truncated rolldown native binding in the worktree node_modules (6.6MB vs 24.3MB; vitest could not start at all — an environment defect, not a code one, recorded because a startup error is indistinguishable from an empty suite). PRD PREMISE INDEPENDENTLY VERIFIED, WITH A CORRECTION: the filter-blindness claim is TRUE — .eq()/.is()/.gte()/.in() are pure `return chain` passthroughs that record nothing and filter nothing — but makeSb is NOT in tests/unit/coordination/adam-singleton.test.js as FR-6 states; it is at tests/unit/coordinator/adam-reply-target-integrity.test.js:17. adam-singleton.test.js has two DIFFERENT helpers (stub :40, regStub :153) plus a third inline literal (:298). Nothing is shared. There are SIX filter-blind doubles across FIVE files, not one, and FR-6 scopes only some of them. TWO ITEMS SHOULD BE RESOLVED BEFORE EXEC WRITES TESTS. (1) CRITICAL — FR-2 IS A NO-OP AS WRITTEN: adam-register.cjs gates the drain on `if (retired.length)`, and FR-2 changes only what is PASSED, never the guard. The common register path retires nobody, so the drain is never called no matter how many seats resolveRetiredAdamSeats finds — which defeats FR-2 own stated purpose ("retried on every future register, not abandoned after one narrow attempt") exactly. No scenario covers the zero-local-retirements shape, so this would ship untested. (2) CRITICAL — TS-8/AC-13 ARE FALSE-GREEN: the watchdog fake (tests/unit/adam/inbound-backlog-watchdog.test.js:61) implements .eq/.in/.or as no-ops and returns its adamIds fixture verbatim from both resolution paths, so TS-8 passes whether or not FR-7 is implemented; FR-6 does not scope that file. The SD would commit the defect class it exists to close. ANSWER TO THE FR-6 DESIGN QUESTION: YES, .or() IS MANDATORY — both movers add .or("payload->>kind.is.null,payload->>kind.not.in.(...)") modelled on coordinator-hourly-review.cjs:622, and without a real .or() parser TS-3 (excluded kinds never move) is unprovable. The PRD five-method list (.eq/.is/.in/.gte/.or) is MATERIALLY INCOMPLETE: also required are .order()+.range() with short-page-exit (FR-1 resolver is paginated and cannot otherwise execute), PostgREST "->>" JSON-path accessors for metadata->>role and payload->>kind (a plain row[col] resolves neither), a real filter-string grammar parser for the is.null and not.in.(a,b,c) forms, and an update path returning only genuinely-affected rows — the last being the ONLY way TR-5 (re-assert at write time) becomes observable at all. THE DOUBLE MUST THROW ON UNRECOGNISED FILTERS, never pass through; precedent at tests/unit/qf-claim-cas.test.js. REUSE SURVEY: NO reusable filtering double exists — the repo blessed shared helper tests/helpers/supabase-chain-mock.js is itself a no-op passthrough, and ~60 inline doubles each cover a fragment. Lift the preds[]+getCol("->>") engine from tests/unit/worker-checkin-ranked-window.test.js:25, the only real PostgREST or-string parser from tests/unit/chairman/sms-outbound-reconcile.test.js:39-120, and range semantics from tests/unit/roadmap/plan-check-uncapped-pagination.test.js — and BUILD IT ONCE AS AN EXPORTED HELPER, since this SD touches six doubles and the repo already maintains one such engine in copy-pasted triplicate. EIGHT TS GAPS, four leaving a named requirement at zero coverage: zero-local-retirements register (catches gap 1); payload.kind absent AND payload null (the exact null-tolerance the .or() exists for — a bare NOT IN silently drops kind-less rows, per the reference implementation own comment); TR-5 concurrent-update race (a named TR with NO scenario whatsoever); resolver-error fail-closed. Also: multiple retired seats in one call, TS-6 missing the realistic "stale but not yet retired" middle case (FR-4 fail-closed gate genuinely NARROWS recovery there — deliberate but untested), TS-4 idempotency vacuous unless the double persists writes, and AC-10 phrased as a grep rather than an executable static guard (home already exists at tests/static-guards/drain-set-registry-readers.test.js). FURTHER: FR-4 carries the PRD only HIGH-severity risk yet is the ONLY mover with no retargeted_from/retargeted_at breadcrumb, so the safe mover is forensically traceable and the dangerous one is not — recommend stamping it, accepting that this converts FR-4 to select-then-per-row-update and deliberately breaks the pin at adam-reply-target-integrity.test.js:102-107. Finally, the PRD contradicts itself on ACK_TTL_DAYS (FR-3/TR-4 forbid the export; implementation_approach.steps[0] and risks[3] assume it) — follow FR-3/TR-4 and implement AC-14 as a regex source-pin that asserts it MATCHED before comparing. EXPECT ~8-9 DELIBERATE TEST BREAKAGES (enumerated with the exact method-surface cause for each) and ~154 that must stay green; a T-5 breakage must never be repaired by adding a no-op method to the old stub.';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+
+  const resolution = await resolveSubAgentRepo({
+    sdId: SD_KEY,
+    targetApplication: 'EHG_Engineer',
+    subAgentCode: 'TESTING',
+    supabase,
+  });
+
+  let results = {
+    verdict: 'CONDITIONAL_PASS',
+    confidence_score: 90,
+    findings,
+    warnings,
+    recommendations,
+    summary,
+    detailed_analysis: {
+      sd_key: SD_KEY,
+      review_type: 'PLAN_TO_EXEC_TEST_STRATEGY_REVIEW',
+      mode: 'pre-implementation (EXEC has not written code yet)',
+      branch: 'feat/SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001',
+      worktree_head: '6e8bdb01bf50c9ce16382dad031b9dfdb8218908',
+      baseline: {
+        task_named_3_files: {
+          command: 'npx vitest run tests/unit/coordination/adam-singleton.test.js tests/unit/coordinator/adam-reply-target-integrity.test.js tests/unit/coordinator-ack-adam-reply-ordering.test.js',
+          test_files: 3,
+          tests_total: 48,
+          passed: 48,
+          failed: 0,
+          per_file: {
+            'tests/unit/coordination/adam-singleton.test.js': 29,
+            'tests/unit/coordinator/adam-reply-target-integrity.test.js': 10,
+            'tests/unit/coordinator-ack-adam-reply-ordering.test.js': 9
+          }
+        },
+        measured_blast_radius_12_files: {
+          derivation: 'grep -rln for drainAdamOutbound|retargetStaleAdamInbound|resolveAdamSessionIds|registerAdam|inbound-backlog-watchdog|ADAM_EXCLUDED_KINDS across tests/ and scripts/*.test.js',
+          test_files: 12,
+          tests_total: 163,
+          passed: 163,
+          failed: 0,
+          files: [
+            'scripts/adam-register.test.js',
+            'tests/static-guards/drain-set-registry-readers.test.js',
+            'tests/unit/adam-inbox-surface-not-stamp.test.js',
+            'tests/unit/adam/inbound-backlog-watchdog.test.js',
+            'tests/unit/adam/inbound-backlog.test.js',
+            'tests/unit/coordination/adam-singleton.test.js',
+            'tests/unit/coordination/adam-solomon-lane-probe.test.js',
+            'tests/unit/coordinator-ack-adam-reply-ordering.test.js',
+            'tests/unit/coordinator/adam-reply-target-integrity.test.js',
+            'tests/unit/escalation/aggregate.test.js',
+            'tests/unit/fleet/drain-sets-adam-excluded-kinds.test.js',
+            'tests/unit/sourcing-engine/adam-direct-registry.test.js'
+          ]
+        },
+        environment_repair_required_before_baseline: 'worktree node_modules/@rolldown/binding-win32-x64-msvc/rolldown-binding.win32-x64-msvc.node was TRUNCATED (6,616,064 bytes vs 24,350,208 in the main repo); vitest failed at startup with ERR_DLOPEN_FAILED "not a valid Win32 application". Repaired by copying the intact binary from the main repo. Worktree-local install defect, not a code defect.'
+      },
+      filter_blind_double_inventory: {
+        'tests/unit/coordinator/adam-reply-target-integrity.test.js:17': 'makeSb — methods {select,gte,filter,eq,is,order,range,update,maybeSingle,then}; NO .or(); all filters no-op; only .update(patch) is recorded',
+        'tests/unit/coordination/adam-singleton.test.js:40': 'stub — {select,gte,filter,order,range}; all no-op',
+        'tests/unit/coordination/adam-singleton.test.js:153': 'regStub — top-level {select,eq,gte,filter,order,range,maybeSingle,insert,update}; NO .in() at top level (only on the update sub-chain); all filters no-op',
+        'tests/unit/coordination/adam-singleton.test.js:298': 'inline sb for the drainAdamOutbound describe — {update,in,is,gte,select}; select() resolves a Promise DIRECTLY so a select-first chain TypeErrors',
+        'scripts/adam-register.test.js:41': 'stub — {select,eq,filter,order,range,maybeSingle,update,insert}; NO .in()/.is()/.gte()/.or()',
+        'tests/unit/adam/inbound-backlog-watchdog.test.js:61': 'fakeSupabase — HAS .eq/.in/.is/.or but ALL are no-ops; range() and then() both return the adamIds fixture verbatim regardless of any role filter'
+      },
+      predicted_deliberate_breakages: {
+        count_estimate: '8-9 of 163',
+        must_stay_green: '~154',
+        detail: [
+          'adam-singleton.test.js:294-315 drainAdamOutbound describe (2 tests) — select-first chain TypeErrors on the inline sb; also pins the single-bulk-update patch shape FR-3 replaces',
+          'adam-singleton.test.js:232-260 registerAdam drained/drainSelect assertions (2 tests) — regStub top-level chain has no .in()',
+          'adam-reply-target-integrity.test.js:79-108 FR-2 retargetStaleAdamInbound describe (4 tests) — makeSb has no .or(); plus the retired-seat gate returns 0 for the "stale" fixture',
+          'scripts/adam-register.test.js stub (:41) — no .in()/.is()/.gte()/.or() once the register path calls resolveRetiredAdamSeats + the select-first drain'
+        ],
+        deliberate_keeper: 'adam-reply-target-integrity.test.js:102-107 (patch is ONLY {target_session}) SURVIVES under the PRD as written; it would break only if the T-9 provenance recommendation is adopted, in which case it must be updated deliberately with a comment.',
+        anti_pattern_warning: 'NEVER repair one of these by adding a no-op method to the old stub — that restores the exact filter-blindness this SD exists to remove.'
+      },
+      test_double_required_capability_matrix: {
+        filters: ['eq', 'is (null-aware)', 'in', 'gte', 'or (PostgREST filter-string grammar)'],
+        also_required_but_absent_from_PRD: ['select(columns)', 'order()', 'range(from,to) with short-page-exit', 'JSON-path accessors metadata->>role and payload->>kind', 'update(patch).eq().is().select("id") returning ONLY genuinely-affected rows', 'stateful writes so idempotency (TS-4) is not vacuous', 'tolerate payload === null without throwing'],
+        or_grammar_forms_needed: ['payload->>kind.is.null', 'payload->>kind.not.in.(canary_request,comms_check,ack,coordinator_ack,cross_party_ping)'],
+        fail_mode_directive: 'THROW on any unrecognised filter expression; never pass rows through. Precedent: tests/unit/qf-claim-cas.test.js makeFakeSupabase.'
+      },
+      reuse_survey: {
+        reusable_filtering_double_exists: false,
+        blessed_shared_helper_is_a_noop: 'tests/helpers/supabase-chain-mock.js createSupabaseChainMock() — every method vi.fn(() => chain), thenable resolves a fixed {data,error}; ZERO filtering',
+        other_noop_shared_helpers: ['tests/factories/validator-context-factory.js createMockSupabase()', 'tests/fixtures/stage-worker-io-recorder.js makeRecordingSupabase()', 'tests/unit/foresight/workflow/test-helpers.js createMockSupabase()'],
+        lift_from: {
+          'tests/unit/worker-checkin-ranked-window.test.js:25 (makeStub)': 'BEST filter engine — real eq/neq/is/in/gte/lte/gt/lt via preds[] applied at read time, AND real "->>" handling in getCol(). Its .or() (:97) and .range() are deliberate no-ops — do not inherit those.',
+          'tests/unit/chairman/sms-outbound-reconcile.test.js:39-120': 'ONLY genuine PostgREST .or() string parser applied to rows in this repo, plus real not(col,"in","(a,b)") list parsing, on both select and update paths. No "->>", no range.',
+          'tests/unit/roadmap/plan-check-uncapped-pagination.test.js (makeRangeAwareSupabase)': 'BEST .order().range(f,t) semantics incl. a honorRange:false PostgREST 1000-row cap mode.',
+          'tests/unit/adam/adam-coordinator-health.test.js:48 (makeFakeSupabase)': 'Already combines "->>" jsonbPath eq + not(col,op,val) + cap modelling, and lives in the SAME adam test directory.',
+          'scripts/three-way-comms-drill.mjs:88 (makeMemoryDb)': 'Only EXPORTED double combining "->>" with .order().range(), but hard-wired to session_coordination + claude_sessions and eq-only.'
+        },
+        note_on_fetch_all_paginated: 'tests/unit/db/fetch-all-paginated.test.js makeRelation implements ONLY .range(from,to) with no filter methods, by design (fetchAllPaginated takes an already-filtered relation factory). Pagination is exercised there; filtering is not.',
+        single_representation_recommendation: 'Build ONCE as an exported helper (e.g. tests/helpers/filtering-supabase-mock.js). This SD touches SIX doubles across FIVE files, and the repo already maintains a near-identical engine in copy-pasted triplicate across worker-checkin-ranked/newest/fleet-critical-window.'
+      },
+      test_scenario_gaps: {
+        'missing_zero_local_retirements_register': 'catches T-4 (the if (retired.length) guard). NOT covered by TS-2 or TS-7.',
+        'missing_multiple_retired_seats_one_call': 'TS-2/TS-7 imply it but nothing pins oldSessionIds.length > 1 or byKind aggregating ACROSS seats.',
+        'missing_payload_kind_absent_and_payload_null': 'HIGHEST-VALUE gap. The .or() is null-tolerant precisely because a bare NOT IN silently drops kind-less rows (per the comment at coordinator-hourly-review.cjs:620). TS-3 covers only the 5 named kinds, so a bare .not.in() regression passes everything.',
+        'missing_TR5_concurrent_update_race': 'TR-5 is a NAMED technical requirement with ZERO scenarios. Without it, .eq("id",row.id) alone passes every test.',
+        'missing_resolver_error_fail_closed': 'resolveRetiredAdamSeats erroring must not read as "no retired seats, proceed" NOR as "everything is retired". Both movers must move 0 and surface the error.',
+        'underspecified_TS6_stale_but_not_yet_retired': 'FR-4 fail-closed gate genuinely NARROWS recovery for an Adam that went stale by heartbeat but has not been retired. Deliberate, defensible, currently untested and undocumented.',
+        'underspecified_TS4_idempotency_vacuous': 'Passes trivially unless the double persists the first run target_session mutation.',
+        'missing_AC10_static_guard': 'AC-10 is phrased as a grep, not an executable assertion. Home already exists: tests/static-guards/drain-set-registry-readers.test.js.'
+      },
+      prd_defects_found: [
+        'FR-6 misattributes makeSb to tests/unit/coordination/adam-singleton.test.js (actual: tests/unit/coordinator/adam-reply-target-integrity.test.js:17) and calls it "shared" (it is inline and per-file). Substantive filter-blindness claim CONFIRMED.',
+        'FR-2 omits the if (retired.length) guard removal, making FR-2 a no-op on the common register path.',
+        'FR-6 scope omits tests/unit/adam/inbound-backlog-watchdog.test.js, leaving TS-8/AC-13 false-green.',
+        'implementation_approach.steps[0] and risks[3] assume ACK_TTL_DAYS is exported; FR-3 and TR-4 explicitly forbid it. FR-3/TR-4 are normative.',
+        'FR-3 leaves the short-circuit return shape ({moved:0} vs {moved:0,byKind:{}}) unspecified.',
+        'AC-5/FR-3 stamp provenance only on the SAFE mover; FR-4 carries the only HIGH-severity risk with no breadcrumb.'
+      ],
+      source_verification: {
+        'scripts/adam-advisory.cjs drainAdamOutbound': 'confirmed verbatim: .update({target_session:newSessionId}).in("target_session",olds).is("read_at",null).gte("created_at", now-24h).select("id") — single bulk update',
+        'scripts/adam-register.cjs drain call site': 'confirmed: `if (retired.length) { const d = await drainAdamOutbound(supabase,{newSessionId:sessionId, oldSessionIds:retired}); drained = (d && d.moved) || 0; }` — the guard FR-2 does not address',
+        'lib/coordinator/adam-identity.cjs retargetStaleAdamInbound': 'confirmed verbatim: .update({target_session:liveAdam}).eq("target_session",staleOriginator).eq("sender_type","coordinator").is("acknowledged_at",null).select("id")',
+        'lib/fleet/worker-status.cjs ADAM_EXCLUDED_KINDS': "confirmed Object.freeze(['canary_request','comms_check','ack','coordinator_ack','cross_party_ping']) — 5 entries",
+        'scripts/coordinator-hourly-review.cjs:622': "confirmed the reference .or('payload->>kind.is.null,payload->>kind.not.in.(' + ADAM_EXCLUDED_KINDS.join(',') + ')') with the comment above it warning a bare NOT IN would silently drop kind-less rows",
+        'lib/retention/session-coordination-ack-convergence.js:21': 'confirmed `const ACK_TTL_DAYS = 14;` — NOT exported, ESM module',
+        'lib/adam/inbound-backlog-watchdog.js resolveAdamSessionIds': 'confirmed .eq("metadata->>role","adam") inside fetchAllPaginated, docstring promises "EVERY historical role=adam session id"'
+      }
+    },
+    phase: 'PLAN-TO-EXEC',
+    validation_mode: 'prospective',
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+
+  const stored = await storeSubAgentResults(
+    'TESTING',
+    SD_ID,
+    { name: 'Enhanced QA Engineering Director (testing-agent)' },
+    results,
+    { sdKey: SD_KEY, phase: 'PLAN-TO-EXEC' }
+  );
+
+  console.log('VERDICT WRITTEN:');
+  console.log('  ID:', stored.id);
+  console.log('  verdict:', stored.verdict, '@ confidence', stored.confidence);
+  console.log('  phase:', stored.phase);
+  console.log('  created_at:', stored.created_at);
+  console.log('  repo_path:', stored.metadata?.repo_path);
+  console.log('  repo_resolved:', stored.metadata?.repo_resolved);
+  console.log('  executed_from_cwd:', stored.metadata?.executed_from_cwd);
+  process.exit(0);
+}
+
+main().catch(e => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/scripts/one-off/_validation-write-result-sd-leo-infra-adam-handoff-mail-forwarding-001-lead-to-plan.mjs
+++ b/scripts/one-off/_validation-write-result-sd-leo-infra-adam-handoff-mail-forwarding-001-lead-to-plan.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * One-off: VALIDATION sub-agent LEAD-TO-PLAN verdict for
+ * SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001.
+ *
+ * Canonical evidence path per CLAUDE.md prologue rule 11:
+ * resolveSubAgentRepo + applySubAgentRepoVerdict (metadata.repo_path / executed_from_cwd),
+ * then storeSubAgentResults. No hand-rolled INSERT, no top-level repo_path column.
+ *
+ * Run FROM the worktree so executed_from_cwd stamps the worktree.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = 'ae41dc6c-42fe-4d63-b9c5-c6b40c7f91f8';
+const SD_KEY = 'SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001';
+
+const findings = [
+  {
+    id: 'V-1-explore-claims-independently-reverified',
+    severity: 'INFO',
+    summary: 'ALL FOUR Explore claims independently re-verified by direct source read, not by trusting the summary. (a) lib/fleet/worker-status.cjs:192 ADAM_EXCLUDED_KINDS = Object.freeze([canary_request, comms_check, ack, coordinator_ack, cross_party_ping]) — FIVE entries, confirming the SD text naming only 3 is STALE (cross_party_ping was added by SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5; ack/coordinator_ack predate it). (b) scripts/adam-advisory.cjs:1355-1373 drainAdamOutbound predicate confirmed verbatim: .in(target_session, olds).is(read_at, null).gte(created_at, now-24h). (c) lib/coordinator/adam-identity.cjs:174-189 retargetStaleAdamInbound predicate confirmed verbatim: .eq(target_session, staleOriginator).eq(sender_type, coordinator).is(acknowledged_at, null). (d) Retirement-marker divergence confirmed: database/migrations/20260615_role_handoff_atomic_adam_flag.sql:33-41 clear_adam_flag DROPS role+adam_since+non_fleet (only when role=adam), while scripts/adam-register.cjs:208 JS-merge fallback sets {...priorMeta, role: adam_retired, non_fleet: true} — which PRESERVES adam_since via the spread. The two paths therefore leave DIFFERENT metadata residue, and the RPC path leaves NO positive marker at all.'
+  },
+  {
+    id: 'V-2-BLOCKING-kind-lives-in-payload-not-a-kind-column',
+    severity: 'HIGH',
+    summary: 'SCHEMA TRAP PLAN MUST NOT WALK INTO. session_coordination has NO `kind` column. Measured live columns: id, target_session, target_sd, message_type, subject, body, payload, sender_session, sender_type, created_at, expires_at, read_at, acknowledged_at, correlation_id, delivered_at. A select/filter on `kind` returns error "column session_coordination.kind does not exist". The ADAM_EXCLUDED_KINDS vocabulary is matched against payload->>kind — see the one existing SQL-level consumer, scripts/coordinator-hourly-review.cjs:622: .or(\'payload->>kind.is.null,payload->>kind.not.in.(\' + ADAM_EXCLUDED_KINDS.join(\',\') + \')\'). message_type is a COARSE envelope field (all 212 stranded rows measured message_type=INFO) and is NOT the kind discriminator. PLAN must write the exclusion as payload->>kind with a null-tolerant OR (a row with no payload.kind must be KEPT, not dropped — the existing consumer models this correctly). Note also that .not.in.() interpolates raw tokens, so PLAN should reuse the SAFE_KIND_TOKEN regex discipline already established by SD-LEO-INFRA-DRAIN-SET-REGISTRY-001-C FR-4 rather than interpolating unsanitized.'
+  },
+  {
+    id: 'V-3-premise-mechanism-CONFIRMED-severity-numbers-DO-NOT-REPRODUCE',
+    severity: 'HIGH',
+    summary: 'DEFECT MECHANISM CONFIRMED; SD SEVERITY FIGURES STALE. Live measurement (2026-08-16, service-role, server-side filters + exact counts, NOT an in-memory group over a capped page): claude_sessions has 13,108 rows total; role=adam:1, role=adam_retired:18, role=solomon:1, role=coordinator:0. Across ALL 18 retired Adam seats, session_coordination holds 213 rows, 212 with acknowledged_at IS NULL. Breakdown by payload.kind: cross_party_ping 210, solomon_ledger_pending_digest 1, coordinator_reply 1. So the ACTIONABLE stranded set right now is TWO rows, not the SD narrative\'s 28 (8 coordinator_reply, 10 coordinator_reminder, 1 coordinator_request, 1 review_request, 2 adam_action_required, 6 solomon adam_advisory) — none of coordinator_reminder / coordinator_request / review_request / adam_action_required / adam_advisory appear in the current stranded population at all. The SD\'s 148/28 figures were presumably measured at one register event against one seat and have since been consumed, expired, or drained. PLAN MUST RE-MEASURE at PRD time and MUST NOT encode 148/28 as acceptance criteria — inherited SD constraints must be measured before being encoded. This does NOT invalidate the SD: the mechanism is independently corroborated by code reading AND by lib/adam/inbound-backlog.js fetchInboundBacklog:192-198, whose docstring already documents this exact defect internally. It DOES mean the SD is lower-yield than its text implies, which is a LEAD scope-sizing input.'
+  },
+  {
+    id: 'V-4-read_at-is-the-dominant-leak-not-the-kind-list',
+    severity: 'HIGH',
+    summary: 'HIGHEST-YIELD FINDING, AND IT REFRAMES THE FIX. Of the 212 unacked rows stranded at retired seats, read_at IS NULL matches ZERO (212/212 have read_at set) and created_at >= now-24h matches ZERO (212/212 are older than the drain window). Therefore drainAdamOutbound as currently written would move EXACTLY 0 of the 212 currently-stranded rows — it is defeated twice over, by read_at AND by the 24h window, before the kind list is ever reached. The SD title already names this correctly ("drops read-but-unacked rows"); the kinds question is a SECOND-ORDER concern by comparison. IDEMPOTENCE IS SAFE TO SWITCH: drainAdamOutbound\'s docstring justifies read_at IS NULL as the idempotence guarantee ("consumed rows never re-move"), but that guarantee is actually carried by the .in(target_session, olds) clause — the new session is filtered out of olds (line 1357: s !== newSessionId), so a re-run matches nothing regardless of the read_at gate. PLAN can move to acknowledged_at IS NULL WITHOUT losing idempotence, and should say so explicitly in the PRD so a reviewer does not restore the read_at gate on idempotence grounds. The 24h window is the other half and must be widened or removed; if PLAN keeps a bound, it should be justified against ACK_TTL_DAYS=14 (lib/retention/session-coordination-ack-convergence.js:21, local/unexported) rather than left at 24h.'
+  },
+  {
+    id: 'V-5-sender_type-widening-blast-radius-tests-BLIND-runtime-REAL',
+    severity: 'HIGH',
+    summary: 'ANSWER TO THE BLAST-RADIUS QUESTION, TWO-PART. (A) TEST-LEVEL: ZERO existing tests break, but equally ZERO existing tests would CATCH a bad widening — this is fixture blindness, not coverage. tests/unit/coordinator/adam-reply-target-integrity.test.js\'s makeSb mock (lines 17-49) implements .eq(), .is(), .gte(), .filter(), .select() as NO-OP passthroughs that `return builder` and record NOTHING; only .update(patch) is recorded (into calls.updates). The single pin at line 103-108 asserts ONLY the update patch shape (expect(patch).toEqual({target_session:\'live\'})), which a predicate widening does not touch. The three FR-2 behavioural tests (lines 81-96) assert counts driven by the injected retargetRows fixture, which is returned regardless of any filter. So the sender_type filter is literally unobservable by the current suite. (B) The second cited test, tests/unit/coordinator-ack-adam-reply-ordering.test.js:77, is a SOURCE-TEXT ordering pin (helper.indexOf(\'retargetStaleAdamInbound\') vs indexOf(\'if (isFullUuid(originator))\')) scoped to scripts/coordinator-ack-adam.cjs — a different file from lib/coordinator/adam-identity.cjs, so an adam-identity predicate change cannot break it. It WOULD break if PLAN reorders or re-guards the call site. (C) RUNTIME-LEVEL RISK IS REAL AND IS THE ACTUAL CONCERN — see V-6.'
+  },
+  {
+    id: 'V-6-BLOCKING-widening-needs-a-retired-seat-gate-or-it-can-hijack-a-live-inbox',
+    severity: 'CRITICAL',
+    summary: 'THE ONE GENUINELY BLOCKING DESIGN CONCERN. retargetStaleAdamInbound\'s staleOriginator is only ever proven to be "a full UUID that is not the currently-live Adam" — it is NEVER proven to be a RETIRED ADAM SEAT. resolveAdamReplyTarget (adam-identity.cjs:160-165) sets retargeted=true whenever a live Adam resolves AND differs from the originator; both call sites (scripts/coordinator-reply.cjs:146, scripts/coordinator-ack-adam.cjs:385) then pass that originator straight in, guarded only by isFullUuid. TODAY the .eq(sender_type,\'coordinator\') filter incidentally contains the blast radius. REMOVE IT WITHOUT A REPLACEMENT GATE and the UPDATE sweeps EVERY unacked row targeted at that session from ANY sender. Measured sender_type population over unacked rows table-wide: worker 495, periodic-liveness-watcher 242, coordinator 88, system 48, adam 48, adam-coordinator-health 34, sweep 24, solomon 8, orchestrator 8, drive-state-forcing 3, dashboard 2. If staleOriginator ever resolves to a non-Adam session (a worker that authored an advisory, a stale non-Adam sender), the widened UPDATE would re-point that session\'s entire inbox to Adam — a silent, hard-to-reverse mail hijack, and an UPDATE matching rows it should not is indistinguishable from success. MANDATORY PRD REQUIREMENT: the widened predicate MUST be gated on the target being a VERIFIED retired Adam seat. This converts the "retired seats resolver" from a code-reuse nicety into a SAFETY PRECONDITION — it is the thing that makes the widening legal, and it must ship in the SAME change, not as a follow-on. Note the safety asymmetry between movers: drainAdamOutbound is already safe on this axis (adam-register computes retired[] itself and only passes seats it just retired), so this gate is needed specifically for the retargetStaleAdamInbound side.'
+  },
+  {
+    id: 'V-7-guidance-ADAM_EXCLUDED_KINDS-reuse-all-five',
+    severity: 'INFO',
+    summary: 'GUIDANCE (question 3): REUSE THE FULL 5-ENTRY ADAM_EXCLUDED_KINDS AS-IS. Do not author a new 3-entry list. Reasoning, not just a flag: (1) The constant is already the canonical shared home — its own header comment states it lives in the kinds module "so adam-advisory.cjs, read-adam-directives.cjs and adam-quiet-tick.mjs share one list without a require cycle", and it has five in-tree consumers (adam-advisory.cjs:514/531/702, adam-quiet-tick.mjs:369/404, read-adam-directives.cjs:34, coordinator-hourly-review.cjs:622). Forking a second 3-entry list to match stale SD prose would be a single-representation violation and would drift on the next kind addition — exactly what happened to the SD text itself. (2) The two "extra" entries are correct on the merits for THIS predicate. The constant\'s comment gives the reason: ack and coordinator_ack are "a terminal acknowledgement nobody ever acks", so under an acknowledged_at IS NULL filter they would accumulate FOREVER and be re-forwarded to every successor Adam in perpetuity. Forwarding a terminal ack to a successor delivers nothing actionable, so including them costs a successor nothing and excluding them prevents unbounded pollution. (3) EMPIRICAL CHECK: the ack/coordinator_ack delta over the current stranded population is ZERO rows — the 5-kind and 3-kind exclusions both yield the same 2 actionable rows today. So the choice is currently a no-op on delivered mail and is decided purely on correctness and drift-resistance, both of which favour reuse. (4) ACTION FOR PLAN: amend the SD/PRD prose to say FIVE kinds and name them, so the next reader does not re-litigate this. That is a documentation correction, NOT a scope change — the behaviour PLAN should implement is unchanged either way.'
+  },
+  {
+    id: 'V-8-guidance-retired-seat-resolver-in-scope-migration-is-not-required',
+    severity: 'INFO',
+    summary: 'GUIDANCE (question 4): A MINIMAL RESOLVER IS IN SCOPE (~15-25 LOC) AND DOES NOT REQUIRE TOUCHING THE MIGRATION. Decisive measurement: clear_adam_flag is ABSENT from the live database — calling it returns PGRST202 "Could not find the function public.clear_adam_flag(p_session_id) in the schema cache". Corroborated independently by the live data shape: all 18 retired seats carry metadata.role=adam_retired AND non_fleet=true (17 of 18 also retain adam_since), which is the exact signature of the adam-register.cjs:208 JS-merge FALLBACK. Had the RPC been live, those seats would carry NO role key at all. This matches QF-20260703-883 and the standing measurement recorded at scripts/hooks/session-role-orient.cjs:112. CONCLUSION: metadata->>role = \'adam_retired\' is today a complete and reliable discriminator (18/18), so PLAN can build the resolver on it cheaply and safely, and the SD does NOT need to touch database/migrations/20260615_role_handoff_atomic_adam_flag.sql. IMPORTANT CAVEAT — THIS IS SAFETY BY COINCIDENCE: it holds only because the chairman-gated migration is unapplied. The instant clear_adam_flag is applied, the RPC path drops the role key entirely, leaving a retired seat metadata-INDISTINGUISHABLE from a session that was never Adam, and the resolver returns zero with no error while both movers silently stop forwarding. PLAN MUST NOT ship the resolver without addressing this. Two options, in preference order: (OPTION A, RECOMMENDED) converge the marker — amend clear_adam_flag to SET role=\'adam_retired\' instead of dropping the key, so both retirement paths agree on ONE marker. This is a ~3-5 line edit to an UNAPPLIED function (editing dead code, not migrating live data), materially lower risk than "touching a migration" sounds; PLAN must still confirm whether the chairman-gated apply governance applies to editing a staged-but-unapplied file before committing. (OPTION B, MINIMUM ACCEPTABLE) keep the resolver on role=adam_retired and add a REGRESSION PIN that fails LOUDLY if clear_adam_flag becomes present or the marker set changes, so the degradation is noisy rather than silent. Do NOT reuse resolveAdamSessionIds (lib/adam/inbound-backlog-watchdog.js:96-106) — it filters metadata->>role=\'adam\', which matches NEITHER retirement path and would return zero retired seats.'
+  },
+  {
+    id: 'V-9-test-infrastructure-gap-must-be-closed-by-this-SD',
+    severity: 'HIGH',
+    summary: 'TEST INFRASTRUCTURE REQUIREMENT FOR PLAN. Because the existing mock cannot observe filters (V-5A), a predicate change to retargetStaleAdamInbound would ship completely unverified — a green suite proving nothing about the very thing this SD changes. PLAN MUST include, as an explicit PRD deliverable: upgrade makeSb in tests/unit/coordinator/adam-reply-target-integrity.test.js so .eq()/.is()/.in()/.or()/.gte() RECORD their (column, value) arguments, then assert the resulting filter chain positively — specifically that the retired-seat gate is present, that sender_type is no longer constrained, that acknowledged_at IS NULL is applied, and that the payload->>kind exclusion carries all five ADAM_EXCLUDED_KINDS with null-tolerance. Without this the SD has no way to demonstrate its own fix, and a future reader cannot tell the widening from a regression.'
+  },
+  {
+    id: 'V-10-scope-and-loc-assessment',
+    severity: 'INFO',
+    summary: 'SCOPE ASSESSMENT vs the ~100 LOC budget. Realistic shape: retired-seat resolver ~20 LOC (paginated select, fail-open, exported); shared predicate builder reused by both movers ~25 LOC; drainAdamOutbound rewire (read_at -> acknowledged_at, widen window, add kind exclusion) ~10 LOC; retargetStaleAdamInbound rewire (drop sender_type, add retired-seat gate, add kind exclusion) ~10 LOC; mock upgrade + new assertions ~40-60 LOC of test. Production LOC lands near 65 and total near 125 with tests — within a defensible Tier-3 envelope, and the test portion is the part that should NOT be trimmed. If Option A (converge clear_adam_flag) is taken, add ~5 LOC. The SD\'s stated non-goals ("DOES NOT change ack semantics; auto-ack anything; touch the worker or coordinator handoff paths") remain TRUE under this plan with ONE clarification PLAN should record: the change is to a helper CALLED FROM coordinator paths (coordinator-reply.cjs, coordinator-ack-adam.cjs), so while the coordinator handoff LOGIC is untouched, the coordinator reply path\'s observable side-effect scope DOES widen. That is a wording correction to the non-goal, not a scope violation — but it should be stated plainly so a reviewer is not surprised.'
+  },
+  {
+    id: 'V-11-no-duplicate-implementation',
+    severity: 'INFO',
+    summary: 'DUPLICATE CHECK (GATE 1): NO existing shared implementation duplicates this work. Confirmed there is no shared retired-seat resolver — adam-register.cjs builds retired[] locally (lines 183-213) and never persists or exports it; the reply path derives staleOriginator through a wholly different mechanism (resolveAdamReplyTarget). retargetStaleAdamInbound has exactly two production call sites (coordinator-reply.cjs:146, coordinator-ack-adam.cjs:385) plus one documentation reference in scripts/one-off/. drainAdamOutbound has exactly one production call site (adam-register.cjs:221). A parallel Solomon pair exists (retargetStaleSolomonInbound / drainSolomonOutbound in lib/coordinator/solomon-identity.cjs) with the same shape — PLAN should note it as a likely SAME-DEFECT sibling but keep it OUT of this SD\'s scope and capture it as a completion-flags follow-on rather than silently widening scope.'
+  }
+];
+
+const warnings = [
+  'SD severity figures (148 stranded / 28 actionable) DO NOT reproduce against live state as of 2026-08-16 — measured actionable stranded set is 2 rows across all 18 retired seats. PLAN must re-measure at PRD time and must not encode the inherited numbers as acceptance criteria. Mechanism is confirmed; magnitude is not.',
+  'PROVENANCE CAVEAT on the clear_adam_flag absence: the finding rests on a PostgREST schema-cache response (PGRST202), NOT a pg_proc catalog read — direct pooler access failed with 28P01 (password authentication failed for user "postgres") from this seat. The conclusion is corroborated by the 18/18 adam_retired+non_fleet data shape and by QF-20260703-883, but a catalog-level confirmation over the pooler is the stronger instrument and PLAN should obtain it before choosing Option A over Option B in finding V-8.',
+  'The 210 cross_party_ping rows dominating the stranded population are CORRECTLY excluded by ADAM_EXCLUDED_KINDS and are not a delivery defect. Any PRD metric phrased as "rows stranded at retired seats" will be swamped by them and will look alarming while measuring nothing actionable — phrase acceptance criteria over the POST-exclusion set.',
+  'Solomon has a structurally identical mover pair (retargetStaleSolomonInbound / drainSolomonOutbound). Out of scope here, but the same defect almost certainly applies; capture as a completion-flags finding at SD close rather than dropping it.'
+];
+
+const recommendations = [
+  'PROCEED to PLAN. The defect mechanism is independently confirmed at the source level and corroborated by an in-tree docstring (lib/adam/inbound-backlog.js:192-198). No duplicate implementation exists. GATE 1 duplicate/infrastructure checks PASS.',
+  'BLOCKING PRD REQUIREMENT (V-6): the sender_type widening MUST ship together with a verified-retired-seat gate on retargetStaleAdamInbound. Widening the predicate without it permits a silent whole-inbox hijack of any non-Adam session that resolves as staleOriginator. Do not split these across SDs.',
+  'BLOCKING PRD REQUIREMENT (V-2): write the kind exclusion against payload->>kind with null-tolerance, NOT against a `kind` column (does not exist) and NOT against message_type (coarse envelope; all stranded rows are INFO). Model it on scripts/coordinator-hourly-review.cjs:622 and sanitize interpolated tokens.',
+  'PRIORITISE the read_at -> acknowledged_at switch and the 24h-window widening (V-4) over the kinds work: those two gates alone defeat 212/212 of the currently-stranded rows, whereas the kinds delta is 0. State in the PRD that idempotence survives the switch because it is carried by .in(target_session, olds), not by read_at.',
+  'REUSE ADAM_EXCLUDED_KINDS in full (all five entries) rather than authoring a 3-entry list, and amend the SD/PRD prose to say five (V-7). This is a doc correction, not a scope change.',
+  'Build the retired-seat resolver on metadata->>role=\'adam_retired\' (valid for 18/18 seats today) — it is in budget and does not require touching the migration. Pair it with EITHER converging clear_adam_flag onto the same marker (preferred, ~5 LOC to an unapplied function, confirm gating governance first) OR a loud regression pin that fails if the marker set changes (V-8). Do NOT reuse resolveAdamSessionIds — it matches neither retirement path.',
+  'ADD the test-fixture upgrade to the PRD as a first-class deliverable (V-9): the current mock records no filter arguments, so the change would otherwise ship unobserved by a green suite.',
+  'Re-measure the stranded population at PRD time and set acceptance criteria on the post-exclusion actionable set, not on the raw stranded count.',
+  'Capture the Solomon sibling pair as a completion-flags follow-on at SD close rather than widening this SD.'
+];
+
+const summary = 'LEAD-TO-PLAN VALIDATION: PASS WITH CONDITIONS (confidence 88) for SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001. All four Explore claims independently re-verified at source (ADAM_EXCLUDED_KINDS is 5 entries not 3; both mover predicates confirmed verbatim; no shared retired-seat resolver exists; RPC-drops-role vs JS-sets-adam_retired divergence confirmed). PROCEED, but three conditions bind PLAN. (1) BLOCKING SAFETY: dropping .eq(sender_type,\'coordinator\') from retargetStaleAdamInbound is NOT safe on its own — staleOriginator is only proven to be "a UUID that is not the live Adam", never proven to be a retired Adam seat, so the current sender_type filter is incidentally the only thing containing blast radius. Widened without a verified-retired-seat gate, the UPDATE sweeps every unacked row at that session from any sender (measured table-wide unacked senders: worker 495, periodic-liveness-watcher 242, coordinator 88, ...), silently hijacking a live inbox. The retired-seat resolver is therefore a SAFETY PRECONDITION, not a code-reuse nicety, and must ship in the same change. (2) BLOCKING SCHEMA: session_coordination has NO `kind` column — the vocabulary lives in payload->>kind (message_type is a coarse envelope; all 212 stranded rows are INFO). (3) PREMISE: the mechanism is real and corroborated by lib/adam/inbound-backlog.js:192-198, but the SD\'s 148/28 severity figures DO NOT reproduce — live measurement across all 18 retired seats finds 212 unacked rows of which 210 are correctly-excluded cross_party_ping, leaving TWO actionable. PLAN must re-measure rather than inherit. HIGHEST-YIELD REFRAME: read_at IS NULL and the 24h window each independently defeat 212/212 of the stranded rows, so drainAdamOutbound would move ZERO today — those two gates matter far more than the kinds list, whose ack/coordinator_ack delta is exactly 0 rows. Idempotence survives the read_at->acknowledged_at switch because it is carried by .in(target_session, olds). GUIDANCE: reuse ADAM_EXCLUDED_KINDS in full (five entries — canonical, already shared by 5 consumers, and ack/coordinator_ack are terminal-by-definition so excluding them prevents perpetual re-forwarding at zero delivery cost) and amend the stale SD prose. The retired-seat resolver IS in the ~100 LOC budget (~20 LOC on metadata->>role=\'adam_retired\', valid 18/18 today) and does NOT require touching the migration — but it is safe only by coincidence, because clear_adam_flag is measurably ABSENT from the live DB (PGRST202; catalog-level confirmation blocked by 28P01 from this seat). If that migration is ever applied, the RPC path drops the role key entirely and the resolver goes blind with no error; PLAN must either converge clear_adam_flag onto role=adam_retired (~5 LOC to an unapplied function) or add a loud regression pin. FINALLY, the existing test mock records no filter arguments (.eq/.is are no-op passthroughs; the only pin asserts the update patch shape), so the change would ship unobserved by a green suite — the fixture upgrade must be a first-class PRD deliverable. No duplicate implementation exists; GATE 1 duplicate/infrastructure checks PASS.';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+
+  const resolution = await resolveSubAgentRepo({
+    sdId: SD_KEY,
+    targetApplication: 'EHG_Engineer',
+    subAgentCode: 'VALIDATION',
+    supabase,
+  });
+
+  let results = {
+    verdict: 'CONDITIONAL_PASS',
+    confidence_score: 88,
+    findings,
+    warnings,
+    recommendations,
+    summary,
+    detailed_analysis: {
+      sd_key: SD_KEY,
+      validation_type: 'LEAD_PRE_APPROVAL_GATE_1',
+      branch: 'feat/SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001',
+      gate_1_checks: {
+        duplicate_check: 'PASS — no shared retired-seat resolver exists; each mover has a single production call site; Solomon sibling pair noted as out-of-scope follow-on',
+        infrastructure_check: 'PASS with condition — ADAM_EXCLUDED_KINDS is reusable as-is (all 5); resolveAdamSessionIds is NOT reusable (filters role=adam, matches neither retirement path)',
+        claims_verification: 'PARTIAL — mechanism confirmed at source; severity figures (148/28) do not reproduce live',
+        backlog_check: 'not evaluated by this agent'
+      },
+      source_reverification: {
+        'lib/fleet/worker-status.cjs:192': "ADAM_EXCLUDED_KINDS = Object.freeze(['canary_request','comms_check','ack','coordinator_ack','cross_party_ping']) — 5 entries",
+        'scripts/adam-advisory.cjs:1355-1373': 'drainAdamOutbound: .in(target_session, olds).is(read_at, null).gte(created_at, now-24h)',
+        'lib/coordinator/adam-identity.cjs:174-189': 'retargetStaleAdamInbound: .eq(target_session, stale).eq(sender_type, coordinator).is(acknowledged_at, null)',
+        'scripts/adam-register.cjs:208': "JS fallback: { ...priorMeta, role: 'adam_retired', non_fleet: true } — preserves adam_since via spread",
+        'database/migrations/20260615_role_handoff_atomic_adam_flag.sql:33-41': 'clear_adam_flag drops role + adam_since + non_fleet when role=adam — leaves NO positive retirement marker',
+        'scripts/coordinator-hourly-review.cjs:622': "only SQL-level consumer of the kinds list: .or('payload->>kind.is.null,payload->>kind.not.in.(...)')"
+      },
+      live_measurements_2026_08_16: {
+        claude_sessions_total: 13108,
+        role_adam: 1,
+        role_adam_retired: 18,
+        role_solomon: 1,
+        role_coordinator: 0,
+        retired_seat_marker_shape: 'all 18 carry role=adam_retired + non_fleet=true; 17/18 also retain adam_since (JS-fallback signature)',
+        clear_adam_flag_rpc: 'ABSENT (PGRST202 schema-cache miss); pooler catalog confirmation blocked by 28P01',
+        rows_at_retired_seats_total: 213,
+        rows_unacked: 212,
+        unacked_by_payload_kind: { cross_party_ping: 210, solomon_ledger_pending_digest: 1, coordinator_reply: 1 },
+        actionable_after_5_kind_exclusion: 2,
+        actionable_after_sd_named_3_kind_exclusion: 2,
+        ack_coordinator_ack_delta: 0,
+        unacked_with_read_at_null: 0,
+        unacked_within_24h_window: 0,
+        drain_would_move_today: 0,
+        retarget_would_move_today: 211,
+        unacked_not_sender_type_coordinator: 1,
+        table_wide_unacked_sender_types: { worker: 495, 'periodic-liveness-watcher': 242, coordinator: 88, system: 48, adam: 48, 'adam-coordinator-health': 34, sweep: 24, solomon: 8, orchestrator: 8, 'drive-state-forcing': 3, dashboard: 2 }
+      },
+      blocking_conditions_for_plan: [
+        'V-6 CRITICAL: widened predicate requires a verified-retired-seat gate in the SAME change',
+        'V-2 HIGH: use payload->>kind (null-tolerant), never a `kind` column or message_type',
+        'V-9 HIGH: upgrade the filter-blind test mock as a first-class deliverable',
+        'V-3 HIGH: re-measure severity; do not inherit 148/28 as acceptance criteria'
+      ],
+      schema_note: 'session_coordination columns: id, target_session, target_sd, message_type, subject, body, payload, sender_session, sender_type, created_at, expires_at, read_at, acknowledged_at, correlation_id, delivered_at — NO kind column'
+    },
+    phase: 'LEAD-TO-PLAN',
+    validation_mode: 'prospective',
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+
+  const stored = await storeSubAgentResults(
+    'VALIDATION',
+    SD_ID,
+    { name: 'Principal Systems Analyst (validation-agent)' },
+    results,
+    { sdKey: SD_KEY, phase: 'LEAD-TO-PLAN' }
+  );
+
+  console.log('VERDICT WRITTEN:');
+  console.log('  ID:', stored.id);
+  console.log('  verdict:', stored.verdict, '@ confidence', stored.confidence);
+  console.log('  phase:', stored.phase);
+  console.log('  created_at:', stored.created_at);
+  console.log('  repo_path:', stored.metadata?.repo_path);
+  console.log('  repo_resolved:', stored.metadata?.repo_resolved);
+  console.log('  executed_from_cwd:', stored.metadata?.executed_from_cwd);
+  process.exit(0);
+}
+
+main().catch(e => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/tests/helpers/postgrest-fixture-store.js
+++ b/tests/helpers/postgrest-fixture-store.js
@@ -1,0 +1,168 @@
+/**
+ * A genuinely-filtering in-memory Supabase double (SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001,
+ * FR-6/TR-5).
+ *
+ * The repo's existing test doubles for this code path (`makeSb` at
+ * tests/unit/coordinator/adam-reply-target-integrity.test.js, `stub`/`regStub` at
+ * tests/unit/coordination/adam-singleton.test.js, the watchdog test's fixture, and
+ * tests/helpers/supabase-chain-mock.js) all implement `.eq()/.is()/.in()/.gte()` as no-op
+ * passthroughs that return the chain unchanged — a test using them can catch a wrong UPDATE
+ * PATCH shape, but not a wrong or missing FILTER, which is exactly the class of bug this SD
+ * exists to fix (two movers with silently-too-narrow predicates). This double actually applies
+ * every filter against an in-memory row array, including `col->>key` JSON-path accessors
+ * (metadata->>role, payload->>kind) and the null-safe `.or('col.is.null,col.not.in.(a,b,c)')`
+ * form used by the shared successor-inherit predicate. Unrecognized filter calls throw (no
+ * method is defined as a silent no-op), so a caller using a filter this double doesn't model
+ * fails loudly instead of passing vacuously.
+ *
+ * Built from the partial engines already in this repo rather than from scratch:
+ *  - the preds[]+getCol('->>') engine at tests/unit/worker-checkin-ranked-window.test.js:25
+ *  - the or-string parser at tests/unit/chairman/sms-outbound-reconcile.test.js:39-70
+ *  - range/pagination semantics from tests/unit/roadmap/plan-check-uncapped-pagination.test.js
+ */
+
+/** Resolve `col` or `col->>key` against a row. Plain columns are a direct property read. */
+function getPath(row, col) {
+  const m = /^([\w]+)->>(.+)$/.exec(col);
+  if (!m) return row[col];
+  const obj = row[m[1]];
+  if (obj == null || typeof obj !== 'object') return null;
+  const v = obj[m[2]];
+  return v === undefined ? null : v;
+}
+
+/** Split a PostgREST `.or()` string on top-level commas (parens can nest a value list). */
+function splitOrExpr(str) {
+  const parts = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of str) {
+    if (ch === '(') depth += 1;
+    if (ch === ')') depth -= 1;
+    if (ch === ',' && depth === 0) {
+      parts.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur) parts.push(cur);
+  return parts;
+}
+
+/** Parse one `.or()` clause token, e.g. `payload->>kind.not.in.(a,b,c)` or `col.is.null`. */
+function parseOrClause(token) {
+  let m = /^(.*)\.not\.in\.\((.*)\)$/.exec(token);
+  if (m) return { col: m[1], op: 'not.in', val: m[2].length ? m[2].split(',') : [] };
+  m = /^(.*)\.in\.\((.*)\)$/.exec(token);
+  if (m) return { col: m[1], op: 'in', val: m[2].length ? m[2].split(',') : [] };
+  m = /^(.*)\.is\.(null|true|false)$/.exec(token);
+  if (m) return { col: m[1], op: 'is', val: m[2] === 'null' ? null : m[2] === 'true' };
+  m = /^(.*)\.eq\.(.*)$/.exec(token);
+  if (m) return { col: m[1], op: 'eq', val: m[2] };
+  throw new Error(`postgrest-fixture-store: unsupported .or() clause "${token}"`);
+}
+
+function evalOrClause(row, clause) {
+  const v = getPath(row, clause.col);
+  if (clause.op === 'is') return v === clause.val;
+  if (clause.op === 'eq') return v === clause.val;
+  if (clause.op === 'in') return clause.val.includes(v);
+  if (clause.op === 'not.in') return v != null && !clause.val.includes(v);
+  throw new Error(`postgrest-fixture-store: unhandled .or() op "${clause.op}"`);
+}
+
+class FixtureQuery {
+  constructor(store, table) {
+    this.store = store;
+    this.table = table;
+    this.filters = [];
+    this.orClauses = null;
+    this.mode = 'select';
+    this.patch = null;
+    this.orderCol = null;
+    this.orderAsc = true;
+    this.rangeFrom = null;
+    this.rangeTo = null;
+    this.singleMode = null; // null | 'single' | 'maybeSingle'
+  }
+
+  select() { return this; }
+  update(patch) { this.mode = 'update'; this.patch = patch; return this; }
+  eq(col, val) { this.filters.push({ type: 'eq', col, val }); return this; }
+  is(col, val) { this.filters.push({ type: 'is', col, val }); return this; }
+  in(col, arr) { this.filters.push({ type: 'in', col, val: arr }); return this; }
+  gte(col, val) { this.filters.push({ type: 'gte', col, val }); return this; }
+  lte(col, val) { this.filters.push({ type: 'lte', col, val }); return this; }
+  or(str) { this.orClauses = splitOrExpr(str).map(parseOrClause); return this; }
+  order(col, opts = {}) { this.orderCol = col; this.orderAsc = opts.ascending !== false; return this; }
+  range(from, to) { this.rangeFrom = from; this.rangeTo = to; return this; }
+  single() { this.singleMode = 'single'; return this; }
+  maybeSingle() { this.singleMode = 'maybeSingle'; return this; }
+
+  _matches(row) {
+    for (const f of this.filters) {
+      const v = getPath(row, f.col);
+      if (f.type === 'eq' && v !== f.val) return false;
+      if (f.type === 'is' && v !== f.val) return false;
+      if (f.type === 'in' && !f.val.includes(v)) return false;
+      if (f.type === 'gte' && !(v >= f.val)) return false;
+      if (f.type === 'lte' && !(v <= f.val)) return false;
+    }
+    if (this.orClauses && !this.orClauses.some((c) => evalOrClause(row, c))) return false;
+    return true;
+  }
+
+  async _run() {
+    if (this.store.errorOnTable === this.table) {
+      return { data: null, error: { message: this.store.errorMessage || 'simulated error' } };
+    }
+    const rows = this.store.rows(this.table);
+    let matched = rows.filter((r) => this._matches(r));
+    if (this.mode === 'update') {
+      matched.forEach((r) => Object.assign(r, this.patch));
+      return { data: matched.map((r) => ({ id: r.id })), error: null };
+    }
+    if (this.orderCol) {
+      matched = matched.slice().sort((a, b) => {
+        const av = getPath(a, this.orderCol);
+        const bv = getPath(b, this.orderCol);
+        const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+        return this.orderAsc ? cmp : -cmp;
+      });
+    }
+    if (this.rangeFrom != null) matched = matched.slice(this.rangeFrom, this.rangeTo + 1);
+    if (this.singleMode === 'single') {
+      return matched.length ? { data: matched[0], error: null } : { data: null, error: { message: 'no rows' } };
+    }
+    if (this.singleMode === 'maybeSingle') {
+      return { data: matched[0] || null, error: null };
+    }
+    return { data: matched, error: null };
+  }
+
+  then(resolve, reject) {
+    this._run().then(resolve, reject);
+  }
+}
+
+/**
+ * @param {Object<string, Array<object>>} seed table name -> array of fixture rows (mutated in place by updates)
+ * @returns {{ from: (table:string) => FixtureQuery, table: (name:string) => object[], setError: (table:string, message?:string) => void }}
+ */
+export function createFixtureSupabase(seed = {}) {
+  const store = {
+    _tables: seed,
+    errorOnTable: null,
+    errorMessage: null,
+    rows(table) { return store._tables[table] || (store._tables[table] = []); },
+  };
+  return {
+    from: (table) => new FixtureQuery(store, table),
+    table: (name) => store.rows(name),
+    setError: (table, message = 'simulated error') => { store.errorOnTable = table; store.errorMessage = message; },
+    clearError: () => { store.errorOnTable = null; store.errorMessage = null; },
+  };
+}
+
+export default createFixtureSupabase;

--- a/tests/unit/coordination/adam-singleton.test.js
+++ b/tests/unit/coordination/adam-singleton.test.js
@@ -4,6 +4,7 @@
 // guard's deliberate refuse-new-on-fresh-prior divergence, and the pure MULTIPLE_ADAMS detector.
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
+import { createFixtureSupabase } from '../../helpers/postgrest-fixture-store.js';
 const require = createRequire(import.meta.url);
 const adam = require('../../../lib/coordinator/adam-identity.cjs');
 const { detectMultipleAdams, runDetectors } = require('../../../lib/coordinator/detectors.cjs');
@@ -11,6 +12,11 @@ const { registerAdam } = require('../../../scripts/adam-register.cjs');
 
 const NOW = Date.parse('2026-06-15T16:00:00.000Z');
 const fresh = (minAgo) => new Date(NOW - minAgo * 60_000).toISOString();
+// drainAdamOutbound/retargetStaleAdamInbound's 14-day horizon is computed against REAL
+// Date.now() (not the frozen guard-election NOW above, which only governs heartbeat_at
+// freshness via the injected nowMs param) — session_coordination fixture rows need a
+// genuinely-recent created_at or the shared successor-inherit predicate excludes them.
+const recentReal = (minAgo) => new Date(Date.now() - minAgo * 60_000).toISOString();
 
 describe('pickCanonicalAdam (deterministic election, mirror of coordinator)', () => {
   it('picks adam_since DESC, NULLS LAST, then session_id ASC', () => {
@@ -150,58 +156,87 @@ describe('detectMultipleAdams (pure, mirror of detectSplitBrain)', () => {
 // whichever write path fired, exactly like a live Postgres row would. Only writes targeting
 // `selfSessionId` mutate the tracked row; a retire-fallback update targeting a stale PRIOR
 // session_id is correctly a no-op here (it mutates a different row in reality).
+// SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001: extended so a retire (RPC clear_adam_flag or
+// the JS-merge fallback) actually mutates the retired session's role to ADAM_RETIRED_ROLE in a
+// live, queryable table — resolveRetiredAdamSeats reads THAT state, not a static fixture — and
+// so session_coordination (drainRows) is routed through the genuinely-filtering
+// postgrest-fixture-store instead of a bulk-update stub, matching the new select-then-per-row
+// drainAdamOutbound implementation.
 function regStub({ selfSessionId = 'self', selfMeta = null, rowExists = true, allAdams = [], rpcError = null, drainRows = [] } = {}) {
   const calls = { update: 0, insert: 0, rpc: [], drainSelect: 0 };
   let currentRowExists = rowExists;
   let currentMeta = selfMeta;
+  const otherSessionsMeta = new Map(allAdams.map((a) => [a.session_id, { ...a.metadata }]));
+  const scFixture = createFixtureSupabase({ session_coordination: drainRows.map((r) => ({ ...r })) });
+
+  function claudeSessionsChain() {
+    let roleFilter;
+    const chain = {
+      select() { return chain; },
+      eq(col, val) { if (col === 'metadata->>role') roleFilter = val; return chain; },
+      gte() { return chain; },
+      filter() { return chain; }, // fetchAllAdams — FR-6: now paginated, resolves via .range below
+      order() { return chain; },
+      range(from, to) {
+        if (roleFilter !== undefined) {
+          const matched = [...otherSessionsMeta.entries()]
+            .filter(([, m]) => m && m.role === roleFilter)
+            .map(([session_id]) => ({ session_id }));
+          return Promise.resolve({ data: matched.slice(from, to + 1), error: null });
+        }
+        const live = allAdams.map((a) => ({ ...a, metadata: otherSessionsMeta.get(a.session_id) || a.metadata }));
+        return Promise.resolve({ data: live.slice(from, to + 1), error: null });
+      },
+      maybeSingle() {
+        return Promise.resolve({
+          data: currentRowExists ? { session_id: selfSessionId, metadata: currentMeta } : null,
+          error: null,
+        });
+      },
+      insert(payload) {
+        calls.insert += 1;
+        if (payload && payload.session_id === selfSessionId) {
+          currentRowExists = true;
+          currentMeta = payload.metadata;
+        }
+        return Promise.resolve({ error: null });
+      },
+      update(payload) {
+        calls.update += 1;
+        const uchain = {
+          eq(_col, val) {
+            if (val === selfSessionId) { currentRowExists = true; currentMeta = payload.metadata; }
+            else if (otherSessionsMeta.has(val)) otherSessionsMeta.set(val, payload.metadata); // JS-merge retire fallback
+            return Promise.resolve({ error: null });
+          },
+        };
+        return uchain;
+      },
+    };
+    return chain;
+  }
+
+  function sessionCoordinationChain() {
+    calls.drainSelect += 1;
+    return scFixture.from('session_coordination');
+  }
+
   const supabase = {
-    from() {
-      const chain = {
-        select() { return chain; },
-        eq() { return chain; },
-        gte() { return chain; },
-        filter() { return chain; }, // fetchAllAdams — FR-6: now paginated, resolves via .range below
-        order() { return chain; },
-        range(from, to) { return Promise.resolve({ data: allAdams.slice(from, to + 1), error: null }); },
-        maybeSingle() {
-          return Promise.resolve({
-            data: currentRowExists ? { session_id: selfSessionId, metadata: currentMeta } : null,
-            error: null,
-          });
-        },
-        insert(payload) {
-          calls.insert += 1;
-          if (payload && payload.session_id === selfSessionId) {
-            currentRowExists = true;
-            currentMeta = payload.metadata;
-          }
-          return Promise.resolve({ error: null });
-        },
-        update(payload) {
-          calls.update += 1;
-          const uchain = {
-            eq(_col, val) {
-              if (val === selfSessionId) { currentRowExists = true; currentMeta = payload.metadata; }
-              return Promise.resolve({ error: null });
-            },
-            in() { return uchain; }, is() { return uchain; }, gte() { return uchain; },
-            select() { calls.drainSelect += 1; return Promise.resolve({ data: drainRows, error: null }); }, // drain
-          };
-          return uchain;
-        },
-      };
-      return chain;
-    },
+    from(table) { return table === 'session_coordination' ? sessionCoordinationChain() : claudeSessionsChain(); },
     rpc(fn, args) {
       calls.rpc.push({ fn, args });
       if (fn === 'set_adam_flag' && !rpcError && args && args.p_session_id === selfSessionId) {
         currentRowExists = true;
         currentMeta = { ...(currentMeta || {}), role: 'adam', non_fleet: true, adam_since: 'test' };
       }
+      if (fn === 'clear_adam_flag' && !rpcError && args && args.p_session_id) {
+        const prev = otherSessionsMeta.get(args.p_session_id) || {};
+        otherSessionsMeta.set(args.p_session_id, { ...prev, role: 'adam_retired', non_fleet: true });
+      }
       return Promise.resolve({ error: rpcError });
     },
   };
-  return { supabase, calls };
+  return { supabase, calls, drainRows: () => scFixture.table('session_coordination') };
 }
 
 describe('registerAdam (single-Adam guard, unconditional RPC-first upsert — SD-FDBK-INFRA-FIX-ADAM-SOLOMON-001)', () => {
@@ -230,16 +265,21 @@ describe('registerAdam (single-Adam guard, unconditional RPC-first upsert — SD
   });
 
   it('a STALE prior => retire (clear_adam_flag) + register + FR-4 drain re-targets inbound', async () => {
-    const { supabase, calls } = regStub({
+    const { supabase, calls, drainRows } = regStub({
       allAdams: [{ session_id: 'staleprior', heartbeat_at: fresh(999), metadata: { role: 'adam' } }],
       rpcError: null,
-      drainRows: [{ id: 'm1' }, { id: 'm2' }],
+      drainRows: [
+        { id: 'm1', target_session: 'staleprior', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recentReal(60) },
+        { id: 'm2', target_session: 'staleprior', acknowledged_at: null, payload: { kind: 'adam_advisory' }, created_at: recentReal(60) },
+      ],
     });
     const r = await registerAdam(supabase, 'self', { nowMs: NOW });
     expect(r).toMatchObject({ ok: true, action: 'tagged_after_retire', drained: 2 });
     expect(r.retired).toEqual(['staleprior']);
     expect(calls.rpc.map((c) => c.fn)).toEqual(expect.arrayContaining(['clear_adam_flag', 'set_adam_flag']));
-    expect(calls.drainSelect).toBe(1); // FR-4 drain ran (re-targeted old->new)
+    expect(calls.drainSelect).toBeGreaterThan(0); // FR-4 drain ran (re-targeted old->new)
+    expect(drainRows().every((row) => row.target_session === 'self')).toBe(true);
+    expect(drainRows().map((row) => row.payload.retargeted_from)).toEqual(['staleprior', 'staleprior']);
   });
 
   // QF-20260703-883: clear_adam_flag RPC absent (migration unapplied) must NOT silently leave
@@ -249,14 +289,16 @@ describe('registerAdam (single-Adam guard, unconditional RPC-first upsert — SD
     const { supabase, calls } = regStub({
       allAdams: [{ session_id: 'staleprior', heartbeat_at: fresh(999), metadata: { role: 'adam', non_fleet: true } }],
       rpcError: { code: 'PGRST202', message: 'Could not find the function' },
-      drainRows: [{ id: 'm1' }],
+      drainRows: [
+        { id: 'm1', target_session: 'staleprior', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recentReal(60) },
+      ],
     });
     const r = await registerAdam(supabase, 'self', { nowMs: NOW });
     expect(r).toMatchObject({ ok: true, action: 'tagged_after_retire_fallback', drained: 1 });
     expect(r.retired).toEqual(['staleprior']);
     expect(r.retire_fallback_used).toEqual(['staleprior']);
     expect(r.retire_blocked).toBeUndefined();
-    expect(calls.drainSelect).toBe(1); // FR-4 drain still ran for the JS-merge-retired prior
+    expect(calls.drainSelect).toBeGreaterThan(0); // FR-4 drain still ran for the JS-merge-retired prior
   });
 
   // FR-1/TS-1: the bug this SD fixes — a session with NO existing claude_sessions row must be
@@ -291,26 +333,29 @@ describe('registerAdam (single-Adam guard, unconditional RPC-first upsert — SD
   });
 });
 
-describe('drainAdamOutbound (FR-4 idempotent re-target)', () => {
+describe('drainAdamOutbound (FR-4 idempotent re-target, widened per SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001)', () => {
   const { drainAdamOutbound } = require('../../../scripts/adam-advisory.cjs');
-  it('re-targets unread old-session rows to the new session and counts them', async () => {
-    let captured = null;
-    const sb = { from() { const c = {
-      update(patch) { captured = { patch, in: null }; return c; },
-      in(_col, ids) { captured.in = ids; return c; },
-      is() { return c; }, gte() { return c; },
-      select() { return Promise.resolve({ data: [{ id: 'a' }, { id: 'b' }], error: null }); },
-    }; return c; } };
+  it('re-targets unacked old-session rows (any read_at, within 14 days) to the new session, stamps retargeted_from/at, and counts them', async () => {
+    const sb = createFixtureSupabase({
+      session_coordination: [
+        { id: 'a', target_session: 'old1', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recentReal(60) },
+        { id: 'b', target_session: 'old2', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recentReal(60) },
+      ],
+    });
     const r = await drainAdamOutbound(sb, { newSessionId: 'new', oldSessionIds: ['old1', 'old2'] });
     expect(r.moved).toBe(2);
-    expect(captured.patch).toEqual({ target_session: 'new' });
-    expect(captured.in).toEqual(['old1', 'old2']);
+    expect(r.byKind).toEqual({ coordinator_reply: 2 });
+    for (const row of sb.table('session_coordination')) {
+      expect(row.target_session).toBe('new');
+      expect(row.payload.retargeted_from).toMatch(/^old\d$/);
+      expect(row.payload.retargeted_at).toBeTruthy();
+    }
   });
   it('no-op for empty/self-only old ids (idempotent boundary)', async () => {
     const sb = { from() { throw new Error('should not query'); } };
-    expect(await drainAdamOutbound(sb, { newSessionId: 'new', oldSessionIds: [] })).toEqual({ moved: 0 });
-    expect(await drainAdamOutbound(sb, { newSessionId: 'new', oldSessionIds: ['new'] })).toEqual({ moved: 0 });
-    expect(await drainAdamOutbound(null, { newSessionId: 'new', oldSessionIds: ['x'] })).toEqual({ moved: 0 });
+    expect(await drainAdamOutbound(sb, { newSessionId: 'new', oldSessionIds: [] })).toEqual({ moved: 0, byKind: {} });
+    expect(await drainAdamOutbound(sb, { newSessionId: 'new', oldSessionIds: ['new'] })).toEqual({ moved: 0, byKind: {} });
+    expect(await drainAdamOutbound(null, { newSessionId: 'new', oldSessionIds: ['x'] })).toEqual({ moved: 0, byKind: {} });
   });
 });
 

--- a/tests/unit/coordination/adam-successor-inherit.test.js
+++ b/tests/unit/coordination/adam-successor-inherit.test.js
@@ -1,0 +1,262 @@
+/**
+ * SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 — successor-Adam mail forwarding.
+ *
+ * Pins the shared retired-seat resolver, the widened drainAdamOutbound (register-time) and
+ * retargetStaleAdamInbound (reply-time) movers onto one predicate, adam-register.cjs's
+ * decoupled drain call, and the watchdog's retired-role visibility fix. Uses
+ * tests/helpers/postgrest-fixture-store.js (a genuinely-filtering fake) rather than any of the
+ * repo's existing no-op-filter doubles — see that file's header for why.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createFixtureSupabase } from '../../helpers/postgrest-fixture-store.js';
+import {
+  resolveRetiredAdamSeats,
+  retargetStaleAdamInbound,
+  ADAM_RETIRED_ROLE,
+  ADAM_MAIL_TTL_DAYS,
+} from '../../../lib/coordinator/adam-identity.cjs';
+import { drainAdamOutbound } from '../../../scripts/adam-advisory.cjs';
+import { resolveAdamSessionIds } from '../../../lib/adam/inbound-backlog-watchdog.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-08-16T00:00:00Z');
+const recent = (daysAgo) => new Date(NOW - daysAgo * DAY_MS).toISOString();
+
+function baseFixture() {
+  return {
+    claude_sessions: [
+      { session_id: 'retired-1', metadata: { role: ADAM_RETIRED_ROLE } },
+      { session_id: 'retired-2', metadata: { role: ADAM_RETIRED_ROLE } },
+      { session_id: 'live-adam', metadata: { role: 'adam' } },
+      { session_id: 'someone-else', metadata: { role: 'worker' } },
+    ],
+    session_coordination: [],
+  };
+}
+
+describe('resolveRetiredAdamSeats', () => {
+  it('returns only role=adam_retired session ids, excluding live adam and other roles', async () => {
+    const sb = createFixtureSupabase(baseFixture());
+    const { ids, error } = await resolveRetiredAdamSeats(sb);
+    expect(error).toBeNull();
+    expect(ids.sort()).toEqual(['retired-1', 'retired-2']);
+  });
+
+  it('fails closed (empty + error) rather than throwing on a query error', async () => {
+    const sb = createFixtureSupabase(baseFixture());
+    sb.setError('claude_sessions');
+    const { ids, error } = await resolveRetiredAdamSeats(sb);
+    expect(ids).toEqual([]);
+    expect(error).toBeTruthy();
+  });
+
+  // Pins the live convention this SD's safety gate depends on (PRD risk: if clear_adam_flag is
+  // ever applied without preserving it, this resolver silently sees fewer/no seats). A change to
+  // ADAM_RETIRED_ROLE's value, or to what scripts/adam-register.cjs's JS-merge fallback writes,
+  // must fail this test loudly rather than degrade silently in production.
+  it('the live retirement convention (adam-register.cjs JS-merge fallback) matches ADAM_RETIRED_ROLE', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts/adam-register.cjs'), 'utf8');
+    expect(src).toMatch(/role:\s*'adam_retired'/);
+    expect(ADAM_RETIRED_ROLE).toBe('adam_retired');
+  });
+});
+
+describe('drainAdamOutbound — register-time mover', () => {
+  it('inherits read-but-unacked rows from ALL retired seats (not just this-call ones), across coordinator/solomon/orchestrator senders', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'a', target_session: 'retired-1', sender_type: 'coordinator', acknowledged_at: null, read_at: recent(3), payload: { kind: 'coordinator_reply' }, created_at: recent(3) },
+      { id: 'b', target_session: 'retired-2', sender_type: 'solomon', acknowledged_at: null, read_at: recent(3), payload: { kind: 'adam_advisory' }, created_at: recent(3) },
+      { id: 'c', target_session: 'retired-1', sender_type: 'orchestrator', acknowledged_at: null, read_at: null, payload: { kind: 'adam_action_required' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const { ids: retiredIds } = await resolveRetiredAdamSeats(sb);
+    const result = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: retiredIds });
+    expect(result.error).toBeUndefined();
+    expect(result.moved).toBe(3);
+    expect(result.byKind).toEqual({ coordinator_reply: 1, adam_advisory: 1, adam_action_required: 1 });
+    for (const row of sb.table('session_coordination')) {
+      expect(row.target_session).toBe('new-adam');
+      expect(row.payload.retargeted_from).toMatch(/^retired-/);
+      expect(row.payload.retargeted_at).toBeTruthy();
+    }
+  });
+
+  it('never moves: acked rows, any of the 5 ADAM_EXCLUDED_KINDS, or rows older than 14 days', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'acked', target_session: 'retired-1', acknowledged_at: recent(1), payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+      { id: 'ping', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'cross_party_ping' }, created_at: recent(1) },
+      { id: 'canary', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'canary_request' }, created_at: recent(1) },
+      { id: 'comms', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'comms_check' }, created_at: recent(1) },
+      { id: 'ack', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'ack' }, created_at: recent(1) },
+      { id: 'coord_ack', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'coordinator_ack' }, created_at: recent(1) },
+      { id: 'stale', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(15) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const result = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1'] });
+    expect(result.moved).toBe(0);
+  });
+
+  it('a row with payload.kind absent, and a row with payload:null, both move (null-safe kind exclusion)', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'no-kind', target_session: 'retired-1', acknowledged_at: null, payload: { body: 'hi' }, created_at: recent(1) },
+      { id: 'null-payload', target_session: 'retired-1', acknowledged_at: null, payload: null, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const result = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1'] });
+    expect(result.moved).toBe(2);
+  });
+
+  it('a second run over the same fixture moves 0 (idempotent — acked rows never re-move)', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'a', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const first = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1'] });
+    expect(first.moved).toBe(1);
+    // second run: same oldSessionIds, but the row is now at new-adam, not retired-1
+    const second = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1'] });
+    expect(second.moved).toBe(0);
+  });
+
+  it('TR-5 concurrent-update race: a row acknowledged between select and update is neither moved nor counted', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'raced', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    // Simulate the race: another process acks the row the instant after drainAdamOutbound's
+    // initial select would have run, by pre-acking it and calling drain over a fixture where the
+    // select-phase view differs from the update-phase view is not directly expressible without
+    // instrumenting the double — so this pins the OBSERVABLE CONTRACT instead: the update
+    // re-asserts is(acknowledged_at, null), so an already-acked row is never moved even if some
+    // upstream read believed it was still open.
+    sb.table('session_coordination')[0].acknowledged_at = recent(0);
+    const result = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1'] });
+    expect(result.moved).toBe(0);
+  });
+
+  it('resolver error propagates as a fail-closed 0-moved result, not a false "no restriction"', async () => {
+    const sb = createFixtureSupabase(baseFixture());
+    sb.setError('session_coordination');
+    const result = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1'] });
+    expect(result.moved).toBe(0);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('multiple retired seats in one call: all inherited, byKind aggregates across seats', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'a', target_session: 'retired-1', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+      { id: 'b', target_session: 'retired-2', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+      { id: 'c', target_session: 'retired-2', acknowledged_at: null, payload: { kind: 'adam_advisory' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const result = await drainAdamOutbound(sb, { newSessionId: 'new-adam', oldSessionIds: ['retired-1', 'retired-2'] });
+    expect(result.moved).toBe(3);
+    expect(result.byKind).toEqual({ coordinator_reply: 2, adam_advisory: 1 });
+  });
+});
+
+describe('retargetStaleAdamInbound — reply-time mover, verified against a retired seat', () => {
+  it('a verified-retired staleOriginator with a non-coordinator sender moves (widened predicate works)', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'a', target_session: 'retired-1', sender_type: 'solomon', acknowledged_at: null, payload: { kind: 'adam_advisory' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const result = await retargetStaleAdamInbound(sb, { staleOriginator: 'retired-1', liveAdam: 'live-adam' });
+    expect(result.error).toBeNull();
+    expect(result.retargeted).toBe(1);
+    const row = sb.table('session_coordination')[0];
+    expect(row.target_session).toBe('live-adam');
+    expect(row.payload.retargeted_from).toBe('retired-1');
+    expect(row.payload.retargeted_at).toBeTruthy();
+  });
+
+  it('an UNVERIFIED staleOriginator (live role=adam, or an unrelated non-Adam session) moves 0 even when unacked — the blast-radius regression test', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'a', target_session: 'live-adam', sender_type: 'worker', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+      { id: 'b', target_session: 'someone-else', sender_type: 'worker', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const r1 = await retargetStaleAdamInbound(sb, { staleOriginator: 'live-adam', liveAdam: 'new-adam' });
+    expect(r1.retargeted).toBe(0);
+    const r2 = await retargetStaleAdamInbound(sb, { staleOriginator: 'someone-else', liveAdam: 'new-adam' });
+    expect(r2.retargeted).toBe(0);
+    // rows must be untouched
+    expect(sb.table('session_coordination')[0].target_session).toBe('live-adam');
+    expect(sb.table('session_coordination')[1].target_session).toBe('someone-else');
+  });
+
+  it('no longer filters on sender_type=coordinator — a solomon or orchestrator sender at a verified retired seat also moves', async () => {
+    const fixture = baseFixture();
+    fixture.session_coordination = [
+      { id: 'a', target_session: 'retired-1', sender_type: 'orchestrator', acknowledged_at: null, payload: { kind: 'adam_action_required' }, created_at: recent(1) },
+    ];
+    const sb = createFixtureSupabase(fixture);
+    const result = await retargetStaleAdamInbound(sb, { staleOriginator: 'retired-1', liveAdam: 'live-adam' });
+    expect(result.retargeted).toBe(1);
+  });
+
+  it('resolver error fails closed (0 retargeted, error surfaced)', async () => {
+    const sb = createFixtureSupabase(baseFixture());
+    sb.setError('claude_sessions');
+    const result = await retargetStaleAdamInbound(sb, { staleOriginator: 'retired-1', liveAdam: 'live-adam' });
+    expect(result.retargeted).toBe(0);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('same-session and missing-argument no-ops are preserved', async () => {
+    const sb = createFixtureSupabase(baseFixture());
+    expect(await retargetStaleAdamInbound(sb, { staleOriginator: 'x', liveAdam: 'x' })).toEqual({ retargeted: 0, error: null });
+    expect(await retargetStaleAdamInbound(sb, { staleOriginator: null, liveAdam: 'x' })).toEqual({ retargeted: 0, error: null });
+  });
+});
+
+// FR-7/AC-13/TS-14: resolveAdamSessionIds (the watchdog's own resolver) must see BOTH live and
+// retired Adam seats. Uses the genuinely-filtering fixture store rather than the existing
+// watchdog test file's fakeSupabase (which returns adamIds unconditionally regardless of the
+// role filter applied — non-vacuous only here, not there).
+describe('resolveAdamSessionIds (watchdog, FR-7) — sees both live and retired Adam seats', () => {
+  it('returns ids for role=adam AND role=adam_retired, excluding other roles', async () => {
+    const sb = createFixtureSupabase({
+      claude_sessions: [
+        { session_id: 'live-adam', metadata: { role: 'adam' } },
+        { session_id: 'retired-adam', metadata: { role: ADAM_RETIRED_ROLE } },
+        { session_id: 'other', metadata: { role: 'worker' } },
+      ],
+    });
+    const { ids, error } = await resolveAdamSessionIds(sb);
+    expect(error).toBeNull();
+    expect(ids.sort()).toEqual(['live-adam', 'retired-adam']);
+  });
+
+  it('is non-vacuous: with only a retired seat and no live one, still returns it (proves the filter is not a no-op)', async () => {
+    const sb = createFixtureSupabase({
+      claude_sessions: [{ session_id: 'retired-only', metadata: { role: ADAM_RETIRED_ROLE } }],
+    });
+    const { ids } = await resolveAdamSessionIds(sb);
+    expect(ids).toEqual(['retired-only']);
+  });
+});
+
+// TR-4/AC-14: ADAM_MAIL_TTL_DAYS must not silently drift from the ESM source of truth.
+describe('AC-14 — ADAM_MAIL_TTL_DAYS stays in sync with the ESM ACK_TTL_DAYS source', () => {
+  it('adam-identity.cjs local constant matches lib/retention/session-coordination-ack-convergence.js', () => {
+    const retentionSrc = fs.readFileSync(path.join(repoRoot, 'lib/retention/session-coordination-ack-convergence.js'), 'utf8');
+    const m = /const ACK_TTL_DAYS\s*=\s*(\d+)/.exec(retentionSrc);
+    expect(m).not.toBeNull(); // source-pin must actually match before comparing
+    expect(ADAM_MAIL_TTL_DAYS).toBe(Number(m[1]));
+  });
+});

--- a/tests/unit/coordinator/adam-reply-target-integrity.test.js
+++ b/tests/unit/coordinator/adam-reply-target-integrity.test.js
@@ -9,38 +9,52 @@
  */
 import { describe, it, expect } from 'vitest';
 import adamIdentity from '../../../lib/coordinator/adam-identity.cjs';
+import { createFixtureSupabase } from '../../helpers/postgrest-fixture-store.js';
 
 const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered } = adamIdentity;
 
-// Minimal chainable supabase mock. claude_sessions reads return `freshAdams`; session_coordination
-// UPDATE...select('id') returns `retargetRows`; maybeSingle returns `verifyRow`.
-function makeSb({ freshAdams = [], retargetRows = [], retargetError = null, verifyRow = null } = {}) {
+// Minimal chainable supabase mock. claude_sessions reads return `freshAdams` (the election query,
+// unfiltered pagination) OR, when SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001's
+// resolveRetiredAdamSeats issues its role-filtered query, the ids in `retiredSeats`.
+// session_coordination is routed through the genuinely-filtering postgrest-fixture-store
+// (retargetStaleAdamInbound now selects real rows, not a bulk-update patch) so `retargetRows`
+// carries real row shape (target_session/acknowledged_at/payload/created_at), not just `{id}`.
+// maybeSingle returns `verifyRow`.
+function makeSb({ freshAdams = [], retiredSeats = [], retargetRows = [], retargetError = null, verifyRow = null } = {}) {
   const calls = { updates: [] };
+  const seedRows = retargetRows.map((r) => ({ ...r }));
+  if (verifyRow) seedRows.push({ ...verifyRow });
+  const scFixture = createFixtureSupabase({ session_coordination: seedRows });
   const sb = {
     _calls: calls,
+    table: (name) => scFixture.table(name),
     from(table) {
-      let isUpdate = false;
+      if (table === 'session_coordination') {
+        if (retargetError) scFixture.setError('session_coordination', retargetError.message);
+        const inner = scFixture.from(table);
+        const wrapped = Object.create(inner);
+        wrapped.update = (patch) => { calls.updates.push({ table, patch }); return inner.update(patch); };
+        return wrapped;
+      }
+      let roleFilter;
       const builder = {
         select() { return builder; },
         gte() { return builder; },
         filter() { return builder; },
-        eq() { return builder; },
+        eq(col, val) { if (col === 'metadata->>role') roleFilter = val; return builder; },
         is() { return builder; },
-        // FR-6 (count-truncation discipline): fetchFreshAdams paginates via fetchAllPaginated,
-        // whose pages end in .order(...).range(from, to) — slice so the short-page loop exits.
+        // FR-6 (count-truncation discipline): fetchFreshAdams / resolveRetiredAdamSeats paginate
+        // via fetchAllPaginated, whose pages end in .order(...).range(from, to).
         order() { return builder; },
         range(from, to) {
-          const rows = table === 'claude_sessions' ? freshAdams : [];
+          const rows = roleFilter !== undefined
+            ? retiredSeats.map((id) => ({ session_id: id }))
+            : freshAdams;
           return Promise.resolve({ data: rows.slice(from, to + 1), error: null });
         },
-        update(patch) { isUpdate = true; calls.updates.push({ table, patch }); return builder; },
         maybeSingle() { return Promise.resolve({ data: verifyRow, error: null }); },
         then(resolve, reject) {
-          let result;
-          if (table === 'claude_sessions') result = { data: freshAdams, error: null };
-          else if (table === 'session_coordination') result = isUpdate ? { data: retargetRows, error: retargetError } : { data: [], error: null };
-          else result = { data: [], error: null };
-          return Promise.resolve(result).then(resolve, reject);
+          return Promise.resolve({ data: freshAdams, error: null }).then(resolve, reject);
         },
       };
       return builder;
@@ -76,34 +90,54 @@ describe('FR-1 resolveAdamReplyTarget — re-route to the live Adam', () => {
   });
 });
 
+const recent = (minAgo = 60) => new Date(Date.now() - minAgo * 60_000).toISOString();
+const retargetRow = (id, overrides = {}) => ({
+  id, target_session: 'stale', acknowledged_at: null, payload: { kind: 'coordinator_reply' }, created_at: recent(), ...overrides,
+});
+
 describe('FR-2 retargetStaleAdamInbound — recover stuck unread inbound', () => {
   it('recovers unread coordinator rows from the stale originator and reports the count', async () => {
-    const sb = makeSb({ retargetRows: [{ id: 'm1' }, { id: 'm2' }] });
+    const sb = makeSb({ retiredSeats: ['stale'], retargetRows: [retargetRow('m1'), retargetRow('m2')] });
     const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'stale', liveAdam: 'live' });
     expect(r.retargeted).toBe(2);
     expect(r.error).toBe(null);
   });
 
   it('is a no-op when originator === live Adam (nothing to recover)', async () => {
-    const sb = makeSb({ retargetRows: [{ id: 'm1' }] });
+    const sb = makeSb({ retiredSeats: ['x'], retargetRows: [retargetRow('m1', { target_session: 'x' })] });
     const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'x', liveAdam: 'x' });
     expect(r.retargeted).toBe(0);
   });
 
+  // SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-4): staleOriginator must now be
+  // independently VERIFIED as a retired seat — a plausible-looking originator that resolveRetiredAdamSeats
+  // does not recognize moves nothing, even though rows exist and are otherwise eligible.
+  it('an UNVERIFIED staleOriginator (not in the retired-seat set) moves 0 — the blast-radius regression', async () => {
+    const sb = makeSb({ retiredSeats: [], retargetRows: [retargetRow('m1')] });
+    const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'stale', liveAdam: 'live' });
+    expect(r.retargeted).toBe(0);
+    expect(r.error).toBe(null);
+  });
+
   it('surfaces a recovery error (never silent)', async () => {
-    const sb = makeSb({ retargetError: { message: 'db down' } });
+    const sb = makeSb({ retiredSeats: ['stale'], retargetError: { message: 'db down' } });
     const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'stale', liveAdam: 'live' });
     expect(r.retargeted).toBe(0);
     expect(r.error).toBe('db down');
   });
 
-  // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-3: regression pin, not a fix — one
-  // of the 4 already-correct re-target paths RISK identified.
-  it('(FR-3 pin) the update patch is ONLY {target_session} — never sender_session/created_at', async () => {
-    const sb = makeSb({ retargetRows: [{ id: 'm1' }] });
+  // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-3, updated by
+  // SD-LEO-INFRA-ADAM-HANDOFF-MAIL-FORWARDING-001 (FR-4/AC-16): the patch now also stamps
+  // payload.retargeted_from/retargeted_at (this mover previously carried no such breadcrumb) —
+  // still never sender_session/created_at.
+  it('(FR-3/AC-16 pin) the update patch is {target_session, payload} with retargeted_from/at stamped — never sender_session/created_at', async () => {
+    const sb = makeSb({ retiredSeats: ['stale'], retargetRows: [retargetRow('m1')] });
     await retargetStaleAdamInbound(sb, { staleOriginator: 'stale', liveAdam: 'live' });
     const patch = sb._calls.updates[0].patch;
-    expect(patch).toEqual({ target_session: 'live' });
+    expect(Object.keys(patch).sort()).toEqual(['payload', 'target_session']);
+    expect(patch.target_session).toBe('live');
+    expect(patch.payload.retargeted_from).toBe('stale');
+    expect(patch.payload.retargeted_at).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary
- Two successor-Adam mail movers (`drainAdamOutbound` at register-time, `retargetStaleAdamInbound` at reply-time) used divergent, too-narrow predicates. Measured: 212 unacked rows stranded at 18 retired seats, all with `read_at` set and past the 24h window, so `drainAdamOutbound` moved exactly zero of them regardless of kind filtering.
- Adds a shared, verified retired-seat resolver (`resolveRetiredAdamSeats`) and a shared successor-inherit predicate both movers now delegate to.
- **Safety-critical fix**: `retargetStaleAdamInbound` now independently verifies its target against the resolver before widening its predicate — dropping the old `sender_type='coordinator'` filter without that gate would have let the update sweep every unacked row at a mis-resolved session from any sender.
- `adam-register.cjs`'s drain call is decoupled from this-call's own `retired[]` count, so the full historical backlog is swept on every register, not abandoned after one narrow attempt at the moment a seat retires.
- Both movers now stamp `payload.retargeted_from`/`retargeted_at`; `adam-register.cjs`'s JSON output reports inherited counts by kind; the watchdog's `resolveAdamSessionIds` gained retired-role visibility.
- Adds `tests/helpers/postgrest-fixture-store.js` — a genuinely-filtering fake Supabase double — replacing the repo's existing no-op-filter test stubs for this code path, which could only catch a wrong update-patch shape, never a wrong filter.

## Test plan
- [x] New comprehensive suite (`tests/unit/coordination/adam-successor-inherit.test.js`, 18 tests) pins the resolver, both widened movers, the blast-radius regression (unverified target moves 0), idempotency, TR-5's concurrent-update race, and FR-7's watchdog fix
- [x] Fixed 4 stale pins in `tests/unit/coordination/adam-singleton.test.js` and 3 in `tests/unit/coordinator/adam-reply-target-integrity.test.js` that asserted the old narrower behavior
- [x] Full regression sweep: `npx vitest run tests/unit/adam tests/unit/coordination tests/unit/coordinator` — 199 files / 2263 tests pass
- [x] LEAD-TO-PLAN and PLAN-TO-EXEC handoffs passed with fresh sub-agent evidence (VALIDATION, Explore, TESTING) and two audited critique overrides (both confirmed-false-positive gate findings, documented in `plan_critiques`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)