### PR TITLE
fix(QF-20260815-918): Stale inherited env beats the on-disk .env after credential rotation: supabase-connection.js loads dotenv without override — prefer the FILE value for DB connection keys + rotation-runbook env-refresh step

### DIFF
--- a/docs/security/key-rotation-runbook.md
+++ b/docs/security/key-rotation-runbook.md
@@ -65,6 +65,14 @@ This runbook covers rotating all compromised credentials found during the securi
    ```bash
    SUPABASE_DB_PASSWORD=<new-password>
    ```
+5. **Broadcast env-refresh to long-running processes (QF-20260815-918):** `scripts/lib/supabase-connection.js`
+   now prefers the on-disk `.env`'s DB-connection values (`SUPABASE_DB_PASSWORD`, `EHG_DB_PASSWORD`,
+   `SUPABASE_POOLER_URL`, `DATABASE_URL`, `PGPASSWORD`) over a stale inherited `process.env` value,
+   so one-shot script/gate invocations (each a fresh `node` process, the common case — e.g. fleet
+   worker Bash calls, CI gate runs) pick up the new password on their very next run with **no
+   seat restart needed**. The one exception is a **long-running** process that already imported this
+   module before the rotation (a persistent dev server, a daemon) — module-level code only runs once
+   per process, so those must be restarted to pick up the new value.
 
 ## 2. OpenAI API Key
 

--- a/scripts/lib/supabase-connection.js
+++ b/scripts/lib/supabase-connection.js
@@ -22,8 +22,72 @@ import { isMainModule } from '../../lib/utils/is-main-module.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Load environment variables
-dotenv.config({ path: join(__dirname, '../..', '.env') });
+// QF-20260815-918: DB-connection credential keys that must reflect the
+// on-disk .env after a credential rotation, even when a stale value was
+// already inherited into process.env by the parent shell/session.
+const DB_CREDENTIAL_KEYS = [
+  'SUPABASE_DB_PASSWORD',
+  'EHG_DB_PASSWORD',
+  'SUPABASE_POOLER_URL',
+  'DATABASE_URL',
+  'PGPASSWORD',
+];
+
+// QF-20260815-918: walk up from cwd (mirrors lib/supabase-client.cjs's
+// loadEnvFromAncestors) instead of a fixed __dirname-relative path — a
+// `git worktree add` checkout has no .env of its own (gitignored), so the
+// old fixed path silently found nothing there.
+export function findEnvFile() {
+  let dir = process.cwd();
+  while (dir !== dirname(dir)) {
+    const candidate = join(dir, '.env');
+    if (fs.existsSync(candidate)) return candidate;
+    dir = dirname(dir);
+  }
+  const fallback = join(__dirname, '../..', '.env');
+  return fs.existsSync(fallback) ? fallback : null;
+}
+
+// QF-20260815-918: after a credential rotation, the on-disk .env holds the
+// new DB-connection values but a parent shell/session may still be holding
+// pre-rotation values in process.env — dotenv.config() (no override, called
+// by the caller before this) never overwrites those. Prefer the file's value
+// for the DB-connection keys specifically (never a global override:true,
+// which would also clobber deliberate CI/test env injection for unrelated
+// vars). Exported so unit tests can exercise it directly without reloading
+// this module.
+export function preferOnDiskDbCredentials(envPath) {
+  if (!envPath) return { changed: [] };
+  const fileValues = dotenv.parse(fs.readFileSync(envPath));
+  const changed = [];
+  for (const key of DB_CREDENTIAL_KEYS) {
+    if (fileValues[key] !== undefined && fileValues[key] !== process.env[key]) {
+      process.env[key] = fileValues[key];
+      changed.push(key);
+    }
+  }
+  if (changed.length) {
+    console.error('[supabase-connection] using on-disk .env for DB credentials; inherited value differs');
+  }
+  return { changed };
+}
+
+// Load environment variables. dotenv.config() (no override) only fills gaps
+// left by the parent process, so a stale inherited value always wins here —
+// intentional, since deliberate CI/test env injection must not be clobbered.
+const envPath = findEnvFile();
+if (envPath) dotenv.config({ path: envPath });
+
+// QF-20260713-897 precedent (lib/supabase-client.cjs's loadEnvFromAncestors guard):
+// skip the credential-preference check under the test runner. The unit vitest project
+// deliberately EMPTIES these DB vars (vitest.config.js) for credential isolation — a
+// value-diff comparison (unlike dotenv's hasOwnProperty-gated fill above) would read
+// "deliberately emptied" the same as "stale" and clobber the fence with the real
+// on-disk password. Test tiers own their own env setup (tests/setup.db.js loads real
+// .env itself for the db tier); this module must not override that.
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') {
+  preferOnDiskDbCredentials(envPath);
+}
 
 const { Client } = pg;
 

