### PR TITLE
fix(SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001): EXEC-phase security/testing review remediations

### DIFF
--- a/lib/checkin/steps/directed-assignment.cjs
+++ b/lib/checkin/steps/directed-assignment.cjs
@@ -17,6 +17,14 @@ const { assessInstructionPremise, PREMISE_FRESHNESS_BOUND_MS } = require('../../
 // and needs its own symmetric exception, or a parent_completion assignment would be created
 // successfully and then immediately declined/purged here.
 const { checkParentCompletable } = require('../../fleet/orchestrator-completion.cjs');
+// SECURITY finding SEC-H1 (EXEC-phase review, evidence d727c054): the injected
+// classifyDispatchIneligibility helper (ctx.helpers, below) is a FIRST-MATCH classifier over an
+// ordered axis table with orchestrator_parent checked first, so it structurally cannot report a
+// second axis for an orchestrator SD even when one is also active. The exception below now uses
+// the ALL-match export directly (required here, same as checkParentCompletable above, rather than
+// threading a new entry through the ctx.helpers construction site) and requires the axis set to
+// be EXACTLY ['orchestrator_parent'] before it applies.
+const { classifyAllDispatchIneligibility } = require('../../fleet/claim-eligibility.cjs');
 
 module.exports = {
   name: 'directed-assignment',
@@ -24,7 +32,7 @@ module.exports = {
     const { sb, sessionId, sessionRole } = ctx;
     const {
       ws, tryClaim, stampDirectedAssignment, ackMessage, extractSdFromAssignment, isInformationalNudge,
-      classifyDispatchIneligibility, antiWinddownDirective,
+      antiWinddownDirective,
       ASSIGNMENT_RECENCY_WINDOW_MS, TERMINAL_CLAIM_ERRORS,
     } = ctx.helpers;
     // 5. pending WORK_ASSIGNMENT -> claim via claim_sd RPC
@@ -205,15 +213,21 @@ module.exports = {
         // sd-start releases -> repeats every tick). No tierCtx: an explicit coordinator directive
         // should not be second-guessed by the WORK-DOWN-NEVER-UP self-claim preference, only the hard
         // fitness/premise axes (repo mismatch, terminal/superseded premise, orchestrator parent, etc).
-        let ineligibleReason = (!terminalStatus && assignedSdRow)
-          ? classifyDispatchIneligibility(assignedSdRow, { cwd: process.cwd() })
-          : null;
+        // SEC-H1: classifyAllDispatchIneligibility (ALL-match), not the single first-match
+        // classifier -- see the file-header comment for why. sd_terminal/sd_deferred are not
+        // axes this classifier reports (that set belongs to the earlier terminalStatus check
+        // above), so no filtering is needed here.
+        const allIneligibleReasons = (!terminalStatus && assignedSdRow)
+          ? classifyAllDispatchIneligibility(assignedSdRow, { cwd: process.cwd() })
+          : [];
+        let ineligibleReason = allIneligibleReasons[0] || null;
         // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-1): symmetric exception to FR-4's
         // dispatch.cjs one. NARROW on purpose: only payload.kind==='parent_completion', only when
-        // the classifier's verdict is specifically orchestrator_parent (never overrides any other
-        // ineligibility reason), and only when independently re-verified completable -- never
-        // fail-open on a could-not-check or not-completable result.
-        if (ineligibleReason === 'orchestrator_parent' && assignment.payload?.kind === 'parent_completion' && assignedSdRow) {
+        // orchestrator_parent is the SOLE active axis (SEC-H1 -- never overrides a DIFFERENT or
+        // ADDITIONAL ineligibility reason that would otherwise have been masked), and only when
+        // independently re-verified completable -- never fail-open on a could-not-check or
+        // not-completable result.
+        if (allIneligibleReasons.length === 1 && allIneligibleReasons[0] === 'orchestrator_parent' && assignment.payload?.kind === 'parent_completion' && assignedSdRow) {
           try {
             const check = await checkParentCompletable(sb, { id: assignedSdRow.id, sd_key: sdKey, status: assignedSdRow.status });
             if (!check.couldNotCheck && check.completable) {

--- a/lib/coordinator/dispatch-parent-completion.test.js
+++ b/lib/coordinator/dispatch-parent-completion.test.js
@@ -132,4 +132,21 @@ describe('assertSdDispatchable — FR-4 parent_completion exception', () => {
       assertSdDispatchable(supabase, waRow({ kind: 'parent_completion' }), { warn() {}, error() {} })
     ).resolves.toBeUndefined();
   });
+
+  it('SEC-H1 regression (evidence d727c054): an orchestrator parent that ALSO carries a real second hold (requires_human_action) is REFUSED, not silently let through as a bare orchestrator_parent case', async () => {
+    // sd_type='orchestrator' fires the orchestrator_parent axis; metadata.requires_human_action
+    // ALSO fires the human_action_required axis. classifyDispatchIneligibility (single, first-
+    // match) would report only 'orchestrator_parent' (checked first in the axis table) and
+    // silently mask the human-action hold -- the exact defect SEC-H1 describes. The fix uses
+    // classifyAllDispatchIneligibility and requires the axis SET to be exactly
+    // ['orchestrator_parent'] before the parent_completion exception applies.
+    const supabase = stubSupabase({
+      sdRow: { id: PARENT_ID, status: 'pending_approval', sd_type: 'orchestrator', metadata: { requires_human_action: true }, target_application: 'EHG_Engineer' },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
+      handoffRows: [],
+    });
+    await expect(
+      assertSdDispatchable(supabase, waRow({ kind: 'parent_completion' }), { warn() {}, error() {} })
+    ).rejects.toMatchObject({ code: 'DISPATCH_SD_INELIGIBLE' });
+  });
 });

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -27,7 +27,7 @@ const { MAX_PARTS } = require('./multi-part-reply.cjs');
 const crypto = require('crypto');
 // SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001 (FR-1): the shared SSOT dispatch-
 // ineligibility classifier, mirror-killed into assertSdDispatchable below.
-const { classifyDispatchIneligibility } = require('../fleet/claim-eligibility.cjs');
+const { classifyAllDispatchIneligibility } = require('../fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-4): the shared completability predicate,
 // consumed ONLY here (dispatch.cjs) for the narrow parent_completion exception below -- deliberately
 // NOT wired into classifyDispatchIneligibility itself, which is shared by the worker SELF-CLAIM
@@ -298,16 +298,30 @@ async function assertSdDispatchable(supabase, row, logger = console) {
   // sd_terminal/sd_deferred are excluded here since the explicit terminal check above already threw
   // a more specific DISPATCH_SD_TERMINAL error for those cases.
   if (!isQf) {
-    const verdict = classifyDispatchIneligibility(
+    // SECURITY finding SEC-H1 (EXEC-phase review, evidence d727c054): classifyDispatchIneligibility
+    // is a FIRST-MATCH classifier over an ORDERED axis table with orchestrator_parent checked
+    // first — so for any orchestrator SD it structurally CANNOT report a second axis, even if one
+    // is also active (human_action_required, chairman_ratification_pending, needs_coordinator_
+    // review, co_author_pending, lead_blocker_active, unfit_repo_mismatch, ...). The FR-4
+    // exception below, keyed on that single first-match verdict, would silently discard any such
+    // masked hold. Fixed by switching to the ALL-match export and requiring the axis set to be
+    // EXACTLY ['orchestrator_parent'] — no other hold present — before the exception applies.
+    const allVerdicts = classifyAllDispatchIneligibility(
       { sd_key: sdKey, sd_type: sdType, metadata, target_application: targetApplication, status },
       undefined
     );
+    // sd_terminal/sd_deferred excluded here since the explicit terminal check above already threw
+    // a more specific DISPATCH_SD_TERMINAL error for those cases (unchanged from before this fix).
+    const relevantVerdicts = allVerdicts.filter((v) => v !== 'sd_terminal' && v !== 'sd_deferred');
+
     // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 (FR-4): narrow, explicit exception to the
-    // orchestrator_parent fence — ONLY for a parent_completion-kind WA, and ONLY when the parent is
+    // orchestrator_parent fence — ONLY for a parent_completion-kind WA, ONLY when orchestrator_
+    // parent is the SOLE active axis (no other hold masked), and ONLY when the parent is
     // independently verified completable (all children terminal per guard 4's definition, no
-    // accepted LEAD-FINAL-APPROVAL yet, not already completed/cancelled). Every other verdict/kind
-    // combination is refused exactly as before this SD — this is additive, not a general relaxation.
-    if (verdict === 'orchestrator_parent' && payload.kind === 'parent_completion') {
+    // accepted LEAD-FINAL-APPROVAL yet, not already completed/cancelled/deferred). Every other
+    // verdict/kind combination is refused exactly as before this SD — this is additive, not a
+    // general relaxation.
+    if (relevantVerdicts.length === 1 && relevantVerdicts[0] === 'orchestrator_parent' && payload.kind === 'parent_completion') {
       const check = await checkParentCompletable(supabase, { id: sdId, sd_key: sdKey, status });
       if (check.couldNotCheck) {
         // Never fail-open on an unverifiable eligibility check (FR-4 acceptance criterion).
@@ -324,8 +338,9 @@ async function assertSdDispatchable(supabase, row, logger = console) {
         logger && logger.error && logger.error(e.message);
         throw e;
       }
-      // Eligible parent_completion — fall through, ALLOWED.
-    } else if (verdict && verdict !== 'sd_terminal' && verdict !== 'sd_deferred') {
+      // Eligible parent_completion, orchestrator_parent the sole axis — fall through, ALLOWED.
+    } else if (relevantVerdicts.length > 0) {
+      const verdict = relevantVerdicts[0];
       const e = new Error(`[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} is dispatch-ineligible (${verdict}) — mirrors the self-claim/sweep path's classifyDispatchIneligibility verdict.`);
       e.code = 'DISPATCH_SD_INELIGIBLE';
       e.verdict = verdict;

--- a/lib/fleet/orchestrator-completion.cjs
+++ b/lib/fleet/orchestrator-completion.cjs
@@ -8,10 +8,17 @@
  * surface), and FR-4 (coordinator dispatch-choke exception in lib/coordinator/dispatch.cjs).
  * MIRRORS complete_orchestrator_sd()'s guard 4 (database/migrations/20260329_pcvp_phase1_close_
  * bypass_holes.sql) literal status set -- a JS mirror of a SQL guard, not a shared call into the
- * same code (Postgres functions cannot be invoked as a JS predicate). See
- * orchestrator-completion.test.js for the cross-check that pins this set against a live
- * pg_get_functiondef(complete_orchestrator_sd) read, so a future SQL-side change is caught by a
- * failing test rather than silently diverging.
+ * same code (Postgres functions cannot be invoked as a JS predicate).
+ *
+ * TESTING finding (EXEC-phase review, evidence a18127d0) -- CORRECTED CLAIM: the cross-check
+ * against the LIVE SQL guard is NOT an automated test. orchestrator-completion-guard4-extract.
+ * test.js is a pure unit test that only exercises the extraction logic against synthetic/doctored
+ * strings (including a deliberate mismatch case, to prove the comparator can reject) -- it has NO
+ * live DB access and cannot detect a real SQL-side drift. The actual live cross-check is
+ * scripts/verify-orchestrator-completion-guard4-crosscheck.mjs, a STANDALONE, MANUALLY-INVOKED
+ * script (not wired into CI as of this SD) -- see that file's own header for why it lives outside
+ * vitest's db-tier project. A future SQL-side change to guard 4 is caught only if that script is
+ * actually run, not by any automated test in this repo today.
  *
  * Three divergent "terminal child status" definitions were found live during this SD's
  * investigation: v_orchestrator_completion_status (status='completed' ONLY), complete_orchestrator_sd()
@@ -47,7 +54,12 @@ async function checkParentCompletable(supabase, parent) {
   if (!parent || !parent.id) {
     return { couldNotCheck: true, completable: false, reason: 'NO_PARENT_ROW', children: [], hasAcceptedLeadFinal: false };
   }
-  if (parent.status === 'completed' || parent.status === 'cancelled') {
+  // SECURITY finding SEC-M2 (EXEC-phase review, evidence d727c054): 'deferred' is the SAME
+  // resurrection-risk class as 'cancelled' (a deliberately paused parent) but was missing from
+  // this exclusion -- live specimen SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-I is a deferred
+  // orchestrator parent that was protected only incidentally (by its own deferred child, not by
+  // this check). Excluded explicitly now, not left to a coincidence.
+  if (parent.status === 'completed' || parent.status === 'cancelled' || parent.status === 'deferred') {
     return { couldNotCheck: false, completable: false, reason: `PARENT_ALREADY_TERMINAL(${parent.status})`, children: [], hasAcceptedLeadFinal: false };
   }
 

--- a/lib/fleet/parent-completion-default-run-handoff.test.js
+++ b/lib/fleet/parent-completion-default-run-handoff.test.js
@@ -1,0 +1,60 @@
+/**
+ * SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001 -- defaultRunHandoff's HANDOFF_RESULT parsing.
+ *
+ * TESTING finding (HIGH, EXEC-phase review, evidence a18127d0): the emitter
+ * (scripts/modules/handoff/cli/execution-helpers.js) documents the result line as "Emitted LAST
+ * so grep/tail can always find it" -- a non-global .match() is FIRST-wins, the opposite
+ * guarantee. Concretely dangerous because handoff.js's own D16 sibling-selection mechanism can
+ * continue past a failed SD and print a SECOND, unrelated HANDOFF_RESULT line into the same
+ * stdout (two live instances observed in this session's own manual runs). A first-wins match
+ * could silently attribute a DIFFERENT SD's result to the caller's request.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const execFileMock = vi.fn();
+vi.mock('node:child_process', () => ({ execFile: (...args) => execFileMock(...args) }));
+vi.mock('node:util', () => ({ promisify: (fn) => (...args) => fn(...args) }));
+
+const { defaultRunHandoff } = await import('./parent-completion.mjs');
+
+function resolveExecFile(stdout) {
+  execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+    // promisify-wrapped execFile is called as (cmd, args, opts) and returns a promise in real
+    // usage; our promisify mock just forwards args, so simulate the promise-returning shape here.
+    return Promise.resolve({ stdout, stderr: '' });
+  });
+}
+
+describe('defaultRunHandoff', () => {
+  it('parses a single, unambiguous HANDOFF_RESULT line correctly', async () => {
+    resolveExecFile('...\nHANDOFF_RESULT=PASS SD=SD-ORCH-PARENT-001 SCORE=99 PHASE=LEAD-FINAL-APPROVAL\n');
+    const result = await defaultRunHandoff('LEAD-FINAL-APPROVAL', 'SD-ORCH-PARENT-001');
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(99);
+  });
+
+  it('regression: picks the LAST HANDOFF_RESULT line, not the first, when handoff.js\'s own sibling-selection mechanism prints a second, unrelated result for a DIFFERENT SD into the same stdout', async () => {
+    resolveExecFile([
+      'HANDOFF_RESULT=FAIL SD=SD-OTHER-SIBLING-001 SCORE=40 PHASE=LEAD-FINAL-APPROVAL REASON=SOME_GATE',
+      '...D16 sibling-selection continued...',
+      'HANDOFF_RESULT=PASS SD=SD-ORCH-PARENT-001 SCORE=99 PHASE=LEAD-FINAL-APPROVAL',
+    ].join('\n'));
+    const result = await defaultRunHandoff('LEAD-FINAL-APPROVAL', 'SD-ORCH-PARENT-001');
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(99);
+  });
+
+  it('never silently accepts a result line naming a DIFFERENT SD than requested -- reports HANDOFF_RESULT_SD_MISMATCH instead', async () => {
+    resolveExecFile('HANDOFF_RESULT=PASS SD=SD-COMPLETELY-UNRELATED-001 SCORE=100 PHASE=LEAD-FINAL-APPROVAL\n');
+    const result = await defaultRunHandoff('LEAD-FINAL-APPROVAL', 'SD-ORCH-PARENT-001');
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('HANDOFF_RESULT_SD_MISMATCH');
+  });
+
+  it('reports UNPARSEABLE_HANDOFF_OUTPUT (never a silent pass) when no result line is found', async () => {
+    resolveExecFile('some unrelated output with no result line\n');
+    const result = await defaultRunHandoff('LEAD-FINAL-APPROVAL', 'SD-ORCH-PARENT-001');
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('UNPARSEABLE_HANDOFF_OUTPUT');
+  });
+});

--- a/lib/fleet/parent-completion.mjs
+++ b/lib/fleet/parent-completion.mjs
@@ -62,9 +62,23 @@ export async function defaultRunHandoff(phase, sdKey) {
     stdout = (e.stdout || '') + (e.stderr || '');
     code = typeof e.code === 'number' ? e.code : 1;
   }
-  const resultLine = stdout.match(/HANDOFF_RESULT=(PASS|FAIL)\s+SD=\S+\s+SCORE=(\d+)\s+PHASE=\S+(?:\s+REASON=(\S+))?/);
+  // TESTING finding (HIGH, EXEC-phase review, evidence a18127d0): the emitter
+  // (scripts/modules/handoff/cli/execution-helpers.js) documents the result line as "Emitted
+  // LAST so grep/tail can always find it" -- but a non-global .match() is FIRST-wins, the
+  // opposite guarantee. Concretely dangerous because handoff.js's own D16 sibling-selection
+  // mechanism can continue past a failed SD and print a SECOND, unrelated HANDOFF_RESULT line
+  // into the SAME stdout (two live instances observed this session) -- a first-wins match could
+  // silently attribute a DIFFERENT SD's result to this call. Fixed two ways: (1) global regex +
+  // take the LAST match, per the emitter's own contract; (2) assert the matched SD actually
+  // equals the requested sdKey -- a result line naming a different SD is never silently accepted.
+  const pattern = /HANDOFF_RESULT=(PASS|FAIL)\s+SD=(\S+)\s+SCORE=(\d+)\s+PHASE=\S+(?:\s+REASON=(\S+))?/g;
+  const matches = [...stdout.matchAll(pattern)];
+  const resultLine = matches[matches.length - 1];
   if (resultLine) {
-    return { pass: resultLine[1] === 'PASS', score: Number(resultLine[2]), reason: resultLine[3] || null, raw: stdout };
+    if (resultLine[2] !== sdKey) {
+      return { pass: false, score: null, reason: 'HANDOFF_RESULT_SD_MISMATCH', raw: stdout };
+    }
+    return { pass: resultLine[1] === 'PASS', score: Number(resultLine[3]), reason: resultLine[4] || null, raw: stdout };
   }
   // No parseable result line -- treat as a failure, never assume pass on ambiguous output.
   return { pass: false, score: null, reason: code === 0 ? 'UNPARSEABLE_HANDOFF_OUTPUT' : 'HANDOFF_PROCESS_ERROR', raw: stdout };

--- a/tests/unit/checkin/directed-assignment-parent-completion.test.js
+++ b/tests/unit/checkin/directed-assignment-parent-completion.test.js
@@ -5,6 +5,12 @@
  * Without this, a parent_completion WORK_ASSIGNMENT that assertSdDispatchable allowed to be
  * CREATED would still be immediately DECLINED/purged at the worker's own claim step, because
  * classifyDispatchIneligibility is consumed independently here too (TESTING finding TST-C3).
+ *
+ * SEC-H1 (EXEC-phase security review, evidence d727c054): the production code now calls the REAL,
+ * unmocked classifyAllDispatchIneligibility (required directly, not injected via ctx.helpers) --
+ * an injectable mock would hide exactly the bug this finding describes (a first-match classifier
+ * silently discarding a second, real axis). These tests exercise the real classifier against real
+ * fixture shapes for that reason; ctx.helpers no longer carries a classifier at all.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
@@ -26,7 +32,7 @@ function assignmentRow(kind) {
   };
 }
 
-function baseHelpers({ classifyVerdict = 'orchestrator_parent', claimResult = { ok: true } } = {}) {
+function baseHelpers({ claimResult = { ok: true } } = {}) {
   return {
     ws: { getMessagesForSession: vi.fn(async () => [assignmentRow('parent_completion')]) },
     tryClaim: vi.fn(async () => claimResult),
@@ -34,7 +40,6 @@ function baseHelpers({ classifyVerdict = 'orchestrator_parent', claimResult = { 
     ackMessage: vi.fn(async () => ({ acknowledged: true })),
     extractSdFromAssignment: () => PARENT_KEY,
     isInformationalNudge: () => false,
-    classifyDispatchIneligibility: vi.fn(() => classifyVerdict),
     antiWinddownDirective: () => '',
     ASSIGNMENT_RECENCY_WINDOW_MS: 24 * 60 * 60 * 1000,
     TERMINAL_CLAIM_ERRORS: new Set(),
@@ -140,11 +145,30 @@ describe('directed-assignment.cjs — FR-1 parent_completion claim exception', (
   });
 
   it('a non-orchestrator_parent ineligibility verdict is never overridden by this exception', async () => {
-    const helpers = baseHelpers({ classifyVerdict: 'human_action_required' });
+    const helpers = baseHelpers();
     const ctx = makeCtx({
       helpers,
       sdRow: { id: PARENT_ID, status: 'pending_approval', sd_type: 'feature', metadata: { requires_human_action: true }, target_application: 'EHG_Engineer' },
       childrenRows: [],
+      handoffRows: [],
+    });
+    const result = await directedAssignment.run(ctx);
+    expect(result).toBeUndefined();
+    expect(helpers.tryClaim).not.toHaveBeenCalled();
+  });
+
+  it('SEC-H1 regression: an orchestrator parent that ALSO carries a real second hold (requires_human_action) is REFUSED, not silently let through as a bare orchestrator_parent case', async () => {
+    const helpers = baseHelpers();
+    const ctx = makeCtx({
+      helpers,
+      // sd_type='orchestrator' fires the orchestrator_parent axis; metadata.requires_human_action
+      // ALSO fires the human_action_required axis. A first-match classifier would report only
+      // 'orchestrator_parent' (checked first) and silently mask the human-action hold -- the
+      // exact defect SEC-H1 describes. The fix requires the axis SET to be exactly
+      // ['orchestrator_parent'] before the parent_completion exception applies; two real axes
+      // present must refuse, even with all children terminal and payload.kind='parent_completion'.
+      sdRow: { id: PARENT_ID, status: 'pending_approval', sd_type: 'orchestrator', metadata: { requires_human_action: true }, target_application: 'EHG_Engineer' },
+      childrenRows: [{ id: 'c1', status: 'completed' }],
       handoffRows: [],
     });
     const result = await directedAssignment.run(ctx);


### PR DESCRIPTION
## Summary
- Fixes 3 genuine findings from LANES-001's own EXEC-phase TESTING (evidence `a18127d0`) and SECURITY (evidence `d727c054`) sub-agent reviews, found and fixed before reporting EXEC-TO-PLAN readiness.
- **TESTING HIGH**: `defaultRunHandoff`'s `HANDOFF_RESULT` parser used first-match instead of last-match, contradicting the emitter's own documented "emitted LAST" contract — `handoff.js`'s D16 sibling-selection mechanism can print a second, unrelated `HANDOFF_RESULT` line for a different SD into the same stdout (observed live twice this session). Fixed: global regex + last-match + SD-key equality assertion; a mismatch now reports `HANDOFF_RESULT_SD_MISMATCH` instead of silently trusting the wrong SD's result.
- **SECURITY HIGH (SEC-H1)**: the `parent_completion` dispatch exception (both `dispatch.cjs` and `directed-assignment.cjs`) was keyed on the single-match `classifyDispatchIneligibility`, which structurally cannot report a second ineligibility axis for an orchestrator SD (axis table is ordered, `orchestrator_parent` checked first) — masking any co-occurring real hold. Fixed: both sites now use `classifyAllDispatchIneligibility` and require the axis set to be exactly `['orchestrator_parent']`.
- **SECURITY MEDIUM (SEC-M2)**: `checkParentCompletable` excluded `completed`/`cancelled` parents but not `deferred` (same resurrection-risk class). Added explicit exclusion; live specimen `SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-I` was previously protected only incidentally.
- Also corrects a stale comment falsely claiming an automated test catches SQL-side guard-4 drift (the real live cross-check is the standalone `scripts/verify-orchestrator-completion-guard4-crosscheck.mjs`).
- SEC-M1 (claim CAS race in the pre-existing, unmodified `claim-orchestrator-for-rollup.mjs`) is documented as a known limitation, not fixed — out of this SD's scope, and `payload.kind='parent_completion'` currently has zero producers repo-wide so it isn't live-exploitable yet.

## Test plan
- [x] `node --check` on all 4 modified production files
- [x] `npx vitest run --project unit lib/fleet/ lib/coordinator/dispatch.test.js lib/coordinator/dispatch-parent-completion.test.js tests/unit/checkin/` — 345/345 passing, 31/31 files, no regressions
- [x] New regression tests added: SEC-H1 masked-second-axis case in both `dispatch-parent-completion.test.js` and `directed-assignment-parent-completion.test.js`; 4 new tests in `lib/fleet/parent-completion-default-run-handoff.test.js` covering the D16 two-result-lines adversarial scenario, SD-mismatch, and unparseable-output cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)