### PR TITLE
fix(QF-20260816-988): chairman_all_decision_signals — stop rendering decided-by-nobody

### DIFF
--- a/database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
+++ b/database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
@@ -99,6 +99,29 @@
 -- venture_decisions, ventures). A non-service reader does not lose access under invoker semantics —
 -- confirmed, not assumed.
 --
+-- ==================== QF-20260816-988 — decided_at/decided_by column mismatch ====================
+-- Coordinator AC (bug_016, A3 ultrareview via Adam, 2026-08-16): the gate above checks
+-- cd.decided_by (text), while the decided_by OUTPUT column projects cd.decided_by_user_id (uuid) —
+-- a DIFFERENT column. Result: a row decided by a system/agent actor (adam, testing_agent,
+-- monitoring_agent — measured 180 of 249 gate-passing rows) OR by the chairman via a free-text
+-- label rather than a linked uuid (measured ~69 of 249: chairman, chairman-cli,
+-- codestreetlabs@gmail.com, etc.) gets a real decided_at timestamp while decided_by silently reads
+-- NULL — "decided at X by nobody".
+--
+-- REJECTED FIX: gate AND project the SAME column (decided_by_user_id for both). Measured live:
+-- only 14 of 249 gate-passing rows have decided_by_user_id set. This would suppress decided_at for
+-- 235 rows outright, including ~69 that a real human chairman genuinely decided — a much larger
+-- regression than the defect it fixes.
+--
+-- APPLIED FIX (the directive's own sanctioned alternative — "surface decided_by text as a label
+-- alongside"): decided_at's gate and decided_by's projection are UNCHANGED from the original merge
+-- (still broad, still honest about which 249 rows have SOME recorded decider); details now also
+-- carries decided_by_label := cd.decided_by (the raw text), so a row with decided_by NULL is no
+-- longer silently unexplained — a consumer reading details.decided_by_label sees "adam" /
+-- "chairman-cli" / etc. even when no linkable uuid exists. Column type stays uuid|NULL on the
+-- union-typed output (text cannot be projected there without breaking the UNION — confirmed by the
+-- superseded File B's own test comment: "UNION types uuid and text cannot be matched").
+--
 -- ROLLBACK: database/chairman-gated/20260817_chairman_all_decision_signals_merged_DOWN.sql
 -- CONTROL QUERY (run immediately after apply): database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql
 -- ============================================================================
@@ -214,7 +237,7 @@ UNION ALL
     cd.decided_by_user_id AS decided_by,
     NULL::text AS requestor_name,
     v.name AS venture_name,
-    jsonb_build_object('health_score', cd.health_score, 'override_reason', cd.override_reason, 'risks_acknowledged', cd.risks_acknowledged, 'quick_fixes_applied', cd.quick_fixes_applied, 'source_decision_type', cd.decision_type) AS details,
+    jsonb_build_object('health_score', cd.health_score, 'override_reason', cd.override_reason, 'risks_acknowledged', cd.risks_acknowledged, 'quick_fixes_applied', cd.quick_fixes_applied, 'source_decision_type', cd.decision_type, 'decided_by_label', cd.decided_by) AS details,
     COALESCE(cd.blocking, false) AS blocking
    FROM chairman_decisions cd
      LEFT JOIN ventures v ON v.id = cd.venture_id

--- a/database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql
+++ b/database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql
@@ -1,6 +1,6 @@
--- CONTROL QUERY for 20260817_chairman_all_decision_signals_merged.sql (QF-20260816-456)
+-- CONTROL QUERY for 20260817_chairman_all_decision_signals_merged.sql (QF-20260816-456, QF-20260816-988)
 --
--- Run this ONE statement immediately after applying the merge. All three checks must read PASS.
+-- Run this ONE statement immediately after applying the merge. All five checks must read PASS.
 --
 -- Row count is NOT hardcoded (it was 1,047 when this file was written on 2026-08-16 and will have
 -- drifted by ceremony time) — instead capture the pre-apply count yourself right before running
@@ -20,23 +20,41 @@ WITH checks AS (
     (SELECT title FROM public.chairman_all_decision_signals
       WHERE id = '3aa84300-0f0b-4a91-bebe-a24768c94320') AS ratified_hold_title,
     (SELECT decided_by FROM public.chairman_all_decision_signals
-      WHERE id = 'b7a7c05f-837c-444b-860b-8abd8197d938') AS decided_row_decided_by
+      WHERE id = 'b7a7c05f-837c-444b-860b-8abd8197d938') AS decided_row_decided_by,
+    (SELECT decided_at FROM public.chairman_all_decision_signals
+      WHERE id = 'fab64495-a580-4b8f-8cef-2aae275c8bc6') AS system_write_decided_at,
+    (SELECT decided_by FROM public.chairman_all_decision_signals
+      WHERE id = 'fab64495-a580-4b8f-8cef-2aae275c8bc6') AS system_write_decided_by,
+    (SELECT details->>'decided_by_label' FROM public.chairman_all_decision_signals
+      WHERE id = 'fab64495-a580-4b8f-8cef-2aae275c8bc6') AS system_write_decided_by_label
 )
 SELECT
   CASE WHEN post_count = pre_count THEN 'PASS' ELSE 'FAIL — row count drifted: ' || pre_count || ' -> ' || post_count END AS check_1_row_count_stable,
   CASE WHEN ratified_hold_status = 'held' THEN 'PASS' ELSE 'FAIL — expected held, got ' || COALESCE(ratified_hold_status, 'NULL') END AS check_2_ratified_hold_renders_held,
   CASE WHEN ratified_hold_title LIKE '%HELD until:%' THEN 'PASS' ELSE 'FAIL — title missing HELD-until suffix: ' || COALESCE(ratified_hold_title, 'NULL') END AS check_3_ratified_hold_title_explains_itself,
-  CASE WHEN decided_row_decided_by = '69c8aa7a-7661-48ed-9779-746fa6290873' THEN 'PASS' ELSE 'FAIL — expected 69c8aa7a-7661-48ed-9779-746fa6290873, got ' || COALESCE(decided_row_decided_by::text, 'NULL') END AS check_4_decided_row_shows_real_decider
+  CASE WHEN decided_row_decided_by = '69c8aa7a-7661-48ed-9779-746fa6290873' THEN 'PASS' ELSE 'FAIL — expected 69c8aa7a-7661-48ed-9779-746fa6290873, got ' || COALESCE(decided_row_decided_by::text, 'NULL') END AS check_4_decided_row_shows_real_decider,
+  -- QF-20260816-988: a row decided by a system/free-text actor (no linked uuid) must NOT read as
+  -- "decided at X by nobody" — decided_at populates, decided_by (uuid) is honestly NULL, but
+  -- details.decided_by_label carries the real actor name so the identity is not silently dropped.
+  CASE WHEN system_write_decided_at IS NOT NULL AND system_write_decided_by IS NULL AND system_write_decided_by_label = 'chairman-cli'
+       THEN 'PASS'
+       ELSE 'FAIL — expected decided_at set + decided_by NULL + decided_by_label=chairman-cli, got decided_at=' || COALESCE(system_write_decided_at::text, 'NULL') || ' decided_by=' || COALESCE(system_write_decided_by::text, 'NULL') || ' decided_by_label=' || COALESCE(system_write_decided_by_label, 'NULL')
+  END AS check_5_system_write_not_decided_by_nobody
 FROM checks;
 
--- Anchor rows (both verified live on 2026-08-16, immediately before this file was written):
+-- Anchor rows (all verified live on 2026-08-16, immediately before this file was written):
 --   3aa84300-0f0b-4a91-bebe-a24768c94320  chairman_decisions row with brief_data->'hold'->>'ratified'='true'
 --                                          (decision='pending', status='approved' on the raw row —
 --                                          deliberately inconsistent-looking; the ratified-hold check
 --                                          must win regardless of what decision/status literally say)
 --   b7a7c05f-837c-444b-860b-8abd8197d938  chairman_decisions row with decided_by_user_id=
 --                                          69c8aa7a-7661-48ed-9779-746fa6290873, status='approved'
+--   fab64495-a580-4b8f-8cef-2aae275c8bc6  chairman_decisions row with decided_by='chairman-cli' (text),
+--                                          decided_by_user_id=NULL, status='rejected' — the QF-988
+--                                          "decided by nobody" case
 --
--- If either anchor row's id no longer exists at ceremony time (e.g. deleted/archived between
--- 2026-08-16 and apply), re-run the two anchor-finding queries from this migration's header
--- comment ("ANCHOR:" queries) to pick fresh live rows before using this control query.
+-- If any anchor row's id no longer exists at ceremony time (e.g. deleted/archived between
+-- 2026-08-16 and apply), re-run the anchor-finding queries from this migration's header comment
+-- ("ANCHOR:" queries) to pick fresh live rows before using this control query. For a fresh
+-- check_5 anchor: SELECT id, decided_by, decided_by_user_id, status FROM chairman_decisions
+-- WHERE decided_by IS NOT NULL AND status <> 'pending' AND decided_by_user_id IS NULL LIMIT 1;

--- a/tests/unit/chairman/merged-decision-signals-view.test.js
+++ b/tests/unit/chairman/merged-decision-signals-view.test.js
@@ -66,6 +66,22 @@ describe('MERGE-1: File A survives — HELD rendering for parked decisions', () 
   });
 });
 
+describe('QF-988: decided_at and decided_by no longer reference different columns silently', () => {
+  it('the gate (decided_at) and the projection (decided_by) still read from different raw columns', () => {
+    // This is not a bug in itself -- decided_by (text) and decided_by_user_id (uuid) really are
+    // different columns with different coverage (249 vs 14 rows). The defect was that a row could
+    // pass the gate and render a real decided_at while decided_by silently read NULL with no
+    // explanation anywhere. The fix is not "make them the same column" (that would suppress
+    // decided_at for 235 of 249 rows) -- it's "never let decided_by read NULL without a label".
+    expect(branch4).toMatch(/CASE WHEN cd\.decided_by IS NOT NULL AND cd\.status <> 'pending'::text THEN cd\.updated_at/);
+    expect(branch4).toMatch(/cd\.decided_by_user_id AS decided_by/);
+  });
+
+  it('details carries the raw text actor as decided_by_label, so a NULL decided_by is never unexplained', () => {
+    expect(branch4).toMatch(/'decided_by_label', cd\.decided_by/);
+  });
+});
+
 describe('MERGE-2: File B survives — honest decided_at/decided_by and blocking-based priority', () => {
   it('decided_at is conditional, not aliased from created_at', () => {
     expect(branch4).not.toMatch(/cd\.created_at AS decided_at/);
@@ -157,6 +173,7 @@ describe('MERGE-6: staging discipline', () => {
     expect(control).toMatch(/check_2_ratified_hold_renders_held/);
     expect(control).toMatch(/check_3_ratified_hold_title_explains_itself/);
     expect(control).toMatch(/check_4_decided_row_shows_real_decider/);
+    expect(control).toMatch(/check_5_system_write_not_decided_by_nobody/);
     // pre_count is a bind parameter, not a literal — a hardcoded number would go stale by ceremony time.
     expect(control).toMatch(/:pre_count/);
   });


### PR DESCRIPTION
## Summary

Coordinator AC (bug_016, A3 ultrareview via Adam) against the just-merged QF-20260816-456 view (#7098), caught before the 2026-08-17 ceremony since the migration is still staged.

`decided_at` gates on `cd.decided_by` (text, 249 gate-passing rows) but `decided_by` projects `cd.decided_by_user_id` (uuid, only 14 rows set) — a different column. A row decided by a system actor (`adam`/`testing_agent`/`monitoring_agent`, ~180 rows) or by the chairman via a free-text label instead of a linked uuid (~69 rows: `chairman`, `chairman-cli`, `codestreetlabs@gmail.com`, etc.) got a real `decided_at` timestamp while `decided_by` silently read `NULL` — "decided at X by nobody".

## Fix considered and rejected

Gate AND project the **same** column (`decided_by_user_id` for both) — the AC's first suggested resolution. Measured live: only 14 of 249 gate-passing rows have `decided_by_user_id` set, so this would suppress `decided_at` entirely for 235 rows, including ~69 that a real human chairman genuinely decided (just recorded via a text label, not a linked uuid). That's a bigger regression than the bug it fixes.

## Fix applied

The AC's own sanctioned alternative: keep the gate/projection as merged (unchanged — still honest about which 249 rows have *some* recorded decider), and add `details.decided_by_label := cd.decided_by` so the raw actor name survives even when no linkable uuid exists. A consumer reading `details.decided_by_label` now sees `"adam"` / `"chairman-cli"` / etc. instead of nothing.

## Verified live (rolled-back transaction, production untouched)

Anchor row `fab64495-a580-4b8f-8cef-2aae275c8bc6` (`decided_by='chairman-cli'`, `decided_by_user_id=NULL`, `status='rejected'`):
- `decided_at`: populates (was already correct)
- `decided_by`: stays honestly `NULL` (unchanged, correct)
- `decided_by_label`: now reads `'chairman-cli'` (the fix)

Row-count stability re-confirmed (1048 → 1048), the two pre-existing anchor checks (ratified-hold → `held`, decided-row → real `decided_by`) still pass.

## Files

- `database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql` — adds `decided_by_label` to branch 4's `details` jsonb, documents the rejected-vs-applied fix in the header.
- `database/chairman-gated/20260817_chairman_all_decision_signals_merged_CONTROL.sql` — adds check_5 asserting the fix against a live anchor row.
- `tests/unit/chairman/merged-decision-signals-view.test.js` — 2 new tests pinning the label mechanism; all 23 tests in the file pass, full chairman suite (524 tests) green.

## Test plan

- [x] Fix verified live in a rolled-back transaction (never committed to production)
- [x] Row-count stability re-confirmed post-change
- [x] 2 new unit tests + full existing chairman suite (524 tests) pass
- [ ] Chairman applies the (now-corrected) merged migration at ceremony, runs the updated CONTROL query (5 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)