### PR TITLE
fix(SD-LEO-INFRA-STUCK100-COMPLETED-WRITE-FENCE-001): paginate the fence's feeding reads, verify the completion UPDATE actually matched a row

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -705,7 +705,7 @@ async function completeStuck100Sd(supabaseClient, sd, { orchestratorSdKeys, acce
         + ' — STUCK_100_NO_LFA_WITNESS (no accepted LEAD-FINAL-APPROVAL handoff found)',
     };
   }
-  const { error } = await supabaseClient
+  const { data: completedRows, error } = await supabaseClient
     .from('strategic_directives_v2')
     .update({
       status: 'completed',
@@ -714,9 +714,21 @@ async function completeStuck100Sd(supabaseClient, sd, { orchestratorSdKeys, acce
       is_working_on: false,
     })
     .eq('sd_key', sd.sd_key)
-    .select();
+    .select('sd_key');
 
   if (error) return { written: false, line: null, error };
+  // QF-20260727-363 (adversarial-review fix): an UPDATE matching zero rows is NOT an error in
+  // PostgREST -- `!error` alone never proved a write happened. Mirrors the sibling reset path's
+  // established `(resetRows || []).length > 0` check a few lines below, so a race between this
+  // function's snapshot and its turn in the caller's loop (e.g. the row was deleted or its
+  // sd_key changed) reports written:false instead of a false "completed" line and an over-counted
+  // applied total at the call site.
+  if ((completedRows || []).length === 0) {
+    return {
+      written: false,
+      line: 'QA: skipped STUCK_100 completion on ' + sd.sd_key + ' — update matched zero rows (raced?)',
+    };
+  }
   return {
     written: true,
     line: 'QA: completed ' + sd.sd_key + ' — was stuck at 100%/pending_approval with completion_date',
@@ -1696,12 +1708,18 @@ async function runQaFixtureScan(ctx) {
   let acceptedPlanToLeadSet = new Set();
   let acceptedLeadFinalSet = new Set();
   if (stuckApprovalIds.length > 0) {
-    const { data: handoffs } = await supabase
-      .from('sd_phase_handoffs')
-      .select('sd_id, handoff_type, status, created_at')
-      .in('handoff_type', ['PLAN-TO-LEAD', 'LEAD-FINAL-APPROVAL'])
-      .in('sd_id', stuckApprovalIds)
-      .order('created_at', { ascending: false });
+    // fapPaginate (not a raw read): adversarial review flagged this as the same silent-1000-row-cap
+    // class this module's own header incident (2026-07-19, gauge read 1000 vs true 1495) exists to
+    // close -- a stuck-approval spike could plausibly push handoff-row volume past the PostgREST cap.
+    let handoffs = [];
+    try {
+      handoffs = await fapPaginate(() => supabase
+        .from('sd_phase_handoffs')
+        .select('sd_id, handoff_type, status, created_at')
+        .in('handoff_type', ['PLAN-TO-LEAD', 'LEAD-FINAL-APPROVAL'])
+        .in('sd_id', stuckApprovalIds)
+        .order('created_at', { ascending: false }));
+    } catch { handoffs = []; } // prior behavior: read error ignored
     ({ acceptedPlanToLeadSet, acceptedLeadFinalSet } = resolveAcceptedHandoffSets(stuckApproval, handoffs || []));
   }
 
@@ -1715,11 +1733,16 @@ async function runQaFixtureScan(ctx) {
   }
   let orchestratorChildRows = [];
   if (parentRefsToCheck.length > 0) {
-    const { data } = await supabase
-      .from('strategic_directives_v2')
-      .select('parent_sd_id')
-      .in('parent_sd_id', parentRefsToCheck);
-    orchestratorChildRows = data || [];
+    // fapPaginate: a stuck-approval row that is a heavily-fanned-out orchestrator parent could
+    // return enough children rows alone to approach the cap (same rationale as the handoffs read
+    // above -- found by adversarial review, not a bound this specific query is otherwise exempt from).
+    try {
+      orchestratorChildRows = await fapPaginate(() => supabase
+        .from('strategic_directives_v2')
+        .select('parent_sd_id')
+        .in('parent_sd_id', parentRefsToCheck)
+        .order('id', { ascending: true })); // FR-6-style tiebreaker: stable ordering across pages
+    } catch { orchestratorChildRows = []; } // prior behavior: read error ignored
   }
   const orchestratorSdKeys = resolveOrchestratorParentSdKeys(stuckApproval, orchestratorChildRows);
 

--- a/tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js
+++ b/tests/unit/scripts/stale-session-sweep-stuck100-completion-fence.test.js
@@ -22,7 +22,7 @@ const require = createRequire(import.meta.url);
 const sweep = require(SOURCE_PATH);
 
 /** A minimal chainable fake for `.from('strategic_directives_v2').update(...).eq(...).select()`. */
-function makeFakeSupabase({ updateError = null } = {}) {
+function makeFakeSupabase({ updateError = null, updateMatchesZeroRows = false } = {}) {
   const calls = [];
   const from = (table) => ({
     update(payload) {
@@ -32,7 +32,10 @@ function makeFakeSupabase({ updateError = null } = {}) {
           calls[calls.length - 1].eqCol = col;
           calls[calls.length - 1].eqVal = val;
           return {
-            select: () => Promise.resolve({ error: updateError, data: updateError ? null : [{ sd_key: val }] }),
+            select: () => Promise.resolve({
+              error: updateError,
+              data: updateError ? null : (updateMatchesZeroRows ? [] : [{ sd_key: val }]),
+            }),
           };
         },
       };
@@ -227,6 +230,20 @@ describe('completeStuck100Sd — LEAD-FINAL-APPROVAL witness fence', () => {
     expect(result.written).toBe(false);
     expect(result.line).toBeNull();
     expect(result.error).toBe(dbError);
+  });
+
+  it('[adversarial-review fix, QF-20260727-363 parity] an UPDATE matching zero rows is NOT reported as written -- !error alone never proved a write happened', async () => {
+    const { from, calls } = makeFakeSupabase({ updateMatchesZeroRows: true });
+    const sd = { id: 'uuid-6', sd_key: 'SD-LEAF-RACED-001', progress_percentage: 100, completion_date: '2026-08-15T00:00:00Z' };
+    const result = await sweep.completeStuck100Sd(
+      { from },
+      sd,
+      { orchestratorSdKeys: new Set(), acceptedLeadFinalSet: new Set(['SD-LEAF-RACED-001']) },
+    );
+    expect(result.written).toBe(false);
+    expect(result.line).toMatch(/zero rows/);
+    expect(result.line).not.toMatch(/^QA: completed/);
+    expect(calls.length).toBe(1); // the write WAS attempted, just didn't match -- distinct from the two upstream guard refusals (zero calls)
   });
 });
 


### PR DESCRIPTION
## Summary
Recovers and ships work originally done by a different fleet-worker session (Golf-4, session 51fab48f-8867-4fe2-9698-0a1b8639e6ee) as round-2 adversarial review on top of the already-merged PR #7082 — committed locally but never pushed before that session ended. Found stranded in a shared worktree via `git reflog` while investigating why a freshly-reset worktree's HEAD didn't match what I expected; verified against current `origin/main` that neither fix below was actually shipped, then cherry-picked the commit (`8ed18545299`) cleanly onto current main.

Two WARNING-level gaps found by round-2 adversarial review, after confirming PR #7082's own orchestrator-axes fix was correct:

1. **`completeStuck100Sd`'s UPDATE only checked `error`, not whether a row was actually matched** — the exact class of bug QF-20260727-363 already fixed for the sibling reset path a few lines below (`(rows || []).length > 0`). Without it, a race (row deleted/rekeyed between the batch snapshot and this SD's turn in the loop) would report a false "completed" line and over-count `applied.completed`.
2. **The handoffs read and the children-lookup read were raw, uncapped Supabase calls**, unlike this file's own established `fapPaginate` convention (built specifically to close the 2026-07-19 silent-1000-row PostgREST cap incident). A stuck-approval spike, or a stuck row that is a heavily-fanned-out orchestrator, could plausibly truncate either read and blind the fence's own safety axes.

A third finding (a pre-existing PLAN-TO-LEAD skip that may intercept most SDs before they reach the STUCK_100 branch at all) was correctly scoped out by the original author — predates this fence, is fail-safe in direction, and fixing it means reordering an unrelated guard with its own regression risk.

## Test plan
- [x] Cherry-picked cleanly onto current `origin/main` (no conflicts with the already-shipped `resolveOrchestratorParentSdKeys` refactor)
- [x] `node --check scripts/stale-session-sweep.cjs` — syntax valid
- [x] Targeted fence tests: 27/27 passing
- [x] Broader sweep + claim-eligibility surface: 129/129 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)