### PR TITLE
fix(QF-20260816-435): capacity reads no longer swallow failures into a manufactured DEFICIT

### DIFF
--- a/scripts/lib/capacity-inputs.mjs
+++ b/scripts/lib/capacity-inputs.mjs
@@ -186,8 +186,13 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
   const [sessions, sds, openQfCountRaw] = await Promise.all([
     // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: claude_sessions is a growing
     // table and this read feeds worker-count/capacity math directly (filtered + iterated
-    // below) — paginate to completion. Preserve the prior fail-open policy (undefined `data`
-    // on error → `(sessions || [])` fallback below) by catching the throw and returning [].
+    // below) — paginate to completion.
+    // QF-20260816-435: the prior `.catch(() => [])` here silently turned a read FAILURE into a
+    // read of ZERO live sessions — indistinguishable from "genuinely no workers online" — which
+    // fed a manufactured DEFICIT verdict into scoreLeg4, persisted and scored 0/2 (the exact
+    // unavailable-vs-zero collapse report-posture.js's header exists to forbid). This read now
+    // propagates its throw; scoreCapacityLeg (scripts/cron/drive-report-sweep.mjs) already
+    // catches it and reports leg4 unavailable() rather than scoring or persisting anything.
     fetchAllPaginated(() => sb.from('claude_sessions')
       // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: + status so released/terminal sessions
       // are not counted as available workers even with a recent heartbeat (FR-2).
@@ -204,12 +209,13 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
       // a fleet-down false alarm to the operator). Replicate the detector input-column contract.
       .select('session_id, terminal_id, sd_key, heartbeat_at, process_alive_at, loop_state, expected_silence_until, metadata, status, released_reason, released_at')
       .gte('heartbeat_at', liveCutoff)
-      .order('session_id', { ascending: true })) // unique tiebreaker: stable page boundaries (FR-6)
-      .catch(() => []),
+      .order('session_id', { ascending: true })), // unique tiebreaker: stable page boundaries (FR-6)
     // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: strategic_directives_v2 is a
     // growing table and this read feeds belt-depth/dependency resolution directly (iterated +
-    // acted on below) — paginate to completion. Preserve the prior fail-open policy (undefined
-    // `data` on error → `(sds || [])` fallbacks below) by catching the throw and returning [].
+    // acted on below) — paginate to completion.
+    // QF-20260816-435: same fix as the sessions read above — a read failure previously became a
+    // silent read of ZERO open SDs (indistinguishable from "genuinely no belt"), manufacturing a
+    // DEFICIT verdict instead of surfacing as unavailable. Now propagates.
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + metadata (is_fixture marker) and
     // title/description (bare-shell detection) so excluded rows do not inflate belt depth.
     // SD-REFILL-00306WTS: + target_application so un-actionable auto-filed venture remediation
@@ -220,8 +226,7 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
       // sd_key) without a per-child DB round-trip.
       .select('id, sd_key, title, description, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies, metadata, target_application, parent_sd_id')
       .not('status', 'in', '("completed","cancelled","deferred")')
-      .order('sd_key', { ascending: true })) // unique tiebreaker (FR-6)
-      .catch(() => []),
+      .order('sd_key', { ascending: true })),
     // Open QFs are claimable belt too (a worker can claim a QF) — counting only SDs
     // under-reports belt depth and over-reports deficit (workers self-claim QFs).
     //

--- a/tests/unit/capacity-inputs.test.js
+++ b/tests/unit/capacity-inputs.test.js
@@ -191,6 +191,26 @@ describe('gatherCapacityInputs — the counts the verdict ladder consumes', () =
     expect(out.openQfCount).toBe(0);
     expect(out.claimableCount, 'the SD arm must still be measured').toBe(1);
   });
+
+  // QF-20260816-435: unlike the QF gauge above, the sessions and SD reads previously had the SAME
+  // `.catch(() => [])` softening — but they feed the deficit computation directly, so a read
+  // failure silently became "read cleanly, zero workers/zero belt", manufacturing a real DEFICIT
+  // verdict indistinguishable from a genuine one. These two now assert the opposite of the QF-gauge
+  // test above: a sessions or SD read failure must propagate out of gatherCapacityInputs so the
+  // caller (scoreCapacityLeg) can convert it to leg4 unavailable() instead of scoring/persisting.
+  it('a claude_sessions read failure propagates — never silently reads as zero live workers', async () => {
+    const client = fakeClient({ sds: [claimableSd()] });
+    const orig = client.from.bind(client);
+    client.from = (n) => (n === 'claude_sessions' ? { select() { throw new Error('sessions read failed'); } } : orig(n));
+    await expect(gatherCapacityInputs(client)).rejects.toThrow('sessions read failed');
+  });
+
+  it('a strategic_directives_v2 read failure propagates — never silently reads as zero belt depth', async () => {
+    const client = fakeClient({ sessions: [liveSession()] });
+    const orig = client.from.bind(client);
+    client.from = (n) => (n === 'strategic_directives_v2' ? { select() { throw new Error('sds read failed'); } } : orig(n));
+    await expect(gatherCapacityInputs(client)).rejects.toThrow('sds read failed');
+  });
 });
 
 describe('the ETA helpers moved intact', () => {

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -31,6 +31,7 @@ import { armedProcessKey } from '../../../lib/machinery-class/armed-registration
 import { produceDriveReport } from '../../../scripts/drive-report-produce.mjs';
 import { LAST_RUN_FIELD } from '../../../lib/drive-loop/report-posture.js';
 import { makeCapacityVerdictPersist } from '../../../scripts/lib/capacity-verdict-store.mjs';
+import { gatherCapacityInputs } from '../../../scripts/lib/capacity-inputs.mjs';
 import { hourlyWindowKey } from '../../../scripts/cron/drive-report-hourly-sweep.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -863,6 +864,32 @@ describe('FR-3 — leg4 is injected, not declared unavailable', () => {
       persistVerdict: okPersist([]),
     });
     expect(leg.unavailable.reason).toMatch(/belt query failed/);
+  });
+
+  // QF-20260816-435: the [TRAP] test above proves scoreCapacityLeg converts ANY thrown gather to
+  // unavailable, using an arbitrary stub. These two prove the REAL gatherCapacityInputs (not a
+  // stub) now actually throws when the sessions or SD read fails — the fix this QF makes — and
+  // that no belt_capacity_verdicts row gets persisted when it does.
+  it('[QF-20260816-435] a real claude_sessions read failure -> leg4 unavailable, nothing persisted', async () => {
+    const captured = [];
+    const client = { from(n) { return n === 'claude_sessions' ? { select() { throw new Error('sessions down'); } } : { select() { return this; }, eq() { return this; }, in() { return this; }, is() { return this; }, not() { return this; }, gte() { return this; }, order() { return this; }, range() { return Promise.resolve({ data: [], error: null }); }, then(res) { return Promise.resolve({ data: [], error: null }).then(res); } }; } };
+    const leg = await scoreCapacityLeg({
+      gatherCapacity: () => gatherCapacityInputs(client),
+      persistVerdict: okPersist(captured),
+    });
+    expect(leg.unavailable.reason).toMatch(/sessions down/);
+    expect(captured, 'a failed gather must never reach the persist call').toHaveLength(0);
+  });
+
+  it('[QF-20260816-435] a real strategic_directives_v2 read failure -> leg4 unavailable, nothing persisted', async () => {
+    const captured = [];
+    const client = { from(n) { return n === 'strategic_directives_v2' ? { select() { throw new Error('sds down'); } } : { select() { return this; }, eq() { return this; }, in() { return this; }, is() { return this; }, not() { return this; }, gte() { return this; }, order() { return this; }, range() { return Promise.resolve({ data: [], error: null }); }, then(res) { return Promise.resolve({ data: [], error: null }).then(res); } }; } };
+    const leg = await scoreCapacityLeg({
+      gatherCapacity: () => gatherCapacityInputs(client),
+      persistVerdict: okPersist(captured),
+    });
+    expect(leg.unavailable.reason).toMatch(/sds down/);
+    expect(captured, 'a failed gather must never reach the persist call').toHaveLength(0);
   });
 
   it('buildGather REFUSES an uninjected leg4 rather than defaulting it', () => {


### PR DESCRIPTION
## Summary
- `gatherCapacityInputs`' `claude_sessions` and `strategic_directives_v2` reads were wrapped in `.catch(() => [])`, so a genuine read FAILURE became a silent read of zero live workers / zero belt depth — indistinguishable from "genuinely nothing there". That fed a manufactured DEFICIT verdict straight into `scoreLeg4`, which persisted it and scored the leg 0/2 — exactly the unavailable-vs-zero collapse `report-posture.js`'s own header exists to forbid.
- Both reads now propagate their throw. No downstream change needed — `scoreCapacityLeg` (`scripts/cron/drive-report-sweep.mjs`) already wraps `gatherCapacity()` in try/catch and converts any thrown error into leg4 `unavailable()` without persisting a row.
- The QF-count (`quick_fixes`) read keeps its existing fail-open-to-0 behavior on purpose — it's one contributing input among several, not the primary driver of a false verdict, and its fallback comment was already honest. An existing test already pins this as unchanged.
- `coordinator-capacity-forecast.mjs` (the third caller) needs no change — its `main()` is already wrapped at the top-level invocation, so a newly-propagating failure now correctly fails that cron run loudly instead of silently forecasting from empty data.
- A2 ultrareview #7065 bug_019 (Adam-verified).

## Test plan
- [x] `tests/unit/capacity-inputs.test.js`: 2 new tests proving `gatherCapacityInputs` itself now throws (not silently returns `[]`) when `claude_sessions` or `strategic_directives_v2` reads fail.
- [x] `tests/unit/cron/drive-report-sweep.test.js`: 2 new integration tests proving the REAL `gatherCapacityInputs` (not a stub) wired through `scoreCapacityLeg` produces `leg4 unavailable` AND that `persistVerdict` is never called (no `belt_capacity_verdicts` row) — the exact scenario the QF description specifies.
- [x] `node --check` on all 3 modified files.
- [x] Full affected surface (capacity-inputs, drive-report-sweep, capacity-forecaster-belt-extent, capacity-verdict-store, coordinator-capacity-forecast, drive-report-hourly-sweep, drive-loop/): 331/331 passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)