--- a/tests/lib/supabase-connection-env-credential-rotation.test.js
+++ b/tests/lib/supabase-connection-env-credential-rotation.test.js
@@ -1,0 +1,140 @@
+/**
+ * QF-20260815-918 — after a DB-credential rotation, the on-disk .env has the
+ * new values but a parent shell/session may still be holding pre-rotation
+ * values in process.env. dotenv.config() (no override) never overwrites an
+ * already-set var, so the stale inherited value would silently win forever.
+ *
+ * This verifies scripts/lib/supabase-connection.js's exported
+ * preferOnDiskDbCredentials() PREFERS the on-disk .env's DB-connection keys
+ * specifically when they differ from inherited env, logging exactly one
+ * notice line — without a global dotenv override that would also clobber
+ * deliberate CI/test env injection for unrelated vars. Also covers
+ * findEnvFile()'s ancestor walk, which fixes the worktree case (a
+ * `git worktree add` checkout has no .env of its own).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  findEnvFile,
+  preferOnDiskDbCredentials,
+} from '../../scripts/lib/supabase-connection.js';
+
+const ENV_KEYS = ['SUPABASE_DB_PASSWORD', 'DATABASE_URL', 'SOME_OTHER_INJECTED_VAR'];
+const SAVED_ENV = {};
+let scratchDir;
+
+function writeEnvFile(dir, contents) {
+  fs.writeFileSync(path.join(dir, '.env'), contents, 'utf8');
+}
+
+// tests/setup.unit.js replaces `console` with a shared { error: vi.fn(), ... }
+// object once for the whole unit project — clear its call log per test rather
+// than spying/restoring on top of it (spyOn would wrap that same shared
+// vi.fn(), and restoreAllMocks unwraps without clearing its call history).
+beforeEach(() => {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+  scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf-20260815-918-'));
+  console.error.mockClear();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+  fs.rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('preferOnDiskDbCredentials — on-disk .env preferred over stale inherited env (QF-20260815-918)', () => {
+  it('prefers the on-disk .env value when it differs from a stale inherited env var, and logs one notice', () => {
+    writeEnvFile(scratchDir, 'SUPABASE_DB_PASSWORD=post-rotation-secret\n');
+    process.env.SUPABASE_DB_PASSWORD = 'pre-rotation-stale-secret';
+
+    const { changed } = preferOnDiskDbCredentials(path.join(scratchDir, '.env'));
+
+    expect(changed).toEqual(['SUPABASE_DB_PASSWORD']);
+    expect(process.env.SUPABASE_DB_PASSWORD).toBe('post-rotation-secret');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error.mock.calls[0][0]).toMatch(
+      /using on-disk \.env for DB credentials; inherited value differs/
+    );
+  });
+
+  it('does not touch env or log when the on-disk value already matches inherited env', () => {
+    writeEnvFile(scratchDir, 'SUPABASE_DB_PASSWORD=same-value\n');
+    process.env.SUPABASE_DB_PASSWORD = 'same-value';
+
+    const { changed } = preferOnDiskDbCredentials(path.join(scratchDir, '.env'));
+
+    expect(changed).toEqual([]);
+    expect(process.env.SUPABASE_DB_PASSWORD).toBe('same-value');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('logs exactly one notice even when multiple DB-connection keys differ', () => {
+    writeEnvFile(
+      scratchDir,
+      'SUPABASE_DB_PASSWORD=post-rotation-secret\nDATABASE_URL=postgres://post-rotation\n'
+    );
+    process.env.SUPABASE_DB_PASSWORD = 'pre-rotation-stale-secret';
+    process.env.DATABASE_URL = 'postgres://pre-rotation-stale';
+
+    const { changed } = preferOnDiskDbCredentials(path.join(scratchDir, '.env'));
+
+    expect(changed.sort()).toEqual(['DATABASE_URL', 'SUPABASE_DB_PASSWORD']);
+    expect(process.env.SUPABASE_DB_PASSWORD).toBe('post-rotation-secret');
+    expect(process.env.DATABASE_URL).toBe('postgres://post-rotation');
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not use a global dotenv override — an unrelated inherited var (not a DB-connection key) is left untouched', () => {
+    writeEnvFile(
+      scratchDir,
+      'SUPABASE_DB_PASSWORD=post-rotation-secret\nSOME_OTHER_INJECTED_VAR=from-file\n'
+    );
+    process.env.SUPABASE_DB_PASSWORD = 'pre-rotation-stale-secret';
+    process.env.SOME_OTHER_INJECTED_VAR = 'from-ci-injection';
+
+    preferOnDiskDbCredentials(path.join(scratchDir, '.env'));
+
+    expect(process.env.SUPABASE_DB_PASSWORD).toBe('post-rotation-secret');
+    expect(process.env.SOME_OTHER_INJECTED_VAR).toBe('from-ci-injection');
+  });
+
+  it('is a no-op when no envPath is given (no .env located anywhere)', () => {
+    process.env.SUPABASE_DB_PASSWORD = 'whatever-was-inherited';
+
+    const { changed } = preferOnDiskDbCredentials(null);
+
+    expect(changed).toEqual([]);
+    expect(process.env.SUPABASE_DB_PASSWORD).toBe('whatever-was-inherited');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('findEnvFile — ancestor walk locates .env from a worktree cwd (QF-20260815-918)', () => {
+  let cwdSpy;
+
+  afterEach(() => {
+    if (cwdSpy) cwdSpy.mockRestore();
+  });
+
+  it('finds a .env directly in cwd', () => {
+    writeEnvFile(scratchDir, 'SUPABASE_DB_PASSWORD=x\n');
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(scratchDir);
+
+    expect(findEnvFile()).toBe(path.join(scratchDir, '.env'));
+  });
+
+  it('walks up to a parent directory holding .env (simulates a worktree checkout with no local .env)', () => {
+    writeEnvFile(scratchDir, 'SUPABASE_DB_PASSWORD=x\n');
+    const nestedDir = path.join(scratchDir, 'worktree-child', 'deeper');
+    fs.mkdirSync(nestedDir, { recursive: true });
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(nestedDir);
+
+    expect(findEnvFile()).toBe(path.join(scratchDir, '.env'));
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260815-918

**Type:** bug
**Severity:** high

### Issue Description
MEASURED 2026-08-15 23:45Z: scripts/lib/supabase-connection.js:26 does dotenv.config({path: root .env}) WITHOUT override, and dotenv never overwrites existing process.env — so any seat whose shell inherited SUPABASE_DB_PASSWORD / SUPABASE_POOLER_URL at launch (the SessionStart dotenvx hook exports them) keeps the STALE value after a rotation even though the on-disk .env is current. Two specimens within 15 min of tonight's rotation: Alpha signal 8a2e1be0 (28P01 on pg-direct) and Golf signal 8a625b09 23:41Z (CHAIRMAN_APPLY_VERIFICATION gate 28P01 on a ZERO-migration SD → documented --bypass-validation burned). FIX: (a) in supabase-connection.js, parse the .env file directly for the DB-connection keys (SUPABASE_DB_PASSWORD, SUPABASE_POOLER_URL, PGPASSWORD*) and PREFER the file value when it differs from inherited env, logging one line ('using on-disk .env for DB credentials; inherited value differs') — narrower and safer than a global override:true (which would clobber deliberate test/CI injection); CI unaffected (no .env file present); (b) unit test: inherited stale value + fresh file → file wins + notice; no file → env used; (c) add one step to the rotation runbook/state doc: at propagation time, broadcast an env-refresh directive to live seats. Premise files named by the coordinator (lib/db/supabase-connection.js) corrected to the real path scripts/lib/supabase-connection.js; verify-migration-apply-state.mjs needs no change (it imports this module — its comment at :637-639 documents that). Coordinator ask ff6665ae (2-specimen rule); Adam sourced.

### Steps to Reproduce
1. export SUPABASE_DB_PASSWORD=<old>; node -e "import('./scripts/lib/supabase-connection.js').then(m=>m.createDatabaseClient().connect())" with a rotated .env 2. observe 28P01 before fix / connect after

### Expected Behavior
file value wins with a one-line notice; gate connectivity survives rotation without seat restarts

### Actual Behavior
inherited stale value wins silently; 28P01 until every seat restarts; one bypass burned

### Changes
- **Files Changed:** 3
  - docs/security/key-rotation-runbook.md
  - scripts/lib/supabase-connection.js
  - tests/lib/supabase-connection-env-credential-rotation.test.js
- **LOC:** 278 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Unit tests: 7 new tests in tests/lib/supabase-connection-env-credential-rotation.test.js all pass (prefer-file-on-diff, no-op-when-equal, single-notice-for-multiple-keys, no-op-when-null, unrelated-var-untouched, findEnvFile direct-hit + ancestor-walk). Regression caught+fixed during verification: initial impl bypassed the unit-tier's deliberate DB-credential-emptying fence (vitest.config.js) because a value-diff comparison treated an intentionally-emptied test var the same as a stale one; fixed by gating the preference logic behind !VITEST (same precedent as lib/supabase-client.cjs's loadEnvFromAncestors guard, QF-20260713-897). Re-ran full npm run test:unit twice: only pre-existing, unrelated, non-deterministic flaky tests failed (timing/spawn-based: heal-vision timeout, stop-loop-wakeup-reminder timing, complexity-scorer, singleton-relaunch-restore, metric-evidence-resolver -- different subset each run, none reference supabase-connection.js). test:e2e (playwright, requires a live localhost:8080 web app) not applicable -- Node CLI/backend-only change, zero UI surface (auto-detected and skipped by the completion script itself). Rotation runbook updated (docs/security/key-rotation-runbook.md section 1.3, step 5) documenting that one-shot script/gate invocations pick up the fix on their next run with no seat restart needed; only a long-running process that already imported the module needs a restart.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol