### PR TITLE
fix(QF-20260816-304): stage DOWN migration + acceptance script for venture-feedback ownership RPC

### DIFF
--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc_DOWN.sql
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc_DOWN.sql
@@ -1,0 +1,38 @@
+-- DOWN migration for database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+-- QF-20260816-304: extracts that file's own inline commented ROLLBACK block (lines 165-179) into
+-- an executable, staged file, so a real rollback does not depend on someone hand-pasting a comment.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, NOT APPLIED. CHAIRMAN-GATED. DO NOT RUN THIS FILE except to reverse a completed apply of
+-- the paired UP migration above.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- Additive except for the one DROP FUNCTION, safe to reverse in one pass. Re-creates
+-- venture_user_insert_feedback with the EXACT WITH CHECK clause it had before the UP migration
+-- dropped it (byte-identical to the policy definition in database/migrations/
+-- 20260401_venture_user_feedback_channel.sql, as re-asserted by the UP file's own header). Wrapped
+-- in its own transaction with a trailing PostgREST reload, matching the UP file's apply block, so a
+-- rollback leaves the schema cache consistent with pg_catalog immediately rather than until
+-- PostgREST's own next reload cycle (SEC-L2 convention).
+
+BEGIN;
+
+-- Same bounded-wait rationale as the UP file's SEC-L1 guard: CREATE POLICY takes ACCESS EXCLUSIVE
+-- on public.feedback, same as the DROP POLICY it is reversing.
+SET LOCAL lock_timeout = '5s';
+
+REVOKE EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT) FROM anon, service_role;
+DROP FUNCTION IF EXISTS public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT);
+GRANT EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) TO anon;
+GRANT EXECUTE ON FUNCTION public.check_feedback_rate_limit(uuid) TO anon, authenticated;
+CREATE POLICY venture_user_insert_feedback ON public.feedback
+  FOR INSERT TO anon
+  WITH CHECK (
+    feedback_type LIKE 'user_%'
+    AND venture_id IS NOT NULL
+    AND venture_exists_and_active(venture_id)
+    AND (NOT check_feedback_rate_limit(venture_id))
+  );
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc_acceptance.mjs
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc_acceptance.mjs
@@ -1,0 +1,153 @@
+// Behavioural acceptance for database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+// (SD-LEO-FIX-CLOSE-ANON-VENTURE-001). Modeled directly on the sibling
+// 20260812_venture_ingest_key_binding_acceptance.mjs — same baseline/verify discipline, same
+// service-role-readback verification, same anon-key .rpc()/.from() surface real callers use.
+//
+// ── RUN IT TWICE. THE BASELINE IS NOT OPTIONAL. ───────────────────────────────────────────────
+//   node <this file> --baseline    BEFORE the apply. fn_submit_venture_user_feedback must be
+//                                  unreachable (PGRST202); the OLD venture_user_insert_feedback
+//                                  policy must still admit a raw anon user_% INSERT — proof the
+//                                  vulnerability this migration closes is genuinely present.
+//   node <this file> --verify      AFTER  the apply. Every test below must PASS.
+//
+// A post-apply green proves nothing on its own unless the baseline first proved the probe CAN
+// fail (RPC) / succeed (raw insert). Every write is verified by SERVICE-ROLE READBACK, never by
+// trusting the RPC's own reported {ok:true} alone, and cleaned up in a finally block.
+//
+// ── BLAST RADIUS ──────────────────────────────────────────────────────────────────────────────
+// Mints and then deletes a venture_ingest_keys row for one real, dynamically-chosen venture
+// (first active venture returned) — same caveat as the sibling script: do not run --verify
+// against a venture whose secret a live caller already depends on.
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const MODE = process.argv.includes('--baseline') ? 'baseline'
+           : process.argv.includes('--verify') ? 'verify'
+           : null;
+if (!MODE) {
+  console.error('Usage: node <this file> --baseline | --verify   (see the header: the baseline is not optional)');
+  process.exit(2);
+}
+
+const URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = createClient(URL, process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+const svc = createClient(URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const results = [];
+const record = (name, pass, detail) => { results.push({ name, pass, detail }); console.log(`  [${pass ? 'PASS' : 'FAIL'}] ${name}${detail ? ' — ' + detail : ''}`); };
+
+const TAG = `qf-304-${Date.now()}`;
+const createdFeedbackIds = [];
+let venture = null, secret = null;
+
+async function readback(id) {
+  const { data, error } = await svc.from('feedback').select('*').eq('id', id).maybeSingle();
+  if (error) throw new Error(`readback failed: ${error.message}`);
+  return data;
+}
+
+// RCA-304: a `.insert(...).select()` anon call adds `Prefer: return=representation`, which makes
+// Postgres ALSO require a SELECT policy to return the row -- anon has none for source_type=
+// 'user_feedback' (only telegram_bot_select_feedback, scoped to source_type='telegram'), so THAT
+// call fails with the identical generic 42501 regardless of whether the INSERT policy under test
+// admitted the row. A false green by construction: it would pass identically before and after this
+// migration. Fixed per the repo's established idiom (20260803_bound_anon_ingress_source_type_
+// qualifier_acceptance.mjs's probe()): insert BARE (no .select()), decide landed-vs-refused by an
+// INDEPENDENT SERVICE-ROLE readback keyed on a distinctive title tag, never by the anon call's own
+// response.
+async function rawInsertProbe(name) {
+  const title = `${TAG} ${name}`;
+  await anon.from('feedback').insert({
+    venture_id: venture.id, feedback_type: 'user_bug', type: 'issue',
+    source_type: 'user_feedback', source_application: 'qf-304-probe', title,
+  });
+  const { data, error } = await svc.from('feedback').select('id').eq('title', title);
+  if (error) throw new Error(`raw-insert-probe readback failed: ${error.message}`);
+  if (data?.[0]?.id) createdFeedbackIds.push(data[0].id);
+  return { landed: (data?.length || 0) > 0 };
+}
+
+async function setup() {
+  const { data: ventures, error } = await svc.from('ventures').select('id, name').is('deleted_at', null).limit(1);
+  if (error || !ventures || ventures.length < 1) throw new Error('need at least 1 live venture to run this acceptance script');
+  [venture] = ventures;
+  console.log(`using venture: ${venture.id} (${venture.name})`);
+
+  if (MODE === 'verify') {
+    const { data, error: provErr } = await svc.rpc('fn_provision_venture_ingest_key', { p_venture_id: venture.id });
+    if (provErr) throw new Error(`provisioning failed in verify mode — the migration may not actually be applied: ${provErr.message}`);
+    secret = data;
+    console.log(`provisioned secret for venture (length ${secret?.length})`);
+  }
+}
+
+async function teardown() {
+  if (createdFeedbackIds.length) {
+    const { error } = await svc.from('feedback').delete().in('id', createdFeedbackIds);
+    if (error) console.error(`CLEANUP WARNING: failed to delete probe feedback rows: ${error.message}`);
+  }
+  if (secret !== null && venture) {
+    const { error } = await svc.from('venture_ingest_keys').delete().eq('venture_id', venture.id);
+    if (error) console.error(`CLEANUP WARNING: failed to delete provisioned test secret: ${error.message}`);
+    else console.log('cleaned up: provisioned test secret deleted');
+  }
+}
+
+async function runBaseline() {
+  console.log('\n--- BASELINE: the fix is absent; the vulnerability it closes is present ---');
+  const { error: rpcErr } = await anon.rpc('fn_submit_venture_user_feedback', {
+    p_venture_id: venture.id, p_ingest_secret: 'x', p_feedback_type: 'user_bug',
+    p_title: 'baseline probe', p_description: 'baseline probe',
+  });
+  record('fn_submit_venture_user_feedback is unreachable pre-apply', !!rpcErr && /could not find|PGRST202|does not exist/i.test(rpcErr.message || ''), rpcErr?.message);
+
+  const { landed } = await rawInsertProbe('baseline-raw-insert');
+  record('pre-apply: raw anon INSERT of a user_% row still succeeds (the open vulnerability)', landed, `landed=${landed}`);
+}
+
+async function runVerify() {
+  console.log('\n--- VERIFY: post-apply behavioural contract ---');
+
+  // (a) bound key -> success, row readback carries the RPC's own tag (source_type='user_feedback').
+  const { data: okResult, error: okErr } = await anon.rpc('fn_submit_venture_user_feedback', {
+    p_venture_id: venture.id, p_ingest_secret: secret, p_feedback_type: 'user_bug',
+    p_title: 'acceptance probe — safe to delete', p_description: 'acceptance probe',
+  });
+  record('(a) bound key: valid submission succeeds', !okErr && okResult?.ok === true, okErr?.message);
+  if (okResult?.id) {
+    createdFeedbackIds.push(okResult.id);
+    const row = await readback(okResult.id);
+    record('(a) row readback carries the RPC tag (source_type=user_feedback) and server-derived status', row?.source_type === 'user_feedback' && row?.status === 'new', JSON.stringify({ source_type: row?.source_type, status: row?.status }));
+  } else {
+    record('(a) row readback', false, 'no row id returned — cannot verify');
+  }
+
+  // (b) unbound/wrong key -> rejected, no row.
+  const { data: badResult, error: badErr } = await anon.rpc('fn_submit_venture_user_feedback', {
+    p_venture_id: venture.id, p_ingest_secret: 'not-the-real-secret', p_feedback_type: 'user_bug',
+    p_title: 'should be rejected', p_description: 'should be rejected',
+  });
+  record('(b) unbound key: rejected', !!badErr && (badErr.code === '28000' || /unauthorized/i.test(badErr.message || '')), badErr?.message);
+  record('(b) unbound key: no row created', !badResult?.id, badResult?.id);
+
+  // (c) direct anon INSERT bypassing the RPC -> refused now that venture_user_insert_feedback is dropped.
+  const { landed } = await rawInsertProbe('verify-raw-insert');
+  record('(c) direct anon INSERT of a user_% row is refused (no longer lands)', !landed, `landed=${landed}`);
+}
+
+(async () => {
+  try {
+    await setup();
+    if (MODE === 'baseline') await runBaseline();
+    else await runVerify();
+  } catch (e) {
+    console.error('ACCEPTANCE SCRIPT ERROR:', e.message);
+    process.exitCode = 1;
+  } finally {
+    await teardown();
+  }
+  const failed = results.filter((r) => !r.pass);
+  console.log(`\n=== ${MODE.toUpperCase()} RESULT: ${failed.length === 0 ? 'PASS' : `FAIL (${failed.length}/${results.length})`} ===`);
+  if (failed.length) process.exitCode = 1;
+})();


### PR DESCRIPTION
## Summary
- Extracts the inline commented ROLLBACK block (lines 165-179) of `database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql` into an executable, staged `_DOWN.sql`.
- Adds a companion `_acceptance.mjs`, modeled on `20260812_venture_ingest_key_binding_acceptance.mjs`'s baseline/verify discipline: (a) bound key succeeds + row readback carries the RPC tag, (b) unbound/wrong key rejected with no row, (c) a raw anon INSERT of a `user_%` row bypassing the RPC is refused post-apply.
- Both files are staged only — no migration is applied by this PR.

## Note on the acceptance script
Running `--baseline` live turned up a real bug in my first draft: `.insert(...).select('id')` adds `Prefer: return=representation`, which additionally requires a SELECT policy anon doesn't have for `source_type='user_feedback'` — producing the same generic 42501 regardless of whether the INSERT policy under test admitted the row (a false-green-by-construction). Fixed using the repo's established dual-form + service-role-readback idiom from `20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs`. Re-ran `--baseline` after the fix: both checks correctly PASS (new RPC unreachable pre-apply; the raw-insert vulnerability genuinely lands pre-apply), with the probe row cleaned up.

## Test plan
- [x] `node --check` on the new `.mjs` (syntax)
- [x] Ran `--baseline` live against the current (pre-apply) DB state — both checks pass, confirming the vulnerability this migration will close is genuinely open today, and that the acceptance script's own instrument is sound
- [x] Confirmed no stray probe rows left in `feedback`
- [x] `schema-reference-lint` clean
- [ ] `--verify` mode will be run by whoever executes the actual apply ceremony (2026-08-17)