### PR TITLE
fix(SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001): fence STUCK_100's raw completion write

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -630,6 +630,45 @@ function resolveAcceptedHandoffSets(candidateSds, handoffRows) {
 }
 
 /**
+ * SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001 (adversarial-review fix): PURE resolver for
+ * the orchestrator-parent fence's two axes. TWO independent axes, because sd_type can be wrong
+ * or missing but a real child row cannot lie:
+ *   1. The SHARED classifier's orchestrator_parent verdict (classifyAllDispatchIneligibility,
+ *      lib/fleet/claim-eligibility.cjs) -- requires candidateSds rows to carry `sd_type` (the
+ *      caller's query must select it; a row missing sd_type silently never matches this axis,
+ *      which is exactly the bug adversarial review found in the original version of this fence:
+ *      the feeding query never selected sd_type, making this axis permanently dead).
+ *   2. A live children lookup keyed on parent_sd_id, DUAL-KEYED the same way
+ *      resolveAcceptedHandoffSets dual-keys sd_id: lib/fleet/claim-eligibility.cjs's
+ *      parentLeadPending queries parent_sd_id via `.or(id.eq...,sd_key.eq...)` with the comment
+ *      "parent_sd_id references the parent id (== sd_key here)" -- proving this codebase already
+ *      treats parent_sd_id as holding EITHER the parent's uuid OR its sd_key string. A UUID-only
+ *      match silently misses any child linked via the sd_key-string form, leaving that parent
+ *      invisible to both axes (the second half of the same adversarial-review finding).
+ *
+ * @param {Array<{id?: string, sd_key?: string, sd_type?: string}>} candidateSds
+ * @param {Array<{parent_sd_id: string}>} childRows -- rows from a query already scoped to
+ *   parent_sd_id IN (the union of candidateSds' ids and sd_keys); caller does the I/O, this
+ *   function only resolves.
+ * @returns {Set<string>} sd_keys of candidateSds identified as orchestrator parents
+ */
+function resolveOrchestratorParentSdKeys(candidateSds, childRows) {
+  const orchestratorSdKeys = new Set(
+    candidateSds.filter(sd => classifyAllDispatchIneligibility(sd).includes('orchestrator_parent')).map(sd => sd.sd_key),
+  );
+  const parentRefToSdKey = new Map();
+  for (const sd of candidateSds) {
+    if (sd.id) parentRefToSdKey.set(sd.id, sd.sd_key);
+    if (sd.sd_key) parentRefToSdKey.set(sd.sd_key, sd.sd_key);
+  }
+  for (const row of (childRows || [])) {
+    const logicalKey = parentRefToSdKey.get(row.parent_sd_id);
+    if (logicalKey) orchestratorSdKeys.add(logicalKey);
+  }
+  return orchestratorSdKeys;
+}
+
+/**
  * SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: the SOLE site in this file that may write
  * status='completed' from the STUCK_100 stale-approval branch (any pending_approval row at
  * 100% progress with a completion_date set). Previously a raw, unfenced UPDATE with no
@@ -1618,7 +1657,10 @@ async function runQaFixtureScan(ctx) {
   try {
     allPendingApproval = await fapPaginate(() => supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, status, current_phase, progress_percentage, completion_date')
+      // sd_type: SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001 -- the orchestrator-parent fence
+      // below needs it. Without it, classifyAllDispatchIneligibility's orchestratorParent axis
+      // reads row.sd_type as always-undefined and can never fire (found by adversarial review).
+      .select('id, sd_key, sd_type, status, current_phase, progress_percentage, completion_date')
       .eq('status', 'pending_approval')
       // FR-3: never QA-reset ephemeral SD-TEST-* fixtures.
       .not('sd_key', 'like', TEST_FIXTURE_SD_KEY_LIKE)
@@ -1664,25 +1706,22 @@ async function runQaFixtureScan(ctx) {
   }
 
   // SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: orchestrator-parent detection for the
-  // STUCK_100 completion fence below. TWO independent axes, because sd_type can be wrong or
-  // missing but a real child row cannot lie: (1) the SHARED classifier's orchestrator_parent
-  // verdict (lib/fleet/claim-eligibility.cjs -- one representation, not a hand-rolled
-  // `sd_type === 'orchestrator'` check re-derived here); (2) a live children lookup
-  // (parent_sd_id), defense-in-depth against an untyped/mistyped parent row.
-  const orchestratorSdKeys = new Set(
-    stuckApproval.filter(sd => classifyAllDispatchIneligibility(sd).includes('orchestrator_parent')).map(sd => sd.sd_key),
-  );
-  const parentIdsToCheck = stuckApproval.map(sd => sd.id).filter(Boolean);
-  if (parentIdsToCheck.length > 0) {
-    const { data: childRows } = await supabase
+  // STUCK_100 completion fence below. Query I/O stays here; the two-axis resolution logic is
+  // the pure, independently-tested resolveOrchestratorParentSdKeys (mirrors resolveAcceptedHandoffSets).
+  const parentRefsToCheck = [];
+  for (const sd of stuckApproval) {
+    if (sd.id) parentRefsToCheck.push(sd.id);
+    if (sd.sd_key) parentRefsToCheck.push(sd.sd_key);
+  }
+  let orchestratorChildRows = [];
+  if (parentRefsToCheck.length > 0) {
+    const { data } = await supabase
       .from('strategic_directives_v2')
       .select('parent_sd_id')
-      .in('parent_sd_id', parentIdsToCheck);
-    const parentIdsWithChildren = new Set((childRows || []).map(r => r.parent_sd_id).filter(Boolean));
-    for (const sd of stuckApproval) {
-      if (sd.id && parentIdsWithChildren.has(sd.id)) orchestratorSdKeys.add(sd.sd_key);
-    }
+      .in('parent_sd_id', parentRefsToCheck);
+    orchestratorChildRows = data || [];
   }
+  const orchestratorSdKeys = resolveOrchestratorParentSdKeys(stuckApproval, orchestratorChildRows);
 
   for (const sd of stuckApproval) {
     // QF-20260423-909: Skip reset if the LATEST PLAN-TO-LEAD handoff is accepted — SD is
@@ -4316,6 +4355,7 @@ module.exports.isSweepResetAllowed = isSweepResetAllowed;
 // without running the whole sweep.
 module.exports.completeStuck100Sd = completeStuck100Sd;
 module.exports.resolveAcceptedHandoffSets = resolveAcceptedHandoffSets;
+module.exports.resolveOrchestratorParentSdKeys = resolveOrchestratorParentSdKeys;
 module.exports.isDormancyWatchdogEnabled = isDormancyWatchdogEnabled; // SD-FDBK-ENH-CONFIRMED-LIVE-TODAY-001
 module.exports.filterDormantByPidLiveness = filterDormantByPidLiveness; // SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001
 module.exports.isHeadlessZombie = isHeadlessZombie; // QF-20260704-081

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -34,7 +34,7 @@ const { buildRetentionAckPayload } = require('../lib/retention/retention-ack-mar
 const { PROMOTION_ACK_KEY, isPromotionAcked } = require('../lib/coordinator/promotion-ack.cjs'); // SIGNAL-ROUTER-AUTO-001 FR-8
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
-const { evaluateDispatchEligibility, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE } = require('../lib/fleet/claim-eligibility.cjs');
+const { evaluateDispatchEligibility, classifyDispatchIneligibility, classifyAllDispatchIneligibility, TEST_FIXTURE_KEY_RE } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: the sweep is the primary scheduled WORK_ASSIGNMENT producer
 // and inserts raw (it does NOT route through insertCoordinationRow), so the dispatch-side terminal
 // guard would never reach it. Call assertSdDispatchable here so the sweep also refuses to nudge a
@@ -586,6 +586,102 @@ async function getExecContextGuard() {
     _execContextGuardCache = await import('../lib/exec-context-guard.mjs');
   }
   return _execContextGuardCache;
+}
+
+/**
+ * QF-20260423-909 / SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: PURE resolver — given the
+ * candidate SD rows and their already-fetched sd_phase_handoffs rows (PLAN-TO-LEAD and/or
+ * LEAD-FINAL-APPROVAL, any order), returns the set of sd_keys with an ACCEPTED, LATEST handoff
+ * of each type. Handles the dual-keying directly: sd_phase_handoffs.sd_id holds EITHER a row's
+ * uuid OR its sd_key across eras AND today (measured live 2026-08-16: 161/1000 LEAD-FINAL-APPROVAL
+ * rows are sd_key-string-keyed, not historical debt) — a handoff row whose sd_id matches neither
+ * a candidate's id nor its sd_key is silently ignored (not this SD's row). "Latest" is by
+ * created_at, PER handoff_type PER logical sd_key (SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001
+ * FR-5 precedent: "does ANY accepted row EVER exist" is the wrong question — an old, superseded
+ * accepted row must never permanently suppress a decision after the SD's state has since
+ * regressed). Caller is responsible for ordering `handoffRows` created_at DESC before calling.
+ *
+ * @param {Array<{id?: string, sd_key?: string}>} candidateSds
+ * @param {Array<{sd_id: string, handoff_type: string, status: string, created_at: string}>} handoffRows
+ * @returns {{acceptedPlanToLeadSet: Set<string>, acceptedLeadFinalSet: Set<string>}}
+ */
+function resolveAcceptedHandoffSets(candidateSds, handoffRows) {
+  const idToSdKey = new Map();
+  for (const sd of candidateSds) {
+    if (sd.id) idToSdKey.set(sd.id, sd.sd_key);
+    if (sd.sd_key) idToSdKey.set(sd.sd_key, sd.sd_key);
+  }
+  const latestBySdKeyAndType = new Map(); // key: `${handoff_type}::${sdKey}`
+  for (const h of handoffRows) {
+    const logicalKey = idToSdKey.get(h.sd_id);
+    if (!logicalKey) continue;
+    const compositeKey = h.handoff_type + '::' + logicalKey;
+    if (!latestBySdKeyAndType.has(compositeKey)) latestBySdKeyAndType.set(compositeKey, h); // caller pre-sorts created_at DESC -> first seen is latest
+  }
+  const acceptedPlanToLeadSet = new Set();
+  const acceptedLeadFinalSet = new Set();
+  for (const [compositeKey, h] of latestBySdKeyAndType) {
+    if (h.status !== 'accepted') continue;
+    const sdKey = compositeKey.slice(h.handoff_type.length + 2);
+    if (h.handoff_type === 'PLAN-TO-LEAD') acceptedPlanToLeadSet.add(sdKey);
+    else if (h.handoff_type === 'LEAD-FINAL-APPROVAL') acceptedLeadFinalSet.add(sdKey);
+  }
+  return { acceptedPlanToLeadSet, acceptedLeadFinalSet };
+}
+
+/**
+ * SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: the SOLE site in this file that may write
+ * status='completed' from the STUCK_100 stale-approval branch (any pending_approval row at
+ * 100% progress with a completion_date set). Previously a raw, unfenced UPDATE with no
+ * sd_type/orchestrator check and no LEAD-FINAL-APPROVAL witness -- safe only by COINCIDENCE
+ * (the two live orchestrator-parent rows at this shape both happen to have completion_date
+ * NULL). Fenced on two independent axes, both precomputed once per batch by the caller (never
+ * a per-SD round trip):
+ *   1. orchestratorSdKeys -- this row (or a row with children pointing at it) is an
+ *      orchestrator parent. Route to the parent-completion path (claim-orchestrator-for-rollup.mjs
+ *      / the LANES-001 outcome) instead -- never a raw write here.
+ *   2. acceptedLeadFinalSet -- an ACCEPTED LEAD-FINAL-APPROVAL handoff exists for this SD
+ *      (dual-keyed: sd_phase_handoffs.sd_id holds uuid- or sd_key-style values, both live
+ *      today, not just historical). Absent => STUCK_100_NO_LFA_WITNESS, no write, surfaced via
+ *      the returned line (this sweep has no interactive session to /signal from; actions[] IS
+ *      the coordinator-visible channel, same convention as the accepted-handoff override guard
+ *      immediately below).
+ * Preserves the exact prior write shape (and prior action-log wording) for the genuinely
+ * eligible case, so accepted, non-orchestrator completions behave byte-identically to before.
+ *
+ * @returns {Promise<{written: boolean, line: string|null, error?: object}>}
+ */
+async function completeStuck100Sd(supabaseClient, sd, { orchestratorSdKeys, acceptedLeadFinalSet }) {
+  if (orchestratorSdKeys.has(sd.sd_key)) {
+    return {
+      written: false,
+      line: 'QA: skipped STUCK_100 completion on ' + sd.sd_key
+        + ' — orchestrator_parent (route to parent-completion path, never a raw write)',
+    };
+  }
+  if (!acceptedLeadFinalSet.has(sd.sd_key)) {
+    return {
+      written: false,
+      line: 'QA: skipped STUCK_100 completion on ' + sd.sd_key
+        + ' — STUCK_100_NO_LFA_WITNESS (no accepted LEAD-FINAL-APPROVAL handoff found)',
+    };
+  }
+  const { error } = await supabaseClient
+    .from('strategic_directives_v2')
+    .update({
+      status: 'completed',
+      claiming_session_id: null,
+      active_session_id: null, // FR-1: co-clear (no claude_sessions flip here → trigger won't fire)
+      is_working_on: false,
+    })
+    .eq('sd_key', sd.sd_key)
+    .select();
+
+  if (error) return { written: false, line: null, error };
+  return {
+    written: true,
+    line: 'QA: completed ' + sd.sd_key + ' — was stuck at 100%/pending_approval with completion_date',
+  };
 }
 
 /**
@@ -1546,28 +1642,45 @@ async function runQaFixtureScan(ctx) {
   // 476+ historically-accepted rows have accepted_at IS NULL) -- only THAT verdict decides whether
   // "awaiting LEAD-FINAL-APPROVAL" is still true.
   const stuckApprovalIds = stuckApproval.flatMap(sd => [sd.id, sd.sd_key].filter(Boolean));
+  // SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: an ACCEPTED LEAD-FINAL-APPROVAL row is the
+  // witness the STUCK_100 completion fence below requires. NOT UUID-only, despite that being this
+  // SD's own original assumption -- measured live 2026-08-16: 161/1000 LEAD-FINAL-APPROVAL rows
+  // are sd_key-STRING-keyed, including one from a completion earlier the SAME SESSION this fence
+  // was authored in (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-142) -- an ACTIVE code path, not resolved
+  // historical debt. A UUID-only witness check would have wrongly STUCK_100_NO_LFA_WITNESS every
+  // legitimately-approved SD that happens to hit that path. Same dual-key + latest-per-SD
+  // resolution the PLAN-TO-LEAD guard already used (see resolveAcceptedHandoffSets): the ORIGINAL
+  // query-shape risk ("does ANY accepted row EVER exist") applies identically here.
   let acceptedPlanToLeadSet = new Set();
+  let acceptedLeadFinalSet = new Set();
   if (stuckApprovalIds.length > 0) {
-    const { data: p2lHandoffs } = await supabase
+    const { data: handoffs } = await supabase
       .from('sd_phase_handoffs')
-      .select('sd_id, status, created_at')
-      .eq('handoff_type', 'PLAN-TO-LEAD')
+      .select('sd_id, handoff_type, status, created_at')
+      .in('handoff_type', ['PLAN-TO-LEAD', 'LEAD-FINAL-APPROVAL'])
       .in('sd_id', stuckApprovalIds)
       .order('created_at', { ascending: false });
-    // Latest-per-SD, resolving the dual-keying: a single logical SD may have handoff rows under
-    // EITHER its uuid or its sd_key across eras, so group by the LOGICAL sd_key, not raw h.sd_id.
-    const idToSdKey = new Map();
+    ({ acceptedPlanToLeadSet, acceptedLeadFinalSet } = resolveAcceptedHandoffSets(stuckApproval, handoffs || []));
+  }
+
+  // SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: orchestrator-parent detection for the
+  // STUCK_100 completion fence below. TWO independent axes, because sd_type can be wrong or
+  // missing but a real child row cannot lie: (1) the SHARED classifier's orchestrator_parent
+  // verdict (lib/fleet/claim-eligibility.cjs -- one representation, not a hand-rolled
+  // `sd_type === 'orchestrator'` check re-derived here); (2) a live children lookup
+  // (parent_sd_id), defense-in-depth against an untyped/mistyped parent row.
+  const orchestratorSdKeys = new Set(
+    stuckApproval.filter(sd => classifyAllDispatchIneligibility(sd).includes('orchestrator_parent')).map(sd => sd.sd_key),
+  );
+  const parentIdsToCheck = stuckApproval.map(sd => sd.id).filter(Boolean);
+  if (parentIdsToCheck.length > 0) {
+    const { data: childRows } = await supabase
+      .from('strategic_directives_v2')
+      .select('parent_sd_id')
+      .in('parent_sd_id', parentIdsToCheck);
+    const parentIdsWithChildren = new Set((childRows || []).map(r => r.parent_sd_id).filter(Boolean));
     for (const sd of stuckApproval) {
-      if (sd.id) idToSdKey.set(sd.id, sd.sd_key);
-      if (sd.sd_key) idToSdKey.set(sd.sd_key, sd.sd_key);
-    }
-    const latestBySdKey = new Map();
-    for (const h of (p2lHandoffs || [])) {
-      const logicalKey = idToSdKey.get(h.sd_id);
-      if (logicalKey && !latestBySdKey.has(logicalKey)) latestBySdKey.set(logicalKey, h); // rows arrive created_at DESC -> first seen is latest
-    }
-    for (const [sdKey, h] of latestBySdKey) {
-      if (h.status === 'accepted') acceptedPlanToLeadSet.add(sdKey);
+      if (sd.id && parentIdsWithChildren.has(sd.id)) orchestratorSdKeys.add(sd.sd_key);
     }
   }
 
@@ -1580,21 +1693,9 @@ async function runQaFixtureScan(ctx) {
     }
     // FIX #1: STUCK_100 — if at 100% with completion_date, mark completed instead of resetting
     if (sd.progress_percentage >= 100 && sd.completion_date) {
-      const { error } = await supabase
-        .from('strategic_directives_v2')
-        .update({
-          status: 'completed',
-          claiming_session_id: null,
-          active_session_id: null, // FR-1: co-clear (no claude_sessions flip here → trigger won't fire)
-          is_working_on: false
-        })
-        .eq('sd_key', sd.sd_key)
-        .select();
-
-      if (!error) {
-        applied.completed++; // QF-20260727-363
-        actions.push('QA: completed ' + sd.sd_key + ' — was stuck at 100%/pending_approval with completion_date');
-      }
+      const result = await completeStuck100Sd(supabase, sd, { orchestratorSdKeys, acceptedLeadFinalSet });
+      if (result.written) applied.completed++; // QF-20260727-363
+      if (result.line) actions.push(result.line);
     } else {
       // SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (FR-3, AC-4/AC-5): generalized
       // accepted-handoff override guard for the pending_approval reset path.
@@ -4210,6 +4311,11 @@ module.exports.anyClaudeProcessRunning = anyClaudeProcessRunning;
 // touching the live ESM module). Seeding the cache is exactly what the first real call
 // does — no production behavior change.
 module.exports.isSweepResetAllowed = isSweepResetAllowed;
+// SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: the fenced STUCK_100 completion write —
+// exported so unit tests can drive it directly with a fake supabase client and fixture sets,
+// without running the whole sweep.
+module.exports.completeStuck100Sd = completeStuck100Sd;
+module.exports.resolveAcceptedHandoffSets = resolveAcceptedHandoffSets;
 module.exports.isDormancyWatchdogEnabled = isDormancyWatchdogEnabled; // SD-FDBK-ENH-CONFIRMED-LIVE-TODAY-001
 module.exports.filterDormantByPidLiveness = filterDormantByPidLiveness; // SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001
 module.exports.isHeadlessZombie = isHeadlessZombie; // QF-20260704-081

--- a/tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js
+++ b/tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js
@@ -106,6 +106,68 @@ describe('resolveAcceptedHandoffSets — dual-keyed LEAD-FINAL-APPROVAL witness 
   });
 });
 
+describe('resolveOrchestratorParentSdKeys — [adversarial-review fix] both axes verified live, not just via completeStuck100Sd fixtures', () => {
+  // Adversarial review of this SD's first draft found BOTH claimed axes broken: axis 1
+  // (sd_type classifier) was fed rows that never selected sd_type, so it was permanently dead;
+  // axis 2 (children lookup) only matched parent_sd_id by UUID, missing the sd_key-string form
+  // that lib/fleet/claim-eligibility.cjs's parentLeadPending already proves is a live pattern.
+  // These tests drive the REAL resolver (not hand-constructed orchestratorSdKeys Sets), so a
+  // regression on either axis fails here, not silently in production.
+
+  it('axis 1: a row with sd_type=orchestrator is detected even with zero child rows', () => {
+    const candidates = [{ id: 'uuid-orch-1', sd_key: 'SD-ORCH-TYPED-001', sd_type: 'orchestrator' }];
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, []);
+    expect(result.has('SD-ORCH-TYPED-001')).toBe(true);
+  });
+
+  it('axis 1 is inert (not a crash) when sd_type is absent — proves the caller-select dependency, not a false positive', () => {
+    const candidates = [{ id: 'uuid-leaf-1', sd_key: 'SD-LEAF-NO-TYPE-001' }];
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, []);
+    expect(result.has('SD-LEAF-NO-TYPE-001')).toBe(false);
+  });
+
+  it('axis 2: a child row whose parent_sd_id holds the parent UUID is detected', () => {
+    const candidates = [{ id: 'uuid-parent-2', sd_key: 'SD-PARENT-UUID-LINKED-001' }];
+    const childRows = [{ parent_sd_id: 'uuid-parent-2' }];
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, childRows);
+    expect(result.has('SD-PARENT-UUID-LINKED-001')).toBe(true);
+  });
+
+  it('[the real bug adversarial review found] axis 2: a child row whose parent_sd_id holds the parent sd_key STRING (not the UUID) is still detected', () => {
+    const candidates = [{ id: 'uuid-parent-3', sd_key: 'SD-PARENT-STRING-LINKED-001' }];
+    const childRows = [{ parent_sd_id: 'SD-PARENT-STRING-LINKED-001' }];
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, childRows);
+    expect(result.has('SD-PARENT-STRING-LINKED-001')).toBe(true);
+  });
+
+  it('a child row whose parent_sd_id matches no candidate (id or sd_key) is silently ignored, not mis-attributed', () => {
+    const candidates = [{ id: 'uuid-parent-4', sd_key: 'SD-PARENT-004' }];
+    const childRows = [{ parent_sd_id: 'some-unrelated-parent-ref' }];
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, childRows);
+    expect(result.size).toBe(0);
+  });
+
+  it('a leaf SD with neither sd_type=orchestrator nor any matching child row is NOT flagged', () => {
+    const candidates = [{ id: 'uuid-leaf-5', sd_key: 'SD-LEAF-005', sd_type: 'feature' }];
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, []);
+    expect(result.has('SD-LEAF-005')).toBe(false);
+  });
+
+  it('both axes can independently contribute across a mixed candidate batch', () => {
+    const candidates = [
+      { id: 'uuid-a', sd_key: 'SD-TYPED-ORCH', sd_type: 'orchestrator' },
+      { id: 'uuid-b', sd_key: 'SD-LINKED-ORCH' },
+      { id: 'uuid-c', sd_key: 'SD-PLAIN-LEAF', sd_type: 'feature' },
+    ];
+    const childRows = [{ parent_sd_id: 'SD-LINKED-ORCH' }]; // string-keyed, axis 2 only
+    const result = sweep.resolveOrchestratorParentSdKeys(candidates, childRows);
+    expect(result.has('SD-TYPED-ORCH')).toBe(true);
+    expect(result.has('SD-LINKED-ORCH')).toBe(true);
+    expect(result.has('SD-PLAIN-LEAF')).toBe(false);
+    expect(result.size).toBe(2);
+  });
+});
+
 describe('completeStuck100Sd — orchestrator-parent fence', () => {
   it('an orchestrator-parent SD (per orchestratorSdKeys) is NOT completed, and a named line is returned', async () => {
     const { from, calls } = makeFakeSupabase();

--- a/tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js
+++ b/tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js
@@ -1,0 +1,184 @@
+/**
+ * SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001 — the STUCK_100 stale-approval branch
+ * (scripts/stale-session-sweep.cjs) previously did a raw `.update({status:'completed'})` on ANY
+ * pending_approval row at 100% progress with a completion_date set — no orchestrator/sd_type
+ * fence, no LEAD-FINAL-APPROVAL witness. Safe only by COINCIDENCE (the two live orchestrator
+ * parents at this shape both happen to have completion_date NULL). This file pins the fenced
+ * replacement, completeStuck100Sd: two independent guard axes, both checked before any write.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const SOURCE_PATH = resolve(REPO_ROOT, 'scripts/stale-session-sweep.cjs');
+const SOURCE = readFileSync(SOURCE_PATH, 'utf8');
+
+const require = createRequire(import.meta.url);
+const sweep = require(SOURCE_PATH);
+
+/** A minimal chainable fake for `.from('strategic_directives_v2').update(...).eq(...).select()`. */
+function makeFakeSupabase({ updateError = null } = {}) {
+  const calls = [];
+  const from = (table) => ({
+    update(payload) {
+      calls.push({ table, payload });
+      return {
+        eq(col, val) {
+          calls[calls.length - 1].eqCol = col;
+          calls[calls.length - 1].eqVal = val;
+          return {
+            select: () => Promise.resolve({ error: updateError, data: updateError ? null : [{ sd_key: val }] }),
+          };
+        },
+      };
+    },
+  });
+  return { from, calls };
+}
+
+describe('[grep guard] status:completed is written from exactly ONE site', () => {
+  it('the literal string "status: \'completed\'" appears exactly once in the whole file — inside completeStuck100Sd', () => {
+    const matches = SOURCE.match(/status: 'completed'/g) || [];
+    expect(matches.length).toBe(1);
+    // Confirm it lives inside completeStuck100Sd, not some other function.
+    const fnStart = SOURCE.indexOf('async function completeStuck100Sd');
+    const matchIndex = SOURCE.indexOf("status: 'completed'");
+    const nextFnStart = SOURCE.indexOf('\nasync function ', fnStart + 1);
+    expect(fnStart).toBeGreaterThan(-1);
+    expect(matchIndex).toBeGreaterThan(fnStart);
+    if (nextFnStart > -1) expect(matchIndex).toBeLessThan(nextFnStart);
+  });
+});
+
+describe('resolveAcceptedHandoffSets — dual-keyed LEAD-FINAL-APPROVAL witness resolution', () => {
+  const candidates = [
+    { id: 'uuid-a', sd_key: 'SD-UUID-KEYED-001' },
+    { id: 'uuid-b', sd_key: 'SD-STRING-KEYED-001' },
+  ];
+
+  it('resolves an ACCEPTED LEAD-FINAL-APPROVAL witness keyed by UUID', () => {
+    const handoffRows = [
+      { sd_id: 'uuid-a', handoff_type: 'LEAD-FINAL-APPROVAL', status: 'accepted', created_at: '2026-08-16T01:00:00Z' },
+    ];
+    const { acceptedLeadFinalSet } = sweep.resolveAcceptedHandoffSets(candidates, handoffRows);
+    expect(acceptedLeadFinalSet.has('SD-UUID-KEYED-001')).toBe(true);
+  });
+
+  it('[the real bug this SD found] resolves an ACCEPTED LEAD-FINAL-APPROVAL witness keyed by the sd_key STRING, not the UUID -- measured live 2026-08-16: 161/1000 real LEAD-FINAL-APPROVAL rows are string-keyed, an ACTIVE code path (one specimen: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-142, completed the same session this fence was authored in)', () => {
+    const handoffRows = [
+      { sd_id: 'SD-STRING-KEYED-001', handoff_type: 'LEAD-FINAL-APPROVAL', status: 'accepted', created_at: '2026-08-16T01:00:00Z' },
+    ];
+    const { acceptedLeadFinalSet } = sweep.resolveAcceptedHandoffSets(candidates, handoffRows);
+    expect(acceptedLeadFinalSet.has('SD-STRING-KEYED-001')).toBe(true);
+  });
+
+  it('only the LATEST row per (handoff_type, logical sd_key) decides the verdict -- an old accepted row does not survive a later non-accepted one', () => {
+    const handoffRows = [
+      // caller pre-sorts created_at DESC -- latest first
+      { sd_id: 'uuid-a', handoff_type: 'LEAD-FINAL-APPROVAL', status: 'rejected', created_at: '2026-08-16T02:00:00Z' },
+      { sd_id: 'uuid-a', handoff_type: 'LEAD-FINAL-APPROVAL', status: 'accepted', created_at: '2026-08-16T01:00:00Z' },
+    ];
+    const { acceptedLeadFinalSet } = sweep.resolveAcceptedHandoffSets(candidates, handoffRows);
+    expect(acceptedLeadFinalSet.has('SD-UUID-KEYED-001')).toBe(false);
+  });
+
+  it('PLAN-TO-LEAD and LEAD-FINAL-APPROVAL are tracked independently for the same SD', () => {
+    const handoffRows = [
+      { sd_id: 'uuid-a', handoff_type: 'PLAN-TO-LEAD', status: 'accepted', created_at: '2026-08-15T01:00:00Z' },
+      // No LEAD-FINAL-APPROVAL row at all for this SD.
+    ];
+    const { acceptedPlanToLeadSet, acceptedLeadFinalSet } = sweep.resolveAcceptedHandoffSets(candidates, handoffRows);
+    expect(acceptedPlanToLeadSet.has('SD-UUID-KEYED-001')).toBe(true);
+    expect(acceptedLeadFinalSet.has('SD-UUID-KEYED-001')).toBe(false);
+  });
+
+  it('a handoff row whose sd_id matches no candidate (id or sd_key) is silently ignored, not mis-attributed', () => {
+    const handoffRows = [
+      { sd_id: 'some-other-sd-entirely', handoff_type: 'LEAD-FINAL-APPROVAL', status: 'accepted', created_at: '2026-08-16T01:00:00Z' },
+    ];
+    const { acceptedLeadFinalSet } = sweep.resolveAcceptedHandoffSets(candidates, handoffRows);
+    expect(acceptedLeadFinalSet.size).toBe(0);
+  });
+});
+
+describe('completeStuck100Sd — orchestrator-parent fence', () => {
+  it('an orchestrator-parent SD (per orchestratorSdKeys) is NOT completed, and a named line is returned', async () => {
+    const { from, calls } = makeFakeSupabase();
+    const sd = { id: 'uuid-1', sd_key: 'SD-PARENT-001', progress_percentage: 100, completion_date: '2026-08-15T00:00:00Z' };
+    const result = await sweep.completeStuck100Sd(
+      { from },
+      sd,
+      { orchestratorSdKeys: new Set(['SD-PARENT-001']), acceptedLeadFinalSet: new Set(['SD-PARENT-001']) },
+    );
+    expect(result.written).toBe(false);
+    expect(result.line).toMatch(/orchestrator_parent/);
+    expect(result.line).toContain('SD-PARENT-001');
+    expect(calls.length).toBe(0); // no DB write attempted at all
+  });
+});
+
+describe('completeStuck100Sd — LEAD-FINAL-APPROVAL witness fence', () => {
+  it('a non-orchestrator leaf WITHOUT an accepted LEAD-FINAL-APPROVAL witness is NOT completed, named STUCK_100_NO_LFA_WITNESS', async () => {
+    const { from, calls } = makeFakeSupabase();
+    const sd = { id: 'uuid-2', sd_key: 'SD-LEAF-NO-LFA-001', progress_percentage: 100, completion_date: '2026-08-15T00:00:00Z' };
+    const result = await sweep.completeStuck100Sd(
+      { from },
+      sd,
+      { orchestratorSdKeys: new Set(), acceptedLeadFinalSet: new Set() },
+    );
+    expect(result.written).toBe(false);
+    expect(result.line).toMatch(/STUCK_100_NO_LFA_WITNESS/);
+    expect(result.line).toContain('SD-LEAF-NO-LFA-001');
+    expect(calls.length).toBe(0);
+  });
+
+  it('a non-orchestrator leaf WITH an accepted LEAD-FINAL-APPROVAL witness completes — existing behavior preserved', async () => {
+    const { from, calls } = makeFakeSupabase();
+    const sd = { id: 'uuid-3', sd_key: 'SD-LEAF-WITH-LFA-001', progress_percentage: 100, completion_date: '2026-08-15T00:00:00Z' };
+    const result = await sweep.completeStuck100Sd(
+      { from },
+      sd,
+      { orchestratorSdKeys: new Set(), acceptedLeadFinalSet: new Set(['SD-LEAF-WITH-LFA-001']) },
+    );
+    expect(result.written).toBe(true);
+    expect(result.line).toMatch(/^QA: completed SD-LEAF-WITH-LFA-001/);
+    expect(calls.length).toBe(1);
+    expect(calls[0].payload).toMatchObject({ status: 'completed', claiming_session_id: null, active_session_id: null, is_working_on: false });
+    expect(calls[0].eqCol).toBe('sd_key');
+    expect(calls[0].eqVal).toBe('SD-LEAF-WITH-LFA-001');
+  });
+
+  it('a DB error on the write surfaces (written:false, error set, no misleading line)', async () => {
+    const dbError = { message: 'boom' };
+    const { from } = makeFakeSupabase({ updateError: dbError });
+    const sd = { id: 'uuid-4', sd_key: 'SD-LEAF-DB-ERROR-001', progress_percentage: 100, completion_date: '2026-08-15T00:00:00Z' };
+    const result = await sweep.completeStuck100Sd(
+      { from },
+      sd,
+      { orchestratorSdKeys: new Set(), acceptedLeadFinalSet: new Set(['SD-LEAF-DB-ERROR-001']) },
+    );
+    expect(result.written).toBe(false);
+    expect(result.line).toBeNull();
+    expect(result.error).toBe(dbError);
+  });
+});
+
+describe('completeStuck100Sd — the orchestrator fence takes precedence over the LFA witness fence', () => {
+  it('an orchestrator SD that ALSO happens to have an accepted LFA witness is still refused (never a raw write on a parent)', async () => {
+    const { from, calls } = makeFakeSupabase();
+    const sd = { id: 'uuid-5', sd_key: 'SD-PARENT-WITH-LFA-001', progress_percentage: 100, completion_date: '2026-08-15T00:00:00Z' };
+    const result = await sweep.completeStuck100Sd(
+      { from },
+      sd,
+      { orchestratorSdKeys: new Set(['SD-PARENT-WITH-LFA-001']), acceptedLeadFinalSet: new Set(['SD-PARENT-WITH-LFA-001']) },
+    );
+    expect(result.written).toBe(false);
+    expect(result.line).toMatch(/orchestrator_parent/);
+    expect(calls.length).toBe(0);
+  });
+});

--- a/tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js
+++ b/tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js
@@ -66,16 +66,52 @@ describe('QF-20260727-363: QA FIXES reports applied repairs, never detections', 
   it('every applied counter is incremented only inside a confirmed-write branch', () => {
     // THE LOAD-BEARING ONE. Moving an increment out of its `if (!error)` branch would restore the
     // original defect while leaving all the assertions above green.
+    //
+    // SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001: `completed` no longer sits directly inside
+    // its own `if (!error)` — the STUCK_100 write moved into a dedicated, independently-tested,
+    // single-write-site function (completeStuck100Sd, required by this SD's own grep guard below)
+    // so it could be fenced on the orchestrator-parent and LEAD-FINAL-APPROVAL-witness axes without
+    // duplicating the write. The invariant this test protects (increment only on a CONFIRMED write,
+    // never an attempt) still holds -- just through one level of indirection: the call site gates
+    // on `result.written`, and `result.written` is proven true ONLY after `completeStuck100Sd`'s
+    // own `if (error)` guard (asserted separately, immediately below) -- so `completed` is checked
+    // against that pattern instead of the same-scope `if (!error` window the other four counters use.
+    // This mirrors this file's own established precedent for widening a scan when a legitimate
+    // structural change shifts WHERE the guard text lives without weakening WHAT it guarantees (see
+    // the `continue;`-adjacency widening later in this file, SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-LANES-001).
+    const SAME_SCOPE_GUARDED = ['released', 'releasedOrphaned', 'reset', 'cleared'];
+    const INDIRECTED_GUARDED = { completed: /if \(result\.written\)/ };
     const increments = [...SRC.matchAll(/applied\.(released|releasedOrphaned|completed|reset|cleared)\+\+/g)];
     expect(increments.length, 'all five counters must be incremented somewhere').toBe(5);
     for (const m of increments) {
       const preceding = SRC.slice(Math.max(0, m.index - 400), m.index);
-      const lastGuard = preceding.lastIndexOf('if (!error');
-      expect(
-        lastGuard,
-        `applied.${m[1]}++ is not inside an if (!error...) branch — it would count an attempt, not a repair`
-      ).toBeGreaterThan(-1);
+      if (SAME_SCOPE_GUARDED.includes(m[1])) {
+        const lastGuard = preceding.lastIndexOf('if (!error');
+        expect(
+          lastGuard,
+          `applied.${m[1]}++ is not inside an if (!error...) branch — it would count an attempt, not a repair`
+        ).toBeGreaterThan(-1);
+      } else {
+        const pattern = INDIRECTED_GUARDED[m[1]];
+        expect(pattern, `applied.${m[1]}++ has no recognized guard pattern registered in this test`).toBeDefined();
+        expect(
+          pattern.test(preceding),
+          `applied.${m[1]}++ is not gated by its registered indirected guard (${pattern}) — it would count an attempt, not a repair`
+        ).toBe(true);
+      }
     }
+  });
+
+  it('[indirected guard, completeStuck100Sd] the function feeding applied.completed++ only reports written:true after its own confirmed-write check — the indirection above is not a loophole', () => {
+    const fnStart = SRC.indexOf('async function completeStuck100Sd');
+    expect(fnStart, 'completeStuck100Sd must still exist').toBeGreaterThan(-1);
+    const fnEnd = SRC.indexOf('\nasync function ', fnStart + 1);
+    const fnBody = SRC.slice(fnStart, fnEnd > -1 ? fnEnd : fnStart + 2000);
+    const errorGuardIdx = fnBody.indexOf('if (error) return { written: false');
+    const writtenTrueIdx = fnBody.indexOf('written: true,');
+    expect(errorGuardIdx, 'completeStuck100Sd must refuse (written:false) on a DB error before it can ever report written:true').toBeGreaterThan(-1);
+    expect(writtenTrueIdx).toBeGreaterThan(-1);
+    expect(errorGuardIdx, 'the error guard must precede the written:true return, not follow it').toBeLessThan(writtenTrueIdx);
   });
 
   it('the pending_approval reset selects its rows, so a zero-row update cannot count as a repair', () => {


### PR DESCRIPTION
## Summary
- The sweep's STUCK_100 branch wrote `status: 'completed'` on any SD at `progress_percentage >= 100` with a `completion_date`, with no fence against orchestrator parents or a missing LEAD-FINAL-APPROVAL witness.
- Extracts the write into a single fenced helper, `completeStuck100Sd`, that refuses on either guard before ever touching the DB.
- Adds `resolveAcceptedHandoffSets`, a pure, dual-keyed (UUID- or sd_key-string-keyed), latest-per-`(handoff_type, sd)` resolver for `sd_phase_handoffs` — reusing the file's own established dual-key discipline (originally added for the PLAN-TO-LEAD reset guard) and extending it to LEAD-FINAL-APPROVAL, which the original proposal assumed was UUID-only. Measured live: 161/1000 real LEAD-FINAL-APPROVAL rows are sd_key-string-keyed — an active pattern, not historical debt.
- Orchestrator-parent detection reuses the shared `classifyAllDispatchIneligibility` classifier plus an independent live children lookup, so a mistyped/untyped parent row with real children is still caught.

## Test plan
- [x] New test file `tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js` (11 tests): single-write-site grep guard, `resolveAcceptedHandoffSets` dual-key/latest-per-type/independence coverage, `completeStuck100Sd` guard-refusal + exact-payload coverage.
- [x] Pre-existing `tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js` widened (not weakened) for the new indirected-guard pattern; added a dedicated test proving `completeStuck100Sd` itself only reports `written:true` after its own `if (error)` guard.
- [x] Full adjacent sweep/claim-eligibility test surface run — no regressions.
- [x] CI green (unit tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)