### PR TITLE
fix(QF-20260816-457): isIdle read the wrong session column, so busy workers self-reported idle every poll

### DIFF
--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -162,6 +162,13 @@ try {
 //     markDelivered instead of read_at where a poll needs to stop treating a row as brand-new
 //     without falsely implying it was processed (SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001
 //     FR-2/FR-3 — see the DIRECTIVE_KINDS branch below).
+// QF-20260816-457: a session is idle iff it holds no SD claim. The prior version read
+// sessionData?.sd_id, a column never selected from claude_sessions (the real column is sd_key),
+// so isIdle was ~always true — busy claim-holding workers got the IDLE/claim banner on every poll.
+function resolveIsIdle(sessionData) {
+  return !sessionData?.sd_key;
+}
+
 // Pure + synchronous; no DB calls (amCoordinator/amAdam/twoWayOn/isIdle resolved once by caller).
 function classifyInboxMessage(msg, opts = {}) {
   const { twoWayOn = false, amAdam = false, amSolomon = false, isIdle = false } = opts;
@@ -616,7 +623,7 @@ async function main() {
       .select('sd_key, metadata')
       .eq('session_id', sessionId)
       .single();
-    isIdle = !sessionData?.sd_id; // NOTE: pre-existing bug — column is sd_key, so this is ~always true (flagged, out of scope)
+    isIdle = resolveIsIdle(sessionData);
     amAdam = sessionData?.metadata?.role === 'adam';
     amSolomon = sessionData?.metadata?.role === 'solomon'; // QF-20260709-800
   } catch { /* assume not idle / not adam / not solomon if query fails */ }
@@ -953,6 +960,8 @@ module.exports = {
   shouldSkipCoordinatorReply,
   // SD-LEO-FIX-FIX-COORDINATION-INBOX-001 — exposed for unit tests
   classifyInboxMessage,
+  // QF-20260816-457 — exposed for unit tests
+  resolveIsIdle,
   // SD-LEO-INFRA-MID-FLIGHT-DIRECTIVE-001 / FR-1 — exposed for unit tests
   mergePriorityExempt
 };

--- a/tests/unit/coordination-inbox-resolve-is-idle.test.js
+++ b/tests/unit/coordination-inbox-resolve-is-idle.test.js
@@ -1,0 +1,29 @@
+/**
+ * Unit test — QF-20260816-457
+ *
+ * isIdle previously read sessionData?.sd_id, a column never selected from claude_sessions
+ * (the real column is sd_key), so isIdle was ~always true regardless of an actual claim.
+ * resolveIsIdle is pure — no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveIsIdle } = require('../../scripts/hooks/coordination-inbox.cjs');
+
+describe('resolveIsIdle (QF-20260816-457)', () => {
+  it('a session row with sd_key set is NOT idle', () => {
+    expect(resolveIsIdle({ sd_key: 'SD-LEO-INFRA-EXAMPLE-001', metadata: {} })).toBe(false);
+  });
+
+  it('a session row with sd_key null IS idle', () => {
+    expect(resolveIsIdle({ sd_key: null, metadata: {} })).toBe(true);
+  });
+
+  it('a missing session row (query failure upstream) IS idle', () => {
+    expect(resolveIsIdle(undefined)).toBe(true);
+  });
+
+  it('sd_id being set does NOT affect the result — sd_id is not the claim column', () => {
+    expect(resolveIsIdle({ sd_id: 'some-uuid', sd_key: null })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `sessionData?.sd_id` was read for the idle check, but `claude_sessions` has no `sd_id` column (the claim is `sd_key`, which the query already selected) — `sd_id` was always `undefined`, so `isIdle` was ~always true regardless of whether the session actually held a claim.
- Busy, claim-holding workers got the IDLE/claim banner every ~15s, and `CLAIM_RELEASED`/`CLAIM_REMINDER` advisories took the surface-not-drain path meant only for genuinely idle sessions.
- Extracted `resolveIsIdle(sessionData)` as a small pure function (mirrors this file's existing `classifyInboxMessage` pattern) so the exact rule is directly unit-testable rather than only reachable through a mocked Supabase call.
- A2 ultrareview #7065 bug_010 (Adam-verified on main).

## Test plan
- [x] New `tests/unit/coordination-inbox-resolve-is-idle.test.js` (4 tests): `sd_key` set → not idle, `sd_key` null → idle, missing session row → idle, `sd_id` set with `sd_key` null → still idle (proves `sd_id` is not the claim column).
- [x] `node --check` on the modified file — syntax valid.
- [x] Full adjacent coordination-inbox test surface (6 files, 80 tests) passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)