### PR TITLE
fix(SD-LEO-FIX-PROGRAMMATIC-LOCAL-LLM-001): bound the QF body inherited into an escalated SD's description

### DIFF
--- a/lib/eva/input-sanitizer.js
+++ b/lib/eva/input-sanitizer.js
@@ -8,7 +8,7 @@
  */
 
 /** Maximum content length for LLM input (matches vision-scorer.js MAX_CONTENT_CHARS). */
-const MAX_CONTENT_CHARS = 8000;
+export const MAX_CONTENT_CHARS = 8000;
 
 /**
  * Injection patterns to detect and strip.

--- a/lib/sd-creation/source-adapters/qf.js
+++ b/lib/sd-creation/source-adapters/qf.js
@@ -9,6 +9,39 @@ import { generateSDKey } from '../../../scripts/modules/sd-key-generator.js';
 import { withRetry } from '../../eva/stage-zero/data-pollers/retry.js';
 import { resolveVenturePrefix, createSDOrThrow as createSD } from '../pipeline.js';
 import { classifyPlanLinkage } from '../plan-linkage-classifier.js';
+import { MAX_CONTENT_CHARS } from '../../eva/input-sanitizer.js';
+
+/**
+ * Compose an escalated SD's description from a QF row (QF-20260729-534 option C).
+ * A QF's free-form `description` narrative can run to tens of thousands of chars
+ * (measured: p99 ~16.6K, max ~42K across 500 QFs; 7% exceed the vision-scorer's own
+ * 8000-char grading cap) — inheriting it verbatim put the escalated SD's actual scope
+ * past where GATE_VISION_SCORE could see it, since title/key_changes/success_criteria
+ * are appended AFTER description in the grading prompt. Prefers the QF's structured
+ * expected/actual fields (measured: max ~1000 chars each, on-topic); falls back to a
+ * bounded slice of the free-form description when those are empty (measured: 23% of
+ * QFs carry neither). The bound applies uniformly regardless of source so the output
+ * is never unbounded. The original text is never discarded — see qfOriginBody().
+ */
+function composeEscalatedDescription(qf) {
+  const behaviorSummary = [
+    qf.expected_behavior ? `Expected: ${qf.expected_behavior}` : null,
+    qf.actual_behavior ? `Actual: ${qf.actual_behavior}` : null,
+  ].filter(Boolean).join('\n');
+  const composed = behaviorSummary || qf.description || qf.title || '';
+  return composed.length > MAX_CONTENT_CHARS
+    ? `${composed.slice(0, MAX_CONTENT_CHARS)}\n\n[…truncated; full text in metadata.qf_origin_body]`
+    : composed;
+}
+
+/** Full, unbounded provenance capture of the QF's own fields — nothing is discarded. */
+function qfOriginBody(qf) {
+  return {
+    description: qf.description || null,
+    expected_behavior: qf.expected_behavior || null,
+    actual_behavior: qf.actual_behavior || null,
+  };
+}
 
 /**
  * Create SD from open quick-fix (QF-* row).
@@ -62,7 +95,7 @@ export async function createFromQF(qfId, opts = {}) {
   const sd = await createSD({
     sdKey,
     title: qf.title,
-    description: qf.description || qf.title,
+    description: composeEscalatedDescription(qf),
     type,
     priority,
     rationale: `Escalated from quick-fix ${qf.id} (Tier 3 routing). Original LOC estimate: ${qf.estimated_loc ?? 'n/a'}.`,
@@ -74,6 +107,9 @@ export async function createFromQF(qfId, opts = {}) {
       qf_severity: qf.severity,
       qf_estimated_loc: qf.estimated_loc,
       qf_target_application: qf.target_application,
+      // QF-20260729-534 (option C): the QF's own body, preserved verbatim for
+      // provenance/reference — NOT the field the vision-scorer grades.
+      qf_origin_body: qfOriginBody(qf),
       // SD-LEO-INFRA-ESCALATION-CONTINUITY-AUTO-001 (FR-2): branch-continuity seed.
       // The QF worker's fix is committed on branch qf/<qf-id>; recording it here lets
       // sd-start.js base the escalated SD's worktree off that local branch instead of

--- a/lib/sd-creation/source-adapters/qf.js
+++ b/lib/sd-creation/source-adapters/qf.js
@@ -15,13 +15,18 @@ import { MAX_CONTENT_CHARS } from '../../eva/input-sanitizer.js';
  * Compose an escalated SD's description from a QF row (QF-20260729-534 option C).
  * A QF's free-form `description` narrative can run to tens of thousands of chars
  * (measured: p99 ~16.6K, max ~42K across 500 QFs; 7% exceed the vision-scorer's own
- * 8000-char grading cap) — inheriting it verbatim put the escalated SD's actual scope
- * past where GATE_VISION_SCORE could see it, since title/key_changes/success_criteria
- * are appended AFTER description in the grading prompt. Prefers the QF's structured
- * expected/actual fields (measured: max ~1000 chars each, on-topic); falls back to a
- * bounded slice of the free-form description when those are empty (measured: 23% of
- * QFs carry neither). The bound applies uniformly regardless of source so the output
- * is never unbounded. The original text is never discarded — see qfOriginBody().
+ * 8000-char per-field grading cap, lib/eva/input-sanitizer.js's sanitizeInput()) —
+ * inheriting it verbatim (QF-20260728-277's own reproduction: a 21,693-char description
+ * graded on its first 8000 chars, which happened to be about a different subject) put
+ * the escalated SD's actual scope past where the grader ever read it. The load-bearing
+ * fix is field PREFERENCE: the QF's structured expected/actual fields (measured: max
+ * ~1000 chars each, on-topic) are almost always on-scope and far under the cap, so
+ * preferring them over the narrative avoids the truncation entirely in the common case.
+ * The length bound below is defense-in-depth for the remaining case (measured: 23% of
+ * QFs carry neither behavior field) — it duplicates, rather than replaces, the per-field
+ * cap sanitizeInput() already applies independently downstream. The bound applies
+ * uniformly regardless of source so the output is never unbounded. The original text is
+ * never discarded — see qfOriginBody().
  */
 function composeEscalatedDescription(qf) {
   const behaviorSummary = [

--- a/tests/unit/qf-escalation-continuity.test.js
+++ b/tests/unit/qf-escalation-continuity.test.js
@@ -248,6 +248,17 @@ describe('Description/scope inheritance (QF-20260729-534 option C)', () => {
     expect(h.createSDArgs.description).toBe(short);
   });
 
+  it('does not truncate a description at exactly MAX_CONTENT_CHARS (boundary, not over it)', async () => {
+    // TESTING sub-agent adversarial pass: composed.length > MAX_CONTENT_CHARS mutated to
+    // >= survived every other test here, because none of them supply a fixture of exactly
+    // 8000 chars -- all sit strictly on one side of both operators. Only an exact-length
+    // fixture distinguishes "over the cap" from "at the cap".
+    const exact = 'w'.repeat(8000);
+    h.cfg = { qfRow: baseQfRow({ description: exact, expected_behavior: null, actual_behavior: null }) };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description).toBe(exact);
+  });
+
   it('preserves the full, untruncated original in metadata.qf_origin_body regardless of length', async () => {
     const long = 'z'.repeat(21693);
     h.cfg = {

--- a/tests/unit/qf-escalation-continuity.test.js
+++ b/tests/unit/qf-escalation-continuity.test.js
@@ -190,6 +190,85 @@ describe('FR-1: born-claim via claim_sd', () => {
   });
 });
 
+describe('Description/scope inheritance (QF-20260729-534 option C)', () => {
+  it('prefers expected/actual behavior over the free-form description when both are present', async () => {
+    h.cfg = {
+      qfRow: baseQfRow({
+        description: 'A long free-form incident narrative that is not the SD scope.',
+        expected_behavior: 'The gate surfaces a warning.',
+        actual_behavior: 'The gate is silent.',
+      }),
+    };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description).toBe('Expected: The gate surfaces a warning.\nActual: The gate is silent.');
+    expect(h.createSDArgs.description).not.toContain('incident narrative');
+  });
+
+  it('falls back to the free-form description when expected/actual are both empty', async () => {
+    h.cfg = { qfRow: baseQfRow({ description: 'Only a narrative here.', expected_behavior: null, actual_behavior: null }) };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description).toBe('Only a narrative here.');
+  });
+
+  it('falls back to the title when description and behavior fields are all empty', async () => {
+    h.cfg = { qfRow: baseQfRow({ title: 'Fallback title', description: null, expected_behavior: null, actual_behavior: null }) };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description).toBe('Fallback title');
+  });
+
+  it('truncates a description exceeding MAX_CONTENT_CHARS at the exact 8000-char boundary', async () => {
+    // Heterogeneous fixture (counter, not a repeated char) so an off-by-one cut point
+    // changes the final character and an exact toBe() can pin the boundary precisely --
+    // a homogeneous 'x'.repeat() fixture with startsWith()/toBeLessThan() only bounds the
+    // cut to the open interval [8000, len), so e.g. a slice(0, 12000) mutant survives it.
+    const long = Array.from({ length: 21693 }, (_, i) => i % 10).join('');
+    h.cfg = { qfRow: baseQfRow({ description: long, expected_behavior: null, actual_behavior: null }) };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description).toBe(`${long.slice(0, 8000)}\n\n[…truncated; full text in metadata.qf_origin_body]`);
+  });
+
+  it('truncates an oversized behavior summary too -- the cap is not bypassed on the preferred path', async () => {
+    // expected_behavior/actual_behavior are unconstrained free-text columns. If the
+    // truncation check were ever moved inside an early-return for the behaviorSummary
+    // branch, this is the exact regression that would silently reintroduce the unbounded-
+    // description defect QF-20260729-534 exists to close -- just via the preferred path
+    // instead of the description fallback.
+    const longExpected = 'e'.repeat(9000);
+    h.cfg = { qfRow: baseQfRow({ description: 'short', expected_behavior: longExpected, actual_behavior: null }) };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description.length).toBe(8000 + '\n\n[…truncated; full text in metadata.qf_origin_body]'.length);
+    expect(h.createSDArgs.description).toContain('…truncated; full text in metadata.qf_origin_body');
+    expect(h.createSDArgs.description.startsWith(`Expected: ${'e'.repeat(100)}`)).toBe(true);
+  });
+
+  it('does not truncate a description within the cap', async () => {
+    const short = 'y'.repeat(500);
+    h.cfg = { qfRow: baseQfRow({ description: short, expected_behavior: null, actual_behavior: null }) };
+    await createFromQF('QF-TEST-1');
+    expect(h.createSDArgs.description).toBe(short);
+  });
+
+  it('preserves the full, untruncated original in metadata.qf_origin_body regardless of length', async () => {
+    const long = 'z'.repeat(21693);
+    h.cfg = {
+      qfRow: baseQfRow({
+        description: long,
+        expected_behavior: 'short expected',
+        actual_behavior: 'short actual',
+      }),
+    };
+    await createFromQF('QF-TEST-1');
+    // description field used the short behavior summary (per the preference test above)...
+    expect(h.createSDArgs.description).toBe('Expected: short expected\nActual: short actual');
+    // ...but nothing from the long original narrative was discarded.
+    expect(h.createSDArgs.metadata.qf_origin_body).toEqual({
+      description: long,
+      expected_behavior: 'short expected',
+      actual_behavior: 'short actual',
+    });
+  });
+});
+
 describe('FR-3: resolveEscalatedBaseRef — local-ref base resolution', () => {
   it('TS-4: returns the local QF ref when seeded and the branch exists', async () => {
     const repo = createFixtureRepo();


### PR DESCRIPTION
## Summary
- QF-20260729-534 (option C): leo-create-sd.js --from-qf copied the escalating QF's free-form description verbatim into the new SD's description, unbounded -- measured 7% of 500 recent QFs exceed the vision-scorer's own 8000-char grading cap
- Exports MAX_CONTENT_CHARS from lib/eva/input-sanitizer.js (was a local const) as the single shared bound
- createFromQF() now prefers the QF's structured expected_behavior/actual_behavior fields, falls back to a bounded slice of description/title, and always preserves the full original in metadata.qf_origin_body
- Originally scoped around programmatic/local-LLM scoring-path truncation parity (from QF-20260816-623); a LEAD-phase validation-agent + Explore pass found that premise false and surfaced this genuinely-open, better-evidenced gap instead -- full trail in sub_agent_execution_results (928f1cc3, eb3bf688, fe3c7723)
- TESTING sub-agent adversarial mutation-testing found the original truncation test only bounded the cut to an open interval, and no test exercised truncation on the preferred (behaviorSummary) path -- both fixed with a heterogeneous-fixture exact-equality test and a new dedicated test

## Test plan
- 15/15 tests passing in tests/unit/qf-escalation-continuity.test.js (8 pre-existing unmodified + 7 new/hardened)
- 38/38 passing across 5 sibling suites (no regression)
- Lint clean
- TESTING sub-agent CONDITIONAL_PASS -> both findings fixed, re-verified against real (unmodified) production code

Generated with Claude Code