### PR TITLE
fix(QF-20260816-173): stop classifying every query error/throw in sms-channel-health as table_absent

### DIFF
--- a/lib/chairman/sms-channel-health.js
+++ b/lib/chairman/sms-channel-health.js
@@ -23,6 +23,18 @@ export const DEFAULT_MIN_SAMPLE = 3; // never alarm on 1-2 rows (noise floor)
 export const EMAIL_ESCALATED_PREFIX = 'EMAIL_ESCALATED: ';
 
 /**
+ * QF-20260816-173: is this a genuine "table not provisioned" signature (PGRST205/42P01),
+ * as opposed to an operational fault (RLS 42501, auth, network, etc.)? Only the former may
+ * fail-soft to 'table_absent' — everything else must surface as a distinct, logged reason so
+ * an active incident (e.g. RLS misconfigured mid-outage) is never indistinguishable from an
+ * inert, not-yet-staged table.
+ */
+function isMissingTable(error) {
+  const code = error?.code || '';
+  return code === 'PGRST205' || code === '42P01';
+}
+
+/**
  * FR-1: register the reconcile sweep as an on-by-default governed cadence
  * (currently_expected_active=true, positive interval). Fail-soft: absent registry
  * table => loud canary, current manual behavior continues.
@@ -89,9 +101,17 @@ export async function detectChannelDegradation(supabase, {
       .select('status, created_at')
       .gte('created_at', cutoffIso)
       .limit(500);
-    if (res.error) return { alarmed: false, reason: 'table_absent' };
+    if (res.error) {
+      if (isMissingTable(res.error)) return { alarmed: false, reason: 'table_absent' };
+      logger.warn?.(`[sms-channel-health] CANARY: degradation query failed (${res.error.code || 'no_code'}: ${res.error.message || res.error}) — NOT table-absent, alarm suppressed by this fault.`);
+      return { alarmed: false, reason: `query_failed:${res.error.code || 'unknown'}` };
+    }
     rows = res.data || [];
-  } catch { return { alarmed: false, reason: 'table_absent' }; }
+  } catch (e) {
+    if (isMissingTable(e)) return { alarmed: false, reason: 'table_absent' };
+    logger.warn?.(`[sms-channel-health] CANARY: degradation query threw (${e?.message || e}) — NOT table-absent, alarm suppressed by this fault.`);
+    return { alarmed: false, reason: `query_threw:${e?.message || String(e)}` };
+  }
 
   const { ratio, total, bad } = computeDegradationRatio(rows, { windowMs, now });
   if (total < minSample || ratio < threshold) return { alarmed: false, ratio, total };
@@ -143,9 +163,19 @@ export async function escalateCarrierFiltered(supabase, { sendEmail, logger = co
       .select('id, body, last_error, status')
       .in('status', ['undelivered', 'failed', 'owed_escalate'])
       .limit(batchLimit);
-    if (res.error) return out; // fail-soft: absent table => nothing to escalate
+    if (res.error) {
+      if (!isMissingTable(res.error)) {
+        logger.warn?.(`[sms-channel-health] CANARY: carrier-filter scan query failed (${res.error.code || 'no_code'}: ${res.error.message || res.error}) — NOT table-absent, escalation suppressed by this fault.`);
+      }
+      return out; // fail-soft either way: nothing to escalate this pass
+    }
     rows = res.data || [];
-  } catch { return out; }
+  } catch (e) {
+    if (!isMissingTable(e)) {
+      logger.warn?.(`[sms-channel-health] CANARY: carrier-filter scan query threw (${e?.message || e}) — NOT table-absent, escalation suppressed by this fault.`);
+    }
+    return out;
+  }
 
   let send = sendEmail;
   if (!send) {

--- a/tests/unit/chairman/sms-channel-health.test.js
+++ b/tests/unit/chairman/sms-channel-health.test.js
@@ -17,6 +17,11 @@ const iso = (msAgo) => new Date(NOW - msAgo).toISOString();
 
 /** Table-aware supabase mock: per-table select rows + recorded upserts/updates. */
 function makeMock({ obligations = [], selectError = null, registryError = null } = {}) {
+  // QF-20260816-173: selectError may be a bare string (message-only, no .code — an
+  // operational fault with no PostgREST error code) or a full {code, message} object
+  // (e.g. {code: 'PGRST205', ...} for a genuine table-absent signature).
+  const selectErrorObj = selectError == null ? null
+    : (typeof selectError === 'string' ? { message: selectError } : selectError);
   const upserts = []; const updates = [];
   function chain(table) {
     const state = { op: 'select', payload: null };
@@ -43,7 +48,7 @@ function makeMock({ obligations = [], selectError = null, registryError = null }
         return { data: [], error: null };
       }
       if (table === 'sms_outbound_obligations') {
-        if (selectError && state.op === 'select') return { data: null, error: { message: selectError } };
+        if (selectErrorObj && state.op === 'select') return { data: null, error: selectErrorObj };
         if (state.op === 'update') { updates.push({ table, payload: state.payload }); return { data: [], error: null }; }
         return { data: obligations, error: null };
       }
@@ -131,10 +136,35 @@ describe('FR-2 / TS-2: channel-state degradation alarm', () => {
     expect(emit).not.toHaveBeenCalled();
   });
 
-  it('fail-soft: absent owed-state table => no alarm, no throw', async () => {
-    const m = makeMock({ selectError: 'relation "sms_outbound_obligations" does not exist' });
+  it('fail-soft: absent owed-state table (PGRST205) => no alarm, no throw, reason table_absent', async () => {
+    const m = makeMock({ selectError: { code: 'PGRST205', message: 'relation "sms_outbound_obligations" does not exist' } });
     const res = await detectChannelDegradation(m.supabase, { now: NOW, emit: vi.fn(), logger: quiet });
     expect(res).toEqual({ alarmed: false, reason: 'table_absent' });
+  });
+
+  it('fail-soft: absent owed-state table (42P01, raw Postgres code) => reason table_absent', async () => {
+    const m = makeMock({ selectError: { code: '42P01', message: 'relation "sms_outbound_obligations" does not exist' } });
+    const res = await detectChannelDegradation(m.supabase, { now: NOW, emit: vi.fn(), logger: quiet });
+    expect(res).toEqual({ alarmed: false, reason: 'table_absent' });
+  });
+
+  it('QF-20260816-173: an operational fault (42501, RLS-denied) is NOT table_absent — distinct reason, warning logged', async () => {
+    const m = makeMock({ selectError: { code: '42501', message: 'permission denied for table sms_outbound_obligations' } });
+    const warn = vi.fn();
+    const res = await detectChannelDegradation(m.supabase, { now: NOW, emit: vi.fn(), logger: { warn } });
+    expect(res).toEqual({ alarmed: false, reason: 'query_failed:42501' });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toMatch(/CANARY/);
+    expect(warn.mock.calls[0][0]).toMatch(/42501/);
+  });
+
+  it('QF-20260816-173: a thrown (non-table-absent) exception is NOT table_absent — distinct reason, warning logged', async () => {
+    const warn = vi.fn();
+    const throwingSupabase = { from: () => { throw new Error('ECONNRESET: network reset'); } };
+    const res = await detectChannelDegradation(throwingSupabase, { now: NOW, emit: vi.fn(), logger: { warn } });
+    expect(res).toEqual({ alarmed: false, reason: 'query_threw:ECONNRESET: network reset' });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toMatch(/CANARY/);
   });
 });
 
@@ -172,6 +202,24 @@ describe('FR-3 / TS-3: carrier-filter email-fallback escalation', () => {
     const res = await escalateCarrierFiltered(m.supabase, { sendEmail, logger: quiet });
     expect(res.escalated).toBe(0);
     expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft: absent owed-state table (PGRST205) => empty result, no warning', async () => {
+    const m = makeMock({ selectError: { code: 'PGRST205', message: 'relation "sms_outbound_obligations" does not exist' } });
+    const warn = vi.fn();
+    const res = await escalateCarrierFiltered(m.supabase, { sendEmail: vi.fn(), logger: { warn } });
+    expect(res).toEqual({ scanned: 0, escalated: 0, emailUnavailable: 0 });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('QF-20260816-173: an operational fault (42501, RLS-denied) still fails soft, but logs a CANARY warning naming the real fault', async () => {
+    const m = makeMock({ selectError: { code: '42501', message: 'permission denied for table sms_outbound_obligations' } });
+    const warn = vi.fn();
+    const res = await escalateCarrierFiltered(m.supabase, { sendEmail: vi.fn(), logger: { warn } });
+    expect(res).toEqual({ scanned: 0, escalated: 0, emailUnavailable: 0 });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toMatch(/CANARY/);
+    expect(warn.mock.calls[0][0]).toMatch(/42501/);
   });
 
   it('email-send failure: logged non-escalation, NO stamp (retryable next sweep)', async () => {


### PR DESCRIPTION
## Summary
- A2 ultrareview #7065 bug_017 (Adam-verified): `detectChannelDegradation` and `escalateCarrierFiltered` in `lib/chairman/sms-channel-health.js` classified ANY supabase query error or thrown exception on `sms_outbound_obligations` as `table_absent` (fail-soft, silent). On the live table the only reachable error IS an operational fault (e.g. RLS `42501`), so a real incident silenced both the FR-2 degradation alarm and the FR-3 email escalation exactly when they were needed — indistinguishable from an inert, not-yet-staged table.
- Fix: added a local `isMissingTable()` that only recognizes `PGRST205`/`42P01` as genuine table-absent signatures, matching this codebase's established `tableAbsent()` pattern (`lib/forecasting/ledger.js`, `lib/fleet/session-registry.js`, `lib/fleet/session-watchdog.js`, etc). Everything else now returns a distinct, logged reason (`query_failed:<code>` / `query_threw:<msg>`) via a CANARY warning, in both functions.

## Test plan
- [x] `tests/unit/chairman/sms-channel-health.test.js`: 18/18 passing, including new coverage for the exact QF reproduction (42501 → `query_failed:42501` + warning logged; PGRST205/42P01 → `table_absent`, no warning; a thrown non-table-absent exception → `query_threw:<msg>` + warning).
- [x] Updated the pre-existing absent-table test to carry a proper `PGRST205` code (it previously used a message-only error object, which is itself the ambiguity this fix closes).
- [x] `npx tsc --noEmit` passes.
- [x] Broader `tests/unit/chairman/` + `tests/unit/cron/` surface run: 801/802 passing; the one failure (`sms-outbound-reconcile.test.js`'s unrelated `provider.send()` call-site audit) is a 60s timeout under this session's heavy parallel load — confirmed a flake by re-running it in isolation (passes in 1.4s), unrelated to this diff (no `provider.send()`/`twilioProvider.send()` call sites touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)