### PR TITLE
fix(QF-20260816-456): merge rival chairman_all_decision_signals views ahead of ceremony

### DIFF
--- a/database/chairman-gated/20260803_chairman_queue_truthful_render.sql
+++ b/database/chairman-gated/20260803_chairman_queue_truthful_render.sql
@@ -1,5 +1,11 @@
 -- SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-003 — FR-3: truthful render
 --
+-- SUPERSEDED-BY: database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
+-- (QF-20260816-456, 2026-08-16). Do NOT apply this file — its title/status/priority fixes were
+-- merged into the successor alongside 20260803_chairman_source4_rework.sql's decided_at/
+-- decided_by/security_invoker fixes, which this file does not have. Kept here unmodified for
+-- history/diff provenance only.
+--
 -- STAGED, NOT APPLIED. Chairman-facing view = TIER-2.
 --
 -- AUTHORED AGAINST THE LIVE VIEW, NOT THE PROPOSED FILE. FR-3's mandatory pin: the PROPOSED

--- a/database/chairman-gated/20260803_chairman_source4_rework.sql
+++ b/database/chairman-gated/20260803_chairman_source4_rework.sql
@@ -1,5 +1,12 @@
 -- SD-LEO-INFRA-CHAIRMAN-DECISION-VIEW-001 — Source-4 rework of chairman_all_decision_signals
 --
+-- SUPERSEDED-BY: database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
+-- (QF-20260816-456, 2026-08-16). Do NOT apply this file — its decided_at/decided_by/priority/
+-- security_invoker fixes were merged into the successor alongside
+-- 20260803_chairman_queue_truthful_render.sql's title/status HELD-rendering fixes, which this file
+-- does not have (this file's branch 4 still renders decision='pause' as 'rejected'). Kept here
+-- unmodified for history/diff provenance only.
+--
 -- ============================ STAGED. NOT APPLIED. ============================
 -- CREATE OR REPLACE VIEW is TIER-2 under scripts/lib/migration-tier-classifier.mjs, so the
 -- classifier will never auto-apply it. There is NO @approved-by attestation on this file and this

--- a/database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
+++ b/database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
@@ -1,0 +1,298 @@
+-- QF-20260816-456 — MERGE of two rival chairman-gated views of chairman_all_decision_signals
+-- into ONE, ahead of the 2026-08-17 chairman ceremony. Supersedes both:
+--   database/chairman-gated/20260803_chairman_queue_truthful_render.sql   ("File A")
+--   database/chairman-gated/20260803_chairman_source4_rework.sql          ("File B")
+--
+-- ============================ STAGED. NOT APPLIED. ============================
+-- CREATE OR REPLACE VIEW is TIER-2 under scripts/lib/migration-tier-classifier.mjs — never
+-- auto-applied. No @approved-by attestation. The builder stages; the chairman applies.
+--
+-- TARGET CONFIRMED: chairman_all_decision_signals, NOT chairman_unified_decisions (a 21-line
+-- thin wrapper over this view — see File B's header for the destructive-if-confused warning
+-- against database/migrations/20260725_chairman_queue_truthful_render_PROPOSED.sql, which still
+-- applies here unchanged).
+--
+-- PROVENANCE: base = pg_get_viewdef('public.chairman_all_decision_signals', true) read live via
+-- the pooler on 2026-08-16 (7,304 chars — byte-identical to both File A's and File B's own
+-- captured-live starting point, confirming neither rival has been applied). Branches 1, 2, 5, 6, 7
+-- are carried forward UNCHANGED from that live read. Only branches 3 and 4 (the two
+-- venture_decisions/chairman_decisions branches touching "decided" semantics) differ, and are
+-- spliced from the two rivals' already-reviewed SQL rather than retyped — retyping a 7-branch
+-- UNION by hand to change two of them is how a branch silently disappears (File A's own stated
+-- risk, and the reason this migration is built the same way its rivals were).
+--
+-- ========================== WHY A MERGE, NOT A PICK ==========================
+-- File A and File B fix ALMOST ENTIRELY NON-OVERLAPPING defects in the SAME branch (4,
+-- chairman_decisions). Measured by diffing both against the live branch:
+--   File A fixes: title (HELD-until rendering off brief_data->'hold'), status (adds 'held' for a
+--     ratified park AND for decision='pause' — in BOTH branch 3 and branch 4; live buckets 'pause'
+--     into 'rejected' in both), priority (softens a ratified hold to 'normal').
+--     File A does NOT touch decided_at/decided_by — both stay unconditional/NULL, i.e. still lies.
+--   File B fixes: decided_at (conditional, real, off cd.updated_at), decided_by (real, off
+--     cd.decided_by_user_id), priority (blocking-based instead of unconditional 'critical'),
+--     WITH (security_invoker = on) stated explicitly.
+--     File B does NOT add a 'held' status anywhere — decision='pause' still renders 'rejected' in
+--     File B's branch 4, and File B's branch 3 is untouched from live (same bug, unaddressed).
+-- A chairman reading this queue needs BOTH: a decision that was actually decided must show who and
+-- when (File B), and a decision that was deliberately parked must not read as rejected (File A).
+-- Shipping either alone leaves the other's defect live. Hence: merge, not pick.
+--
+-- ============================ PER-BRANCH MERGE DECISIONS ============================
+-- Branch 3 (venture_decisions, decision IS NOT NULL): adopt File A's status CASE verbatim — pause
+--   separated from kill/reject/cancel into 'held'. File B did not touch this branch (out of its
+--   SD's scope, not a deliberate keep); the bug is the identical pattern File B's own header names
+--   as the (branch-4) defect it exists to fix, so leaving it unfixed here would be inconsistent
+--   only by omission, not by design.
+-- Branch 4 (chairman_decisions):
+--   decision_type: STAYS 'chairman_approval' (File B's explicit, verified choice). Re-verified live
+--     on 2026-08-16 against all four cited consumers — still real, still load-bearing:
+--       lib/chairman/decision-queue.mjs:186        routeDecision switches on it
+--       lib/chairman/chairman-actionable.mjs:24     CONSOLE_ACTIONABLE_TYPES
+--       lib/chairman/decision-layman.mjs:26         GROUPABLE_TYPES
+--       lib/chairman/decision-layman.mjs:113        dead-venture drop
+--     Changing this column would make every one of those mis-route or drop the row. The real
+--     subtype still reaches the human through the title (File B's mechanism), extended below.
+--   title: File B's real-subtype + summary rendering, with File A's HELD-until suffix appended.
+--     File A's stage-suffix/initcap formatting is dropped in favor of B's richer content (the real
+--     cd.decision_type plus actual summary text says more than "Stage N Chairman Approval" ever
+--     did); the HELD-suffix is kept because it is what makes a bare status='held' legible instead
+--     of just cryptic.
+--   priority: File B's blocking-based baseline, with File A's ratified-hold override on top — a
+--     row the chairman already parked must not permanently read 'critical' just because
+--     blocking=true; that is the same "already-decided row reads critical forever" defect class
+--     File B's own header measured at 114 rows (QF-20260725-450) reappearing one column over if the
+--     override is dropped.
+--   status: File A's full CASE ladder verbatim (ratified-hold -> held; pending; proceed ->
+--     approved; pause -> held, separated from kill/reject/cancel -> rejected; pivot/fix/override;
+--     else decided). This is a strict superset of File B's, which has no 'held' branch at all.
+--   decided_at / decided_by: File B's fix verbatim, unchanged by the status merge above — the
+--     decided_at CASE reads the pre-existing cd.decided_by (text) column as its gate, independent
+--     of both the derived view-status column and the decided_by (uuid) output column, so it
+--     composes safely with every change above.
+--   Everything else in branch 4 (venture_id, stage, gate_type, recommendation, response_deadline,
+--     created_at, requestor_name, venture_name, details, blocking) is identical across live/A/B —
+--     carried forward unchanged.
+--
+-- ======================== brief_data->'hold' MECHANISM — VERIFIED REAL ========================
+-- Not a File-A invention: scripts/apply-chairman-decision-captures.mjs:146 reads
+-- row.brief_data?.hold?.ratified live in production, and :157 writes unpark_trigger under the same
+-- key. Confirmed live on 2026-08-16 against a real ratified-hold row
+-- (id=3aa84300-0f0b-4a91-bebe-a24768c94320): brief_data->'hold' = {"ratified": true,
+-- "unpark_trigger": "Sessions+Roadmap live in EHG, or explicit chairman direction", ...}.
+--
+-- ============================ security_invoker = on ============================
+-- STATED EXPLICITLY, MUST NOT BE DROPPED — carrying File B's rationale forward unchanged: relying
+-- on CREATE OR REPLACE to retain reloptions implicitly would be gambling on a semantic not worth
+-- gambling on; if ever lost, the view would run DEFINER and silently bypass RLS for every querying
+-- user. This is NOT a new behavior change — verified live on 2026-08-16 that pg_class.reloptions
+-- for this view is ALREADY {security_invoker=on} today, so this migration preserves current
+-- production behavior rather than introducing it.
+--
+-- READER-ACCESS CHECK (the explicit precondition for touching this reloption at all): the chairman
+-- dashboard's decide flow queries Postgres RPCs/views directly from the browser as the
+-- `authenticated` role (docs/governance/chairman-decision-surfaces.md, "Architecture note" —
+-- ehg/src/components/chairman-v3/decisions/DecisionActions.tsx +
+-- ehg/src/hooks/usePendingGateDecision.ts), not service_role. Verified live on 2026-08-16 via
+-- information_schema.role_table_grants + pg_policies: `authenticated` holds SELECT grant AND a
+-- permissive USING(true)-shaped RLS policy on EVERY base table this view reads (agent_messages,
+-- agent_registry, chairman_decisions, feedback, leo_feature_flags, okr_generation_log,
+-- venture_decisions, ventures). A non-service reader does not lose access under invoker semantics —
+-- confirmed, not assumed.
+--
+-- ROLLBACK: database/chairman-gated/20260817_chairman_all_decision_signals_merged_DOWN.sql
+-- CONTROL QUERY (run immediately after apply): database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.chairman_all_decision_signals
+WITH (security_invoker = on) AS
+ SELECT am.id,
+    'escalation'::text AS decision_type,
+    am.subject AS title,
+    COALESCE(am.priority, 'normal'::character varying)::text AS priority,
+    'pending'::text AS status,
+    ar.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULL::text AS recommendation,
+    am.response_deadline,
+    am.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    ar.display_name AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('message_type', am.message_type, 'body', am.body, 'from_agent_id', am.from_agent_id) AS details,
+    false AS blocking
+   FROM agent_messages am
+     LEFT JOIN agent_registry ar ON ar.id = am.from_agent_id
+     LEFT JOIN ventures v ON v.id = ar.venture_id
+  WHERE am.message_type::text = 'escalation'::text AND am.status::text = 'pending'::text
+UNION ALL
+ SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+        CASE
+            WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+            WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+            ELSE 'normal'::text
+        END AS priority,
+    'pending'::text AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details,
+    vd.gate_type = 'hard_gate'::text AS blocking
+   FROM venture_decisions vd
+     LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NULL
+UNION ALL
+ SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+        CASE
+            WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+            WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+            ELSE 'normal'::text
+        END AS priority,
+        CASE
+            WHEN vd.decision = 'proceed'::text THEN 'approved'::text
+            WHEN vd.decision = 'pause'::text THEN 'held'::text
+            WHEN vd.decision = ANY (ARRAY['kill'::text, 'reject'::text, 'cancel'::text]) THEN 'rejected'::text
+            ELSE 'decided'::text
+        END AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    vd.decided_at,
+    vd.decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'decision', vd.decision, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details,
+    vd.gate_type = 'hard_gate'::text AS blocking
+   FROM venture_decisions vd
+     LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NOT NULL
+UNION ALL
+ SELECT cd.id,
+    'chairman_approval'::text AS decision_type,
+    concat(cd.decision_type, ': ', COALESCE(left(cd.summary, 120), '(no summary)'),
+      CASE WHEN cd.brief_data->'hold'->>'ratified' = 'true'
+           THEN concat(' — HELD until: ', COALESCE(NULLIF(cd.brief_data->'hold'->>'unpark_trigger', ''), 'trigger NOT RECORDED'))
+           ELSE '' END) AS title,
+    CASE WHEN cd.brief_data->'hold'->>'ratified' = 'true' THEN 'normal'::text
+         WHEN COALESCE(cd.blocking, false) THEN 'critical'::text
+         ELSE 'medium'::text END AS priority,
+        CASE
+            WHEN cd.brief_data->'hold'->>'ratified' = 'true' THEN 'held'::text
+            WHEN cd.status = 'pending'::text THEN 'pending'::text
+            WHEN cd.decision::text = 'proceed'::text THEN 'approved'::text
+            WHEN cd.decision::text = 'pause'::text THEN 'held'::text
+            WHEN cd.decision::text = ANY (ARRAY['kill'::character varying::text, 'reject'::character varying::text, 'cancel'::character varying::text]) THEN 'rejected'::text
+            WHEN cd.decision::text = 'pivot'::text THEN 'pivot'::text
+            WHEN cd.decision::text = 'fix'::text THEN 'fix'::text
+            WHEN cd.decision::text = 'override'::text THEN 'override'::text
+            ELSE 'decided'::text
+        END AS status,
+    cd.venture_id,
+    cd.lifecycle_stage AS stage,
+    NULL::text AS gate_type,
+    cd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    cd.created_at,
+    CASE WHEN cd.decided_by IS NOT NULL AND cd.status <> 'pending'::text THEN cd.updated_at ELSE NULL::timestamp with time zone END AS decided_at,
+    cd.decided_by_user_id AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('health_score', cd.health_score, 'override_reason', cd.override_reason, 'risks_acknowledged', cd.risks_acknowledged, 'quick_fixes_applied', cd.quick_fixes_applied, 'source_decision_type', cd.decision_type) AS details,
+    COALESCE(cd.blocking, false) AS blocking
+   FROM chairman_decisions cd
+     LEFT JOIN ventures v ON v.id = cd.venture_id
+UNION ALL
+ SELECT f.id,
+    'flag_review'::text AS decision_type,
+    f.title::text AS title,
+        CASE
+            WHEN f.severity::text = 'critical'::text THEN 'critical'::text
+            ELSE 'high'::text
+        END AS priority,
+    'pending'::text AS status,
+    f.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULLIF(f.metadata ->> 'recommendation'::text, ''::text) AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    f.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('id', f.id, 'category', f.category, 'severity', f.severity, 'body', "left"(COALESCE(f.description, ''::text), 280)) AS details,
+    f.severity::text = 'critical'::text AS blocking
+   FROM feedback f
+     LEFT JOIN ventures v ON v.id = f.venture_id
+  WHERE (f.severity::text = ANY (ARRAY['critical'::text, 'high'::text])) AND f.resolved_at IS NULL AND (COALESCE(f.status, 'new'::character varying)::text <> ALL (ARRAY['resolved'::text, 'wont_fix'::text]))
+UNION ALL
+ SELECT ff.id,
+    'flag_enablement'::text AS decision_type,
+    concat('Feature flag: ', ff.flag_key) AS title,
+    'normal'::text AS priority,
+    'pending'::text AS status,
+    NULL::uuid AS venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    'Review for enablement or kill'::text AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    ff.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    NULL::character varying(255) AS venture_name,
+    jsonb_build_object('flag_key', ff.flag_key, 'display_name', ff.display_name, 'description', ff.description, 'risk_tier', ff.risk_tier::text) AS details,
+    false AS blocking
+   FROM leo_feature_flags ff
+  WHERE ff.is_enabled = false AND ff.lifecycle_state::text = 'draft'::text AND ff.created_at < (now() - '7 days'::interval)
+UNION ALL
+ SELECT ogl.id,
+    'okr_acceptance'::text AS decision_type,
+    concat('Accept OKR generation — ', ogl.period, ' (', ogl.generation_date, ')') AS title,
+    'high'::text AS priority,
+    'pending'::text AS status,
+    NULL::uuid AS venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    'Review and accept or reject this OKR generation'::text AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    ogl.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    NULL::character varying(255) AS venture_name,
+    jsonb_build_object('generation_id', ogl.id, 'period', ogl.period, 'generation_date', ogl.generation_date, 'total_krs_generated', ogl.total_krs_generated) AS details,
+    false AS blocking
+   FROM okr_generation_log ogl
+  WHERE ogl.status = 'pending_chairman_acceptance'::text;
+
+COMMIT;
+
+-- ==================== ANCHOR-FINDING QUERIES (for the CONTROL file) ====================
+-- If the anchor row ids hardcoded in the CONTROL file no longer exist at ceremony time, re-run
+-- these against chairman_decisions (NOT the view) to pick fresh ones:
+--
+--   -- a ratified-hold row (expect view status='held' regardless of raw decision/status):
+--   SELECT id, decision, status, brief_data->'hold' AS hold
+--   FROM chairman_decisions WHERE brief_data->'hold'->>'ratified' = 'true' LIMIT 1;
+--
+--   -- a decided row with a real decider recorded (expect view decided_by = decided_by_user_id):
+--   SELECT id, decided_by_user_id, status, decision
+--   FROM chairman_decisions WHERE decided_by_user_id IS NOT NULL AND status <> 'pending' LIMIT 1;

--- a/database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql
+++ b/database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql
@@ -1,0 +1,42 @@
+-- CONTROL QUERY for 20260817_chairman_all_decision_signals_merged.sql (QF-20260816-456)
+--
+-- Run this ONE statement immediately after applying the merge. All three checks must read PASS.
+--
+-- Row count is NOT hardcoded (it was 1,047 when this file was written on 2026-08-16 and will have
+-- drifted by ceremony time) — instead capture the pre-apply count yourself right before running
+-- BEGIN on the merge migration:
+--   SELECT count(*) FROM public.chairman_all_decision_signals;   -- note this number as :pre_count
+-- then substitute it into the query below. The merge changes only computed columns (title,
+-- priority, status, decided_at, decided_by) on branches 3 and 4 — it does not add, remove, or
+-- re-filter any WHERE predicate on any branch — so the post-apply count must equal :pre_count
+-- exactly. Any difference means a branch's row set moved and the merge did NOT do what it claims.
+
+WITH checks AS (
+  SELECT
+    (SELECT count(*) FROM public.chairman_all_decision_signals) AS post_count,
+    :pre_count AS pre_count,
+    (SELECT status FROM public.chairman_all_decision_signals
+      WHERE id = '3aa84300-0f0b-4a91-bebe-a24768c94320') AS ratified_hold_status,
+    (SELECT title FROM public.chairman_all_decision_signals
+      WHERE id = '3aa84300-0f0b-4a91-bebe-a24768c94320') AS ratified_hold_title,
+    (SELECT decided_by FROM public.chairman_all_decision_signals
+      WHERE id = 'b7a7c05f-837c-444b-860b-8abd8197d938') AS decided_row_decided_by
+)
+SELECT
+  CASE WHEN post_count = pre_count THEN 'PASS' ELSE 'FAIL — row count drifted: ' || pre_count || ' -> ' || post_count END AS check_1_row_count_stable,
+  CASE WHEN ratified_hold_status = 'held' THEN 'PASS' ELSE 'FAIL — expected held, got ' || COALESCE(ratified_hold_status, 'NULL') END AS check_2_ratified_hold_renders_held,
+  CASE WHEN ratified_hold_title LIKE '%HELD until:%' THEN 'PASS' ELSE 'FAIL — title missing HELD-until suffix: ' || COALESCE(ratified_hold_title, 'NULL') END AS check_3_ratified_hold_title_explains_itself,
+  CASE WHEN decided_row_decided_by = '69c8aa7a-7661-48ed-9779-746fa6290873' THEN 'PASS' ELSE 'FAIL — expected 69c8aa7a-7661-48ed-9779-746fa6290873, got ' || COALESCE(decided_row_decided_by::text, 'NULL') END AS check_4_decided_row_shows_real_decider
+FROM checks;
+
+-- Anchor rows (both verified live on 2026-08-16, immediately before this file was written):
+--   3aa84300-0f0b-4a91-bebe-a24768c94320  chairman_decisions row with brief_data->'hold'->>'ratified'='true'
+--                                          (decision='pending', status='approved' on the raw row —
+--                                          deliberately inconsistent-looking; the ratified-hold check
+--                                          must win regardless of what decision/status literally say)
+--   b7a7c05f-837c-444b-860b-8abd8197d938  chairman_decisions row with decided_by_user_id=
+--                                          69c8aa7a-7661-48ed-9779-746fa6290873, status='approved'
+--
+-- If either anchor row's id no longer exists at ceremony time (e.g. deleted/archived between
+-- 2026-08-16 and apply), re-run the two anchor-finding queries from this migration's header
+-- comment ("ANCHOR:" queries) to pick fresh live rows before using this control query.

--- a/database/chairman-gated/20260817_chairman_all_decision_signals_merged_DOWN.sql
+++ b/database/chairman-gated/20260817_chairman_all_decision_signals_merged_DOWN.sql
@@ -1,0 +1,189 @@
+-- ROLLBACK for 20260817_chairman_all_decision_signals_merged.sql (QF-20260816-456)
+--
+-- Restores the pre-merge live definition VERBATIM, captured via
+-- pg_get_viewdef('public.chairman_all_decision_signals', true) over the pooler on 2026-08-16,
+-- immediately before the merge was authored (7,304 chars — matches both rivals' own captured
+-- starting point). This is the original 3-lies-plus-parked-as-rejected view: decision_type
+-- hardcoded, title hardcoded to "Stage N Chairman Approval", priority hardcoded to 'critical',
+-- decided_at/decided_by unconditional NULL/created_at, and no security_invoker clause.
+--
+-- NOTE: this DOWN file intentionally does NOT restate `WITH (security_invoker = on)` — the
+-- pre-merge live view had no explicit reloption in its own CREATE OR REPLACE history, yet
+-- pg_class.reloptions measured {security_invoker=on} live regardless (set by some prior,
+-- undocumented statement). If this rollback is ever run, immediately re-check
+-- `SELECT reloptions FROM pg_class WHERE oid = 'public.chairman_all_decision_signals'::regclass`
+-- and re-apply `ALTER VIEW public.chairman_all_decision_signals SET (security_invoker = on);`
+-- if it came back empty — do not assume CREATE OR REPLACE preserved it silently.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.chairman_all_decision_signals AS
+ SELECT am.id,
+    'escalation'::text AS decision_type,
+    am.subject AS title,
+    COALESCE(am.priority, 'normal'::character varying)::text AS priority,
+    'pending'::text AS status,
+    ar.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULL::text AS recommendation,
+    am.response_deadline,
+    am.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    ar.display_name AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('message_type', am.message_type, 'body', am.body, 'from_agent_id', am.from_agent_id) AS details,
+    false AS blocking
+   FROM agent_messages am
+     LEFT JOIN agent_registry ar ON ar.id = am.from_agent_id
+     LEFT JOIN ventures v ON v.id = ar.venture_id
+  WHERE am.message_type::text = 'escalation'::text AND am.status::text = 'pending'::text
+UNION ALL
+ SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+        CASE
+            WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+            WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+            ELSE 'normal'::text
+        END AS priority,
+    'pending'::text AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details,
+    vd.gate_type = 'hard_gate'::text AS blocking
+   FROM venture_decisions vd
+     LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NULL
+UNION ALL
+ SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+        CASE
+            WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+            WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+            ELSE 'normal'::text
+        END AS priority,
+        CASE
+            WHEN vd.decision = 'proceed'::text THEN 'approved'::text
+            WHEN vd.decision = ANY (ARRAY['kill'::text, 'pause'::text]) THEN 'rejected'::text
+            ELSE 'decided'::text
+        END AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    vd.decided_at,
+    vd.decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'decision', vd.decision, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details,
+    vd.gate_type = 'hard_gate'::text AS blocking
+   FROM venture_decisions vd
+     LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NOT NULL
+UNION ALL
+ SELECT cd.id,
+    'chairman_approval'::text AS decision_type,
+    concat('Stage ', cd.lifecycle_stage, ' Chairman Approval') AS title,
+    'critical'::text AS priority,
+        CASE
+            WHEN cd.status = 'pending'::text THEN 'pending'::text
+            WHEN cd.decision::text = 'proceed'::text THEN 'approved'::text
+            WHEN cd.decision::text = ANY (ARRAY['kill'::character varying::text, 'pause'::character varying::text]) THEN 'rejected'::text
+            WHEN cd.decision::text = 'pivot'::text THEN 'pivot'::text
+            WHEN cd.decision::text = 'fix'::text THEN 'fix'::text
+            WHEN cd.decision::text = 'override'::text THEN 'override'::text
+            ELSE 'decided'::text
+        END AS status,
+    cd.venture_id,
+    cd.lifecycle_stage AS stage,
+    NULL::text AS gate_type,
+    cd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    cd.created_at,
+    cd.created_at AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('health_score', cd.health_score, 'override_reason', cd.override_reason, 'risks_acknowledged', cd.risks_acknowledged, 'quick_fixes_applied', cd.quick_fixes_applied, 'source_decision_type', cd.decision_type) AS details,
+    COALESCE(cd.blocking, false) AS blocking
+   FROM chairman_decisions cd
+     LEFT JOIN ventures v ON v.id = cd.venture_id
+UNION ALL
+ SELECT f.id,
+    'flag_review'::text AS decision_type,
+    f.title::text AS title,
+        CASE
+            WHEN f.severity::text = 'critical'::text THEN 'critical'::text
+            ELSE 'high'::text
+        END AS priority,
+    'pending'::text AS status,
+    f.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULLIF(f.metadata ->> 'recommendation'::text, ''::text) AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    f.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('id', f.id, 'category', f.category, 'severity', f.severity, 'body', "left"(COALESCE(f.description, ''::text), 280)) AS details,
+    f.severity::text = 'critical'::text AS blocking
+   FROM feedback f
+     LEFT JOIN ventures v ON v.id = f.venture_id
+  WHERE (f.severity::text = ANY (ARRAY['critical'::text, 'high'::text])) AND f.resolved_at IS NULL AND (COALESCE(f.status, 'new'::character varying)::text <> ALL (ARRAY['resolved'::text, 'wont_fix'::text]))
+UNION ALL
+ SELECT ff.id,
+    'flag_enablement'::text AS decision_type,
+    concat('Feature flag: ', ff.flag_key) AS title,
+    'normal'::text AS priority,
+    'pending'::text AS status,
+    NULL::uuid AS venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    'Review for enablement or kill'::text AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    ff.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    NULL::character varying(255) AS venture_name,
+    jsonb_build_object('flag_key', ff.flag_key, 'display_name', ff.display_name, 'description', ff.description, 'risk_tier', ff.risk_tier::text) AS details,
+    false AS blocking
+   FROM leo_feature_flags ff
+  WHERE ff.is_enabled = false AND ff.lifecycle_state::text = 'draft'::text AND ff.created_at < (now() - '7 days'::interval)
+UNION ALL
+ SELECT ogl.id,
+    'okr_acceptance'::text AS decision_type,
+    concat('Accept OKR generation — ', ogl.period, ' (', ogl.generation_date, ')') AS title,
+    'high'::text AS priority,
+    'pending'::text AS status,
+    NULL::uuid AS venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    'Review and accept or reject this OKR generation'::text AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    ogl.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    NULL::character varying(255) AS venture_name,
+    jsonb_build_object('generation_id', ogl.id, 'period', ogl.period, 'generation_date', ogl.generation_date, 'total_krs_generated', ogl.total_krs_generated) AS details,
+    false AS blocking
+   FROM okr_generation_log ogl
+  WHERE ogl.status = 'pending_chairman_acceptance'::text;
+
+COMMIT;

--- a/tests/unit/chairman/merged-decision-signals-view.test.js
+++ b/tests/unit/chairman/merged-decision-signals-view.test.js
@@ -1,0 +1,173 @@
+// QF-20260816-456 — the merged chairman_all_decision_signals migration.
+//
+// WHAT THESE TESTS CAN AND CANNOT PROVE. Like its two superseded predecessors, this migration is
+// TIER-2 and is never applied by the builder, so no test here proves the merged view returns
+// correct rows from an assertion alone. That was verified separately, live, inside a rolled-back
+// transaction: row count 1047 -> 1047 (stable), a real ratified-hold row rendered status='held'
+// with a self-explaining title, a real decided row surfaced its actual decided_by instead of NULL,
+// and security_invoker=on survived. See the PR body for the full transcript.
+//
+// What these tests DO pin is that the merge actually carries BOTH predecessors' fixes forward —
+// which is the entire point of merging rather than picking one — so a future edit cannot silently
+// drop one side's contribution while leaving the other intact.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { routeDecision } from '../../../lib/chairman/decision-queue.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const MIGRATION = path.join(root, 'database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql');
+const DOWN = path.join(root, 'database/chairman-gated/20260817_chairman_all_decision_signals_merged_DOWN.sql');
+const CONTROL = path.join(root, 'database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql');
+const FILE_A = path.join(root, 'database/chairman-gated/20260803_chairman_queue_truthful_render.sql');
+const FILE_B = path.join(root, 'database/chairman-gated/20260803_chairman_source4_rework.sql');
+
+const sql = fs.readFileSync(MIGRATION, 'utf8');
+const statement = sql.slice(sql.indexOf('CREATE OR REPLACE VIEW public.chairman_all_decision_signals'), sql.indexOf('COMMIT;'));
+
+/** Branch 4 only (chairman_decisions) — the branch both rivals touched. */
+const branch4 = (() => {
+  const anchor = statement.indexOf('FROM chairman_decisions cd');
+  return statement.slice(statement.lastIndexOf('UNION ALL', anchor), statement.indexOf('UNION ALL', anchor + 1) === -1 ? statement.length : statement.indexOf('UNION ALL', statement.indexOf('flag_review')));
+})();
+
+/** Branch 3 only (venture_decisions, decision IS NOT NULL) — the second HELD-status site. */
+const branch3 = (() => {
+  const notNullIdx = statement.indexOf('WHERE vd.decision IS NOT NULL');
+  const start = statement.lastIndexOf('UNION ALL', notNullIdx);
+  return statement.slice(start, notNullIdx);
+})();
+
+describe('MERGE-1: File A survives — HELD rendering for parked decisions', () => {
+  it('branch 4 checks the ratified-hold marker for title, priority, and status', () => {
+    expect(branch4).toMatch(/cd\.brief_data->'hold'->>'ratified' = 'true'/);
+    expect((branch4.match(/cd\.brief_data->'hold'->>'ratified' = 'true'/g) || []).length).toBe(3);
+  });
+
+  it('branch 4 title explains a hold with the unpark trigger, not a bare label', () => {
+    expect(branch4).toMatch(/HELD until: /);
+    expect(branch4).toMatch(/unpark_trigger/);
+    expect(branch4).toMatch(/trigger NOT RECORDED/);
+  });
+
+  it('branch 4 status resolves held for both a ratified park and a bare decision=pause', () => {
+    expect(branch4).toMatch(/THEN 'held'::text/);
+    expect(branch4).toMatch(/WHEN cd\.decision::text = 'pause'::text THEN 'held'::text/);
+  });
+
+  it('branch 4 no longer buckets pause into the same rejected array as kill', () => {
+    expect(branch4).not.toMatch(/ARRAY\['kill'[^\]]*'pause'/);
+  });
+
+  it('branch 3 (venture_decisions) carries the identical pause -> held fix', () => {
+    expect(branch3).toMatch(/WHEN vd\.decision = 'pause'::text THEN 'held'::text/);
+    expect(branch3).not.toMatch(/ARRAY\['kill'[^\]]*'pause'/);
+  });
+});
+
+describe('MERGE-2: File B survives — honest decided_at/decided_by and blocking-based priority', () => {
+  it('decided_at is conditional, not aliased from created_at', () => {
+    expect(branch4).not.toMatch(/cd\.created_at AS decided_at/);
+    expect(branch4).toMatch(/cd\.decided_by IS NOT NULL/);
+    expect(branch4).toMatch(/cd\.status <> 'pending'::text/);
+  });
+
+  it('projects the uuid decider column, not the legacy text actor column', () => {
+    expect(branch4).toMatch(/cd\.decided_by_user_id AS decided_by/);
+    expect(branch4).not.toMatch(/^\s+cd\.decided_by,\s*$/m);
+  });
+
+  it('priority is blocking-based, not an unconditional critical literal', () => {
+    expect(branch4).toMatch(/COALESCE\(cd\.blocking, false\) THEN 'critical'::text/);
+    expect(branch4).not.toMatch(/^\s+'critical'::text AS priority,\s*$/m);
+  });
+});
+
+describe('MERGE-3: the merge adds one thing neither predecessor had alone', () => {
+  it('a ratified hold softens priority even when blocking=true (or B\'s priority fix regresses)', () => {
+    // Without this override, a parked-but-blocking row would render 'critical' forever — the exact
+    // "already-decided row reads critical" defect class File B's own header measured (114 rows).
+    const priorityBlock = branch4.slice(branch4.indexOf('AS priority') - 400, branch4.indexOf('AS priority'));
+    expect(priorityBlock).toMatch(/ratified'\s*=\s*'true'\s*THEN\s*'normal'::text/s);
+  });
+});
+
+describe('MERGE-4: THE GUARD — decision_type stays the routing key', () => {
+  it('branch 4 still projects chairman_approval as decision_type', () => {
+    expect(branch4).toMatch(/'chairman_approval'::text AS decision_type/);
+  });
+
+  it('the real subtype reaches the title, not the routing column', () => {
+    expect(branch4).toMatch(/cd\.decision_type/);
+    expect(branch4).toMatch(/cd\.summary/);
+  });
+
+  it('routeDecision resolves chairman_approval but cannot route a raw subtype', async () => {
+    const writers = { chairmanDecide: async () => ({ ok: true }) };
+    const routed = await routeDecision(
+      { decisionType: 'chairman_approval', id: 'abc', decision: 'approve', rationale: 'r' }, writers);
+    expect(routed.writer).toBe('chairmanDecide');
+    expect(routed.error).toBeUndefined();
+
+    const broken = await routeDecision({ decisionType: 'portfolio_review', id: 'abc', decision: 'approve' }, writers);
+    expect(broken.error).toMatch(/unknown decision_type/);
+    expect(broken.writer).toBeUndefined();
+  });
+});
+
+describe('MERGE-5: no collateral damage', () => {
+  it('keeps all seven source branches', () => {
+    expect((statement.match(/UNION ALL/g) || []).length).toBe(6); // 6 joins => 7 branches
+  });
+
+  it('states security_invoker explicitly in the migration', () => {
+    expect(statement).toMatch(/WITH \(security_invoker = on\) AS/);
+  });
+
+  it('targets chairman_all_decision_signals, not the wrapper', () => {
+    expect(statement).toMatch(/CREATE OR REPLACE VIEW public\.chairman_all_decision_signals/);
+    expect(statement).not.toMatch(/CREATE OR REPLACE VIEW public\.chairman_unified_decisions/);
+  });
+});
+
+describe('MERGE-6: staging discipline', () => {
+  it('lives outside every auto-scanned migration directory', () => {
+    expect(MIGRATION).toContain('chairman-gated');
+    for (const scanned of ['database/migrations', 'database/manual-updates', 'supabase/migrations']) {
+      expect(fs.existsSync(path.join(root, scanned, path.basename(MIGRATION)))).toBe(false);
+    }
+  });
+
+  it('carries no approved-by attestation', () => {
+    expect(sql).not.toMatch(/^-- @approved-by:/m);
+  });
+
+  it('ships a DOWN file with the exact pre-merge definition (all three original defects present)', () => {
+    const down = fs.readFileSync(DOWN, 'utf8');
+    expect(down).toMatch(/cd\.created_at AS decided_at/);
+    expect(down).toMatch(/'critical'::text AS priority/);
+    expect(down).toMatch(/concat\('Stage ', cd\.lifecycle_stage, ' Chairman Approval'\)/);
+    expect((down.match(/UNION ALL/g) || []).length).toBe(6);
+  });
+
+  it('ships a CONTROL file with all four checks and no hardcoded row-count literal', () => {
+    const control = fs.readFileSync(CONTROL, 'utf8');
+    expect(control).toMatch(/check_1_row_count_stable/);
+    expect(control).toMatch(/check_2_ratified_hold_renders_held/);
+    expect(control).toMatch(/check_3_ratified_hold_title_explains_itself/);
+    expect(control).toMatch(/check_4_decided_row_shows_real_decider/);
+    // pre_count is a bind parameter, not a literal — a hardcoded number would go stale by ceremony time.
+    expect(control).toMatch(/:pre_count/);
+  });
+});
+
+describe('MERGE-7: both rivals point at their successor', () => {
+  it('File A is marked superseded-by this migration', () => {
+    expect(fs.readFileSync(FILE_A, 'utf8')).toMatch(/SUPERSEDED-BY: database\/chairman-gated\/20260817_chairman_all_decision_signals_merged\.sql/);
+  });
+
+  it('File B is marked superseded-by this migration', () => {
+    expect(fs.readFileSync(FILE_B, 'utf8')).toMatch(/SUPERSEDED-BY: database\/chairman-gated\/20260817_chairman_all_decision_signals_merged\.sql/);
+  });
+});


### PR DESCRIPTION
## Summary

Pre-ceremony merge of two rival chairman-gated `database/chairman-gated/` staged migrations that both target `public.chairman_all_decision_signals`, requested via URGENT coordinator directive ahead of the 2026-08-17 chairman ceremony.

- **File A** (`20260803_chairman_queue_truthful_render.sql`): adds HELD-status rendering for parked decisions (title suffix, `status='held'`, softened priority) via `brief_data->'hold'->>'ratified'`.
- **File B** (`20260803_chairman_source4_rework.sql`): adds real `decided_at`/`decided_by`, blocking-based priority, and explicit `WITH (security_invoker = on)`.

These fix **almost entirely non-overlapping defects in the same UNION branch** (`chairman_decisions`). Neither alone was sufficient — shipping either would leave the other's defect live in production. This PR produces one merged file combining both.

## What was verified before merging (not assumed)

- Live `pg_get_viewdef('public.chairman_all_decision_signals', true)` read via pooler: **7,304 chars**, matching both rivals' own captured-live starting point — confirms **neither has been applied yet**.
- `decision_type` stays hardcoded `'chairman_approval'` (File B's choice) — re-verified live against all 4 cited consumer call sites (`decision-queue.mjs:186`, `chairman-actionable.mjs:24`, `decision-layman.mjs:26`, `decision-layman.mjs:113`). Still real, still load-bearing.
- `brief_data->'hold'->>'ratified'` / `unpark_trigger` (File A's mechanism) — confirmed real and live-written by `scripts/apply-chairman-decision-captures.mjs:146,157`, not a File-A invention.
- `security_invoker=on` — confirmed this is **already the live reloption today** (not a new change). Confirmed the chairman dashboard's actual reader path (`ehg/src/components/chairman-v3/decisions/DecisionActions.tsx`, browser-side, `authenticated` role per `docs/governance/chairman-decision-surfaces.md`) has permissive `SELECT` grant + RLS policy on **every** underlying table (`agent_messages`, `agent_registry`, `chairman_decisions`, `feedback`, `leo_feature_flags`, `okr_generation_log`, `venture_decisions`, `ventures`) — a non-service reader does not lose access.
- All referenced columns (`decided_by_user_id`, `summary`, `updated_at`) confirmed to exist on `chairman_decisions` via `information_schema`.
- **Dry-run in a rolled-back transaction** (`BEGIN` → apply → assert → `ROLLBACK`, production never touched): row count stable **1047 → 1047**; a real ratified-hold row (`3aa84300-...`) renders `status='held'` with title `"portfolio_review: Portfolio review 2026-07-17 — board proposes FIX — HELD until: Sessions+Roadmap live in EHG, or explicit chairman direction"`; a real decided row (`b7a7c05f-...`) surfaces its actual `decided_by` instead of `NULL`. All 4 control checks **PASS**.

## Files

- `database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql` — the merge, `@approved-by` left unfilled (chairman fills at apply, per TIER-2 convention).
- `database/chairman-gated/20260817_chairman_all_decision_signals_merged_DOWN.sql` — exact pre-merge live definition, for rollback.
- `database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql` — one-statement post-apply verification (4 checks), run this immediately after applying.
- Both source files marked `SUPERSEDED-BY` in their headers (not deleted — kept for provenance).

## Test plan

- [x] Merged SQL is syntactically valid (dry-run applied successfully in a transaction)
- [x] Row-count stability verified live (1047 → 1047, rolled back)
- [x] Ratified-hold anchor row renders `status='held'` with self-explaining title (verified live, rolled back)
- [x] Decided anchor row surfaces real `decided_by` (verified live, rolled back)
- [x] `security_invoker=on` reloption preserved (verified live, rolled back)
- [ ] Chairman applies at ceremony (2026-08-17), fills `@approved-by`, runs the CONTROL query post-apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)