### PR TITLE
fix(SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001): thread tierCtx into the two live acquisition lanes that omitted it

### DIFF
--- a/database/migrations/20260816_claim_sd_tier_check.sql
+++ b/database/migrations/20260816_claim_sd_tier_check.sql
@@ -29,6 +29,13 @@
 -- per-SD floor is an author reservation independent of fleet headcount) before or as part of the
 -- apply ceremony.
 --
+-- KNOWN DIVERGENCE #3 (found during EXEC-phase SECURITY review): a NULL or malformed caller
+-- tier_rank REFUSES the claim here, whereas the client-side resolveWorkerTierRank(session)
+-- defaults an absent/invalid stamp to the TOP rung and never refuses on that basis alone. Flagged
+-- inline at the comparison for a reviewer to resolve before applying -- unstamped-caller behavior
+-- may reasonably be stricter for a server-side backstop of last resort, but it is a deliberate
+-- choice this migration does not make silently.
+--
 -- SIMPLIFIED "tiering active" check, deliberately NOT a faithful port of
 -- lib/fleet/tier-ladder.cjs isTieringActive(): that function excludes canary/test sessions and
 -- the active coordinator via lib/fleet/genuine-worker.mjs liveFleetWorkers before counting, which
@@ -175,9 +182,18 @@ BEGIN
     -- SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-5): THE ONE BEHAVIORAL ADDITION in this
     -- migration. Same guard family as the terminal-status check above -- a structural eligibility
     -- refusal that fires before any live-peer/takeover logic. Unscored SDs (no min_tier_rank) are
-    -- unaffected. See the file header for the simplified tiering-active check's known divergence
-    -- from lib/fleet/tier-ladder.cjs isTieringActive.
-    SELECT (sd2.metadata->>'min_tier_rank')::integer
+    -- unaffected. See the file header for the simplified tiering-active check's known divergences
+    -- from lib/fleet/tier-ladder.cjs isTieringActive and lib/fleet/tier-claimable.cjs tierBlocks.
+    --
+    -- SECURITY REVIEW FINDING (EXEC-phase, this SD): a bare ::integer cast on a JSONB text value
+    -- raises an UNHANDLED 22P02 (invalid_text_representation) on any malformed stamp -- e.g. a
+    -- min_tier_rank or tier_rank accidentally written as a non-numeric string -- which would abort
+    -- the ENTIRE claim_sd call with a raw Postgres error instead of a structured refusal, making
+    -- the SD permanently unclaimable through this RPC until the bad value is manually corrected.
+    -- Guarded below with a regex pre-check (NULL on anything non-numeric, same fail-open posture
+    -- as an absent stamp) so a malformed value degrades to "treat as missing" rather than erroring.
+    SELECT CASE WHEN sd2.metadata->>'min_tier_rank' ~ '^[0-9]+$'
+                THEN (sd2.metadata->>'min_tier_rank')::integer END
       INTO v_sd_min_tier_rank
       FROM strategic_directives_v2 sd2
      WHERE sd2.sd_key = p_sd_id;
@@ -187,7 +203,14 @@ BEGIN
        WHERE status IN ('active', 'idle')
          AND heartbeat_at >= NOW() - INTERVAL '900 seconds';
       IF v_live_worker_count >= 2 THEN
-        SELECT (metadata->>'tier_rank')::integer
+        -- KNOWN DIVERGENCE #3 (SECURITY review): a NULL/malformed caller tier_rank REFUSES here
+        -- (v_caller_tier_rank IS NULL below), whereas the client-side resolveWorkerTierRank(session)
+        -- defaults an absent/invalid stamp to the TOP rung (never refuses on that basis alone). A
+        -- reviewer should decide whether this backstop should match that default-up posture before
+        -- applying, or whether refusing on an unstamped caller is the intended stricter server-side
+        -- behavior for a backstop of last resort.
+        SELECT CASE WHEN metadata->>'tier_rank' ~ '^[0-9]+$'
+                    THEN (metadata->>'tier_rank')::integer END
           INTO v_caller_tier_rank
           FROM claude_sessions
          WHERE session_id = p_session_id;

--- a/database/migrations/20260816_claim_sd_tier_check.sql
+++ b/database/migrations/20260816_claim_sd_tier_check.sql
@@ -17,6 +17,18 @@
 -- Explore evidence. This migration mirrors that scope exactly rather than introducing a new,
 -- broader QF-tier invariant unilaterally.
 --
+-- KNOWN DIVERGENCE FROM THE CLIENT-SIDE CHECK (found during EXEC-phase TESTING review): the
+-- client-side fix (lib/fleet/tier-claimable.cjs tierBlocks, reused by recoverStrandedFinal and
+-- adoptOrphanInProgress) ALSO honors a scored SD's explicit min_tier_rank floor when tiering is
+-- OFF (fewer than 2 live workers) -- it synthesizes tiering_active:true for that comparison
+-- specifically (the SD-LEO-INFRA-BELT-CLAIMABLE-ACCURACY-FLOOR-001 precedent). This migration
+-- does NOT replicate that: it only refuses when v_live_worker_count >= 2, matching a literal
+-- "tiering active" reading rather than the floor-always-honored behavior tierBlocks provides.
+-- A reviewer applying this migration should decide whether to port the floor-always-honored
+-- semantics into SQL too (drop the v_live_worker_count >= 2 condition entirely, since an explicit
+-- per-SD floor is an author reservation independent of fleet headcount) before or as part of the
+-- apply ceremony.
+--
 -- SIMPLIFIED "tiering active" check, deliberately NOT a faithful port of
 -- lib/fleet/tier-ladder.cjs isTieringActive(): that function excludes canary/test sessions and
 -- the active coordinator via lib/fleet/genuine-worker.mjs liveFleetWorkers before counting, which

--- a/database/migrations/20260816_claim_sd_tier_check.sql
+++ b/database/migrations/20260816_claim_sd_tier_check.sql
@@ -1,0 +1,541 @@
+-- @approved-by: STAGED ONLY -- NOT APPLIED. Chairman-gated DDL; apply only at a future ceremony.
+-- SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-5)
+--
+-- RCA: every enforcement of the WORK-DOWN-NEVER-UP tier invariant today is JS-side only
+-- (lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility's tierAxes for the self-claim
+-- ladder; lib/coordinator/dispatch.cjs assertWorkerTierAllowed for directed dispatch). This SD's
+-- own root cause -- two acquisition lanes (recoverStrandedFinal, adoptOrphanInProgress) silently
+-- omitting the tierCtx a caller must remember to pass -- demonstrates that a JS-only invariant has
+-- nothing below it to catch a lane that forgets. This migration adds a SERVER-SIDE backstop: a
+-- tier check inside claim_sd() itself, so a future JS lane that forgets tierCtx still cannot
+-- write a claim the database itself refuses.
+--
+-- SCOPE: strategic_directives_v2 (SD) claims only. QFs are NOT tier-gated -- neither
+-- assertWorkerTierAllowed (`if (!sdKey || /^QF-/.test(sdKey)) return;`) nor the self-claim QF
+-- lane (scripts/worker-checkin.cjs selfClaimQuickFix, lib/fleet/qf-auto-start.cjs) compares
+-- quick_fixes.routing_tier against a caller's rank today -- confirmed during this SD's PLAN-phase
+-- Explore evidence. This migration mirrors that scope exactly rather than introducing a new,
+-- broader QF-tier invariant unilaterally.
+--
+-- SIMPLIFIED "tiering active" check, deliberately NOT a faithful port of
+-- lib/fleet/tier-ladder.cjs isTieringActive(): that function excludes canary/test sessions and
+-- the active coordinator via lib/fleet/genuine-worker.mjs liveFleetWorkers before counting, which
+-- is non-trivial to replicate correctly in PL/pgSQL. This guard instead counts ALL claude_sessions
+-- rows with status IN ('active','idle') and a heartbeat within the last 900 seconds (mirroring
+-- isTieringActive's own MIN_LIVE_FOR_TIERING=2 threshold and 900s window), which is a reasonable
+-- OVER-COUNT (a canary or the coordinator could tip a 1-genuine-worker fleet into
+-- "tiering active" here when the JS side would call it degrade-to-1/inactive). This is an
+-- intentional, documented simplification for a STAGED migration awaiting human review before any
+-- apply ceremony -- NOT a claim of behavioral parity with isTieringActive. A reviewer should
+-- decide whether the simplified count is acceptable as-is or whether canary/coordinator exclusion
+-- needs porting into SQL first.
+--
+-- Signature is UNCHANGED (still 5 args, same defaults) -- CREATE OR REPLACE is safe here, same
+-- precedent as 20260717_claim_sd_phantom_session_guard.sql.
+--
+-- The body below is the LIVE production claim_sd() definition (database/migrations/
+-- 20260717_claim_sd_phantom_session_guard.sql) with exactly ONE behavioral addition, marked
+-- below: a tier-rank check for the SD path, positioned immediately after the existing
+-- terminal-status guard (same guard family -- both refuse a structurally-ineligible claim before
+-- any live-peer/takeover logic runs). Every existing guard, comment, and provenance note is
+-- preserved verbatim so this migration is a pure additive change.
+--
+-- DO NOT APPLY without chairman sign-off and a fresh migration_reviewed pass -- this file exists
+-- to be reviewed, not run. See strategic_directives_v2.metadata.migration_plan on this SD.
+
+CREATE OR REPLACE FUNCTION public.claim_sd(p_sd_id text, p_session_id text, p_track text, p_force_takeover boolean DEFAULT false, p_client_gate_version integer DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing_session    text;
+  v_existing_hb_age     numeric;
+  v_existing_status     text;
+  v_existing_wt_path    text;
+  v_existing_wt_branch  text;
+  v_sd_claiming_id      text;
+  v_sd_parent_id        text;
+  v_drift_detected      boolean := FALSE;
+  v_takeover            boolean := FALSE;
+  v_takeover_reason     text;
+  v_caller_parent_id    text;
+  v_audit_event_id      uuid;
+  v_conflict            RECORD;
+  v_is_qf               boolean := p_sd_id LIKE 'QF-%';
+  v_sd_status           text;
+  v_qf_status           text;
+  v_sd_claim_hb_age     numeric;
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: armed-silence-window awareness (parity with cleanup_stale_sessions).
+  v_respect_inflight       boolean := FALSE;
+  v_ttl_minutes            integer := 15;
+  v_hardcap_minutes        integer := 45;
+  v_existing_silence_until timestamptz;
+  v_sd_claim_silence_until timestamptz;
+  -- SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 (FR-4): the sd_key/QF-id evicted by the
+  -- claim-switch UPDATE below, captured so its SD/QF-side claim pointer can be cleared.
+  v_evicted_sd_key         text;
+  -- SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-5): server-side tier-rank backstop.
+  v_sd_min_tier_rank       integer;
+  v_caller_tier_rank       integer;
+  v_live_worker_count      integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-1): reject a claim from a session_id with NO
+  -- live claude_sessions row. Real sessions always upsert into claude_sessions at
+  -- SessionStart (session-register.cjs hook) before ever calling claim_sd, so this never
+  -- rejects a genuine worker. Fires before any other read/lock (SD or QF path), so it
+  -- applies uniformly to both.
+  IF NOT EXISTS (SELECT 1 FROM claude_sessions WHERE session_id = p_session_id) THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'phantom_session',
+      'message', format('[CLAIM_PHANTOM_SESSION] session_id %s has no live claude_sessions row — refusing to claim %s.', p_session_id, p_sd_id));
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: read the SAME respect-in-flight flag cleanup_stale_sessions
+  -- uses, so the sweep and the claim arbiter never disagree about an armed silence window. FAIL-OPEN:
+  -- any error leaves the flag OFF (today's reap-on-stale behavior).
+  BEGIN
+    SELECT
+      COALESCE((metadata->>'sweep_respect_inflight_agent')::boolean, FALSE),
+      COALESCE((metadata->>'claim_ttl_minutes')::integer, 15)
+    INTO v_respect_inflight, v_ttl_minutes
+    FROM chairman_dashboard_config
+    WHERE config_key = 'default'
+    LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_respect_inflight := FALSE;
+    v_ttl_minutes := 15;
+  END;
+  -- Hard-cap ceiling = max in-flight silence window (30 min) + claim TTL margin; beyond this no
+  -- expected_silence_until can wedge a dead claim open forever. Mirrors cleanup_stale_sessions.
+  v_hardcap_minutes := 30 + GREATEST(COALESCE(v_ttl_minutes, 15), 0);
+
+  -- 2a. Capture prior session's worktree state (for audit metadata) under the
+  --     SAME FOR UPDATE row lock as the existing-session check.
+  SELECT cs.session_id, cs.status,
+         EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+         cs.worktree_path, cs.worktree_branch,
+         cs.expected_silence_until
+    INTO v_existing_session, v_existing_status, v_existing_hb_age,
+         v_existing_wt_path, v_existing_wt_branch,
+         v_existing_silence_until
+    FROM claude_sessions cs
+   WHERE cs.sd_key = p_sd_id
+     AND cs.session_id != p_session_id
+     AND cs.status IN ('active', 'idle')
+   ORDER BY cs.heartbeat_at DESC
+   LIMIT 1
+     FOR UPDATE;
+
+  IF NOT v_is_qf THEN
+    SELECT sd.claiming_session_id, sd.parent_sd_id, sd.status
+      INTO v_sd_claiming_id, v_sd_parent_id, v_sd_status
+      FROM strategic_directives_v2 sd
+     WHERE sd.sd_key = p_sd_id
+       FOR UPDATE;
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: reject phantom (non-existent) SD ids instead of
+    -- optimistically returning success. claim_sd was OPTIMISTIC -- a typo / stale sd_key used
+    -- to self-claim a non-existent SD and write claude_sessions.sd_key. The existing FOR UPDATE
+    -- SELECT above sets FOUND only when an sd_key row exists, so this is the minimal guard.
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_SD_NOT_FOUND] SD %s does not exist in strategic_directives_v2 — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: terminal-status guard. Refuse to claim an SD whose
+    -- lifecycle has already ended (completed/cancelled/deferred) instead of optimistically
+    -- stomping claiming_session_id. Orthogonal to the sd_not_found guard above; fires BEFORE
+    -- the claim UPDATE so it pre-empts trigger 393's raw P0001 with a clean structured failure
+    -- and additionally covers completed/deferred which that cancelled-only trigger does not.
+    IF v_sd_status IN ('completed', 'cancelled', 'deferred') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_sd_status,
+        'message', format('[CLAIM_SD_TERMINAL] SD %s is in terminal status %s — refusing to claim a finished/cancelled/deferred SD.', p_sd_id, v_sd_status));
+    END IF;
+
+    -- SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-5): THE ONE BEHAVIORAL ADDITION in this
+    -- migration. Same guard family as the terminal-status check above -- a structural eligibility
+    -- refusal that fires before any live-peer/takeover logic. Unscored SDs (no min_tier_rank) are
+    -- unaffected. See the file header for the simplified tiering-active check's known divergence
+    -- from lib/fleet/tier-ladder.cjs isTieringActive.
+    SELECT (sd2.metadata->>'min_tier_rank')::integer
+      INTO v_sd_min_tier_rank
+      FROM strategic_directives_v2 sd2
+     WHERE sd2.sd_key = p_sd_id;
+    IF v_sd_min_tier_rank IS NOT NULL THEN
+      SELECT count(*) INTO v_live_worker_count
+        FROM claude_sessions
+       WHERE status IN ('active', 'idle')
+         AND heartbeat_at >= NOW() - INTERVAL '900 seconds';
+      IF v_live_worker_count >= 2 THEN
+        SELECT (metadata->>'tier_rank')::integer
+          INTO v_caller_tier_rank
+          FROM claude_sessions
+         WHERE session_id = p_session_id;
+        IF v_caller_tier_rank IS NULL OR v_caller_tier_rank < v_sd_min_tier_rank THEN
+          RETURN jsonb_build_object(
+            'success', FALSE,
+            'error', 'sd_above_worker_tier',
+            'message', format(
+              '[CLAIM_ABOVE_WORKER_TIER] SD %s requires tier_rank %s but caller session %s has tier_rank %s — refusing (WORK-DOWN-NEVER-UP server-side backstop).',
+              p_sd_id, v_sd_min_tier_rank, p_session_id, COALESCE(v_caller_tier_rank::text, 'missing')),
+            'required_tier_rank', v_sd_min_tier_rank,
+            'caller_tier_rank', v_caller_tier_rank
+          );
+        END IF;
+      END IF;
+    END IF;
+
+    -- SD-LEO-FIX-CLAIM-RPC-REFUSE-001: capture the SD-side claimant's heartbeat age so the
+    -- live-foreign-claim guard below can refuse to stomp a LIVE peer even when its session-side
+    -- claude_sessions.sd_key pointer has drifted out of sync with the SD-side claiming_session_id.
+    -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: also capture its expected_silence_until for the silence guard.
+    IF v_sd_claiming_id IS NOT NULL AND v_sd_claiming_id != p_session_id THEN
+      SELECT EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+             cs.expected_silence_until
+        INTO v_sd_claim_hb_age,
+             v_sd_claim_silence_until
+        FROM claude_sessions cs
+       WHERE cs.session_id = v_sd_claiming_id
+         AND cs.status IN ('active', 'idle')
+       ORDER BY cs.heartbeat_at DESC
+       LIMIT 1;
+    END IF;
+  ELSE
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: same guard for the QF path (claim_sd resolves QFs
+    -- by quick_fixes.id = p_sd_id, mirrored from the QF UPDATE below).
+    SELECT qf.status INTO v_qf_status FROM quick_fixes qf WHERE qf.id = p_sd_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_QF_NOT_FOUND] Quick-fix %s does not exist in quick_fixes — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: QF terminal-status guard. 'escalated' is a one-way
+    -- promotion to a full SD (classify-quick-fix.js never reverts it), so claiming an escalated
+    -- QF resumes superseded work. Mirrors the SD terminal guard; fires before the QF UPDATE.
+    IF v_qf_status IN ('completed', 'cancelled', 'escalated') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_qf_status,
+        'message', format('[CLAIM_QF_TERMINAL] Quick-fix %s is in terminal status %s — refusing to claim a finished/cancelled/escalated quick-fix.', p_sd_id, v_qf_status));
+    END IF;
+  END IF;
+
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_existing_session IS NULL
+  THEN
+    v_drift_detected := TRUE;
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age < 900 THEN
+    IF NOT p_force_takeover THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'already_claimed',
+        'message', format(
+          '[CLAIM_PEER_ACTIVE] SD %s is already claimed by active session %s (heartbeat %ss ago). Use --force to take over or wait for release.',
+          p_sd_id, v_existing_session, ROUND(v_existing_hb_age)),
+        'claimed_by', v_existing_session,
+        'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+      );
+    END IF;
+
+    SELECT cs2.sd_key INTO v_caller_parent_id
+      FROM claude_sessions cs2
+     WHERE cs2.session_id = p_session_id
+       AND cs2.status IN ('active', 'idle')
+     LIMIT 1;
+
+    IF v_existing_hb_age >= 60 THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_heartbeat_threshold';
+    ELSIF v_sd_parent_id IS NOT NULL
+          AND v_caller_parent_id = v_sd_parent_id THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_parent_authority';
+    ELSE
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'unauthorized_force',
+        'message', format(
+          '[CLAIM_FORCE_DENIED] SD %s force-takeover refused: caller session %s lacks authority (prior heartbeat %ss < 60s threshold and no parent SD authority). Use sd:release first or wait.',
+          p_sd_id, p_session_id, ROUND(v_existing_hb_age))
+      );
+    END IF;
+  END IF;
+
+  -- SD-LEO-FIX-CLAIM-RPC-REFUSE-001: refuse to overwrite a claim held by a LIVE foreign session.
+  -- The session-side refusal above only fires when the live peer's claude_sessions.sd_key still
+  -- equals p_sd_id; it misses the case where only the SD-side claim (claiming_session_id) points
+  -- to a still-live session whose session pointer drifted. Without this guard the drift_recovery
+  -- takeover below would silently stomp that live peer. A stale claimant (hb >= 900s) or an absent
+  -- session leaves v_sd_claim_hb_age NULL / >= 900 and still falls through to takeover; --force too.
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_sd_claim_hb_age IS NOT NULL
+     AND v_sd_claim_hb_age < 900
+     AND NOT p_force_takeover
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_live_peer',
+      'message', format(
+        '[CLAIM_LIVE_PEER] SD %s is claimed by LIVE session %s (heartbeat %ss ago) — refusing to overwrite a live peer''s claim. Use --force to take over or wait for release.',
+        p_sd_id, v_sd_claiming_id, ROUND(v_sd_claim_hb_age)),
+      'claimed_by', v_sd_claiming_id,
+      'heartbeat_age_seconds', ROUND(v_sd_claim_hb_age)
+    );
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: drift_recovery choke point. If the SD-side claimant is a
+  -- parked worker inside its armed silence window (flag ON, window in the future, heartbeat within
+  -- the hard-cap ceiling), refuse to reap it. --force and expired / beyond-cap windows still take
+  -- over (this guard requires NOT p_force_takeover and a future window <= hard-cap). Mutually
+  -- exclusive with the auto_stale guard below: v_drift_detected implies v_existing_session IS NULL.
+  IF v_respect_inflight
+     AND v_drift_detected AND NOT v_takeover
+     AND NOT p_force_takeover
+     AND v_sd_claim_silence_until IS NOT NULL
+     AND v_sd_claim_silence_until > NOW()
+     AND v_sd_claim_hb_age IS NOT NULL
+     AND v_sd_claim_hb_age <= (v_hardcap_minutes * 60)
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_silenced_peer',
+      'message', format(
+        '[CLAIM_SILENCED_PEER] SD %s is claimed by session %s parked inside an armed silence window (until %s, heartbeat %ss ago) — refusing to reap a parked worker. Use --force to override.',
+        p_sd_id, v_sd_claiming_id, v_sd_claim_silence_until, ROUND(v_sd_claim_hb_age)),
+      'claimed_by', v_sd_claiming_id,
+      'silence_until', v_sd_claim_silence_until,
+      'heartbeat_age_seconds', ROUND(v_sd_claim_hb_age)
+    );
+  END IF;
+
+  IF v_drift_detected AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'drift_recovery';
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: auto_stale_takeover choke point. A session silent past 900s
+  -- but inside its armed silence window (flag ON, within the hard-cap ceiling) is a PARKED worker,
+  -- not a dead one — refuse the auto-stale takeover. --force and expired / beyond-cap windows still
+  -- reap (a window beyond the 45-min hard-cap, or already past, falls through to takeover below).
+  IF v_respect_inflight
+     AND v_existing_session IS NOT NULL
+     AND v_existing_hb_age >= 900 AND NOT v_takeover
+     AND NOT p_force_takeover
+     AND v_existing_silence_until IS NOT NULL
+     AND v_existing_silence_until > NOW()
+     AND v_existing_hb_age <= (v_hardcap_minutes * 60)
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_silenced_peer',
+      'message', format(
+        '[CLAIM_SILENCED_PEER] SD %s is claimed by parked session %s inside an armed silence window (until %s, heartbeat %ss ago) — refusing auto-stale takeover. Use --force to override.',
+        p_sd_id, v_existing_session, v_existing_silence_until, ROUND(v_existing_hb_age)),
+      'claimed_by', v_existing_session,
+      'silence_until', v_existing_silence_until,
+      'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+    );
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age >= 900 AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'auto_stale_takeover';
+  END IF;
+
+  IF NOT v_is_qf AND NOT v_takeover THEN
+    SELECT cm.*, cs_other.sd_key AS active_sd, cs_other.session_id AS active_session
+      INTO v_conflict
+      FROM sd_conflict_matrix cm
+      JOIN claude_sessions cs_other ON (
+        (cm.sd_id_a = p_sd_id AND cm.sd_id_b = cs_other.sd_key) OR
+        (cm.sd_id_b = p_sd_id AND cm.sd_id_a = cs_other.sd_key)
+      )
+     WHERE cm.conflict_severity = 'blocking'
+       AND cm.resolved_at IS NULL
+       AND cs_other.sd_key IS NOT NULL
+       AND cs_other.status IN ('active', 'idle')
+       AND EXTRACT(EPOCH FROM (NOW() - cs_other.heartbeat_at)) < 900
+       AND cs_other.session_id != p_session_id
+     LIMIT 1;
+
+    IF v_conflict IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'blocking_conflict',
+        'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+        'conflict_type', v_conflict.conflict_type,
+        'conflicting_sd', v_conflict.active_sd,
+        'conflicting_session', v_conflict.active_session
+      );
+    END IF;
+  END IF;
+
+  -- ============================================================================
+  -- TAKEOVER PATH: NULL the prior session's claim AND its worktree state.
+  -- (FR-1 of SD-LEO-INFRA-LEO-INFRA-SESSION-001 — only the worktree_* columns
+  -- are new vs. 20260427.)
+  -- ============================================================================
+  IF v_takeover AND v_existing_session IS NOT NULL THEN
+    UPDATE claude_sessions
+       SET sd_key = NULL,
+           track = NULL,
+           claimed_at = NULL,
+           released_at = NOW(),
+           released_reason = v_takeover_reason,
+           status = 'idle',
+           updated_at = NOW(),
+           worktree_path = NULL,
+           worktree_branch = NULL
+     WHERE session_id = v_existing_session;
+  END IF;
+
+  -- Claim-switch path: caller is releasing some OTHER SD to claim p_sd_id.
+  -- SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 (FR-4): RETURNING captures the evicted sd_key
+  -- (NULL if no row matched) so its own claim pointer can be cleared symmetrically below.
+  UPDATE claude_sessions
+     SET sd_key = NULL,
+         track = NULL,
+         claimed_at = NULL,
+         released_at = NOW(),
+         released_reason = 'claim_switch',
+         status = 'idle',
+         worktree_path = NULL,
+         worktree_branch = NULL
+   WHERE session_id = p_session_id
+     AND sd_key IS NOT NULL
+     AND sd_key != p_sd_id
+     AND (v_sd_parent_id IS NULL OR sd_key != v_sd_parent_id)
+   RETURNING sd_key INTO v_evicted_sd_key;
+
+  -- SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 (FR-4): symmetric clear of the EVICTED SD's/QF's
+  -- claim pointer. The claim-switch UPDATE above only clears the CALLING SESSION's
+  -- claude_sessions row; without this, strategic_directives_v2.claiming_session_id (or
+  -- quick_fixes.claiming_session_id) on the evicted item was never cleared, leaving it
+  -- looking claimed by a session that has since moved to a different SD (RCA QF-20260712-310).
+  -- Guarded by `claiming_session_id = p_session_id` so this never clobbers a claim some OTHER
+  -- session has since legitimately taken on the evicted item.
+  IF v_evicted_sd_key IS NOT NULL THEN
+    IF v_evicted_sd_key LIKE 'QF-%' THEN
+      UPDATE quick_fixes
+         SET claiming_session_id = NULL
+       WHERE id = v_evicted_sd_key
+         AND claiming_session_id = p_session_id;
+    ELSE
+      UPDATE strategic_directives_v2
+         SET claiming_session_id = NULL,
+             active_session_id = NULL,
+             is_working_on = FALSE
+       WHERE sd_key = v_evicted_sd_key
+         AND claiming_session_id = p_session_id;
+    END IF;
+  END IF;
+
+  -- New-claim UPDATE intentionally does NOT set worktree_path / worktree_branch.
+  -- sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after
+  -- createWorktree completes. Keeping them NULL here means the FR-5 CHECK
+  -- constraint is never violated transiently.
+  UPDATE claude_sessions
+     SET sd_key = p_sd_id,
+         track = p_track,
+         claimed_at = NOW(),
+         released_at = NULL,
+         released_reason = NULL,
+         heartbeat_at = NOW(),
+         status = 'active'
+   WHERE session_id = p_session_id;
+
+  IF v_is_qf THEN
+    UPDATE quick_fixes
+       SET claiming_session_id = p_session_id,
+           status = 'in_progress'
+     WHERE id = p_sd_id;
+  ELSE
+    -- SD-LEO-INFRA-SIDE-CLAIM-ELIGIBILITY-001 (FR-2): stamp the caller's gate-code version on
+    -- the SD-side claim mirror so the observe-only trigger can compare it against the version-floor.
+    UPDATE strategic_directives_v2
+       SET claiming_session_id = p_session_id,
+           active_session_id = p_session_id,
+           is_working_on = TRUE,
+           claim_gate_client_version = p_client_gate_version
+     WHERE sd_key = p_sd_id;
+  END IF;
+
+  IF v_takeover THEN
+    INSERT INTO session_lifecycle_events (
+      event_type,
+      session_id,
+      reason,
+      metadata
+    ) VALUES (
+      CASE
+        WHEN v_takeover_reason = 'auto_stale_takeover' THEN 'CLAIM_AUTO_RECLAIM'
+        ELSE 'CLAIM_TAKEOVER'
+      END,
+      p_session_id,
+      v_takeover_reason,
+      jsonb_build_object(
+        'sd_key', p_sd_id,
+        'prior_session_id', v_existing_session,
+        'prior_heartbeat_age_seconds', ROUND(COALESCE(v_existing_hb_age, 0)),
+        'drift_detected', v_drift_detected,
+        'force_authorized_by', CASE
+          WHEN v_takeover_reason LIKE 'force_%' THEN v_takeover_reason
+          ELSE NULL
+        END,
+        'sd_claiming_id_before', v_sd_claiming_id,
+        'worktree_path_before', v_existing_wt_path,
+        'worktree_branch_before', v_existing_wt_branch
+      )
+    )
+    RETURNING id INTO v_audit_event_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_sd_parent_id IS NOT NULL,
+    'takeover', v_takeover,
+    'takeover_reason', v_takeover_reason,
+    'prior_session_id', v_existing_session,
+    'prior_heartbeat_age_seconds', CASE
+      WHEN v_existing_hb_age IS NOT NULL THEN ROUND(v_existing_hb_age)
+      ELSE NULL
+    END,
+    'drift_detected', v_drift_detected,
+    'evicted_sd_key', v_evicted_sd_key,
+    'audit_event_id', v_audit_event_id
+  );
+END;
+$function$;
+
+-- Prompt PostgREST to reload its schema cache promptly (unchanged signature, but the
+-- function body changed).
+NOTIFY pgrst, 'reload schema';
+
+DO $$
+DECLARE
+  v_overload_count int;
+BEGIN
+  SELECT count(*) INTO v_overload_count FROM pg_proc WHERE proname = 'claim_sd';
+  IF v_overload_count != 1 THEN
+    RAISE EXCEPTION 'VERIFICATION FAILED: expected exactly 1 claim_sd overload, found %', v_overload_count;
+  END IF;
+  RAISE NOTICE 'claim_sd: exactly one overload confirmed (5-arg, tier-rank backstop added).';
+END $$;

--- a/lib/checkin/steps/adopt-orphan.cjs
+++ b/lib/checkin/steps/adopt-orphan.cjs
@@ -9,7 +9,7 @@ module.exports = {
     //     claims, session reaped mid-build) BEFORE self-claiming new work — finishing a
     //     partially-built SD beats starting fresh, but a one-handoff-from-shipped stranded final
     //     (5.7) still wins over a mid-build orphan.
-    const adopted = await adoptOrphanInProgress(sb, sessionId, ctx.base);
+    const adopted = await adoptOrphanInProgress(sb, sessionId, ctx.base, ctx.tierCtx);
     if (adopted) return adopted;
   },
 };

--- a/lib/checkin/steps/index.cjs
+++ b/lib/checkin/steps/index.cjs
@@ -21,8 +21,13 @@
  *                                target_sd null) short-circuits ALL self-claim tiers below —
  *                                positioned after directed-assignment (unaffected) and before
  *                                recover-stranded-final (fenced))
- *   8. recover-stranded-final  (rung 5.7  — re-claim a stranded LEAD_FINAL SD)
- *   9. adopt-orphan            (rung 5.8  — adopt an orphaned in_progress SD)
+ * 7.6. tier-context             (rung 5.65 — SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: hoist
+ *                                {worker_tier_rank, tiering_active} into ctx.tierCtx ONCE per tick,
+ *                                before recover-stranded-final/adopt-orphan, so both can apply the
+ *                                tier axis via tierBlocks() -- previously only merged-pool-self-claim
+ *                                (rung 6) computed this, too late for the two earlier lanes)
+ *   8. recover-stranded-final  (rung 5.7  — re-claim a stranded LEAD_FINAL SD; now tier-gated)
+ *   9. adopt-orphan            (rung 5.8  — adopt an orphaned in_progress SD; now tier-gated)
  *  9.5. drain-reservations     (rung 5.85 — SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C:
  *                                read active coordinator_reservation fences into ctx.reservations,
  *                                strictly after directed/stranded/orphan recovery, strictly
@@ -50,6 +55,7 @@ module.exports = [
   require('./canary-claim-fence.cjs'),
   require('./directed-assignment.cjs'),
   require('./seat-busy-fence.cjs'),
+  require('./tier-context.cjs'),
   require('./recover-stranded-final.cjs'),
   require('./adopt-orphan.cjs'),
   require('./drain-reservations.cjs'),

--- a/lib/checkin/steps/merged-pool-self-claim.cjs
+++ b/lib/checkin/steps/merged-pool-self-claim.cjs
@@ -9,7 +9,7 @@ module.exports = {
     const {
       ensureActiveBaseline, fetchDraftCandidates, fetchNewestDraftCandidates,
       fetchFleetCriticalCandidates, fetchRankedCandidates, sortByDispatchRank,
-      resolveWorkerTierRank, isTieringActive, fetchLowerTierBacklogData, ladderTopRank, seatCapabilityIsVerified,
+      fetchLowerTierBacklogData, ladderTopRank, seatCapabilityIsVerified,
       fetchFableWindowActive, claimableForTier, claimableForRepo, baselinedCandidateEligible, isSdInFlight,
       tryClaim, tryClaimDraftCandidate, antiWinddownDirective, coordinatorReservation,
       SELF_CLAIM_CANDIDATE_LIMIT,
@@ -97,14 +97,18 @@ module.exports = {
       // any fault leaves tierCtx empty => byte-identical pre-tiering behavior.
       let tierCtx = {};
       try {
+        // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: worker_tier_rank/tiering_active are now
+        // computed ONCE per tick by the tier-context.cjs step (rung 5.65, before this one) and
+        // read from ctx.tierCtx here rather than recomputed -- relocates, not duplicates, the
+        // resolveWorkerTierRank/isTieringActive calls this file used to make on its own.
         tierCtx = {
-          worker_tier_rank: resolveWorkerTierRank({ metadata: ctx.sessionMetadata }),
+          worker_tier_rank: ctx.tierCtx && ctx.tierCtx.worker_tier_rank,
           // SD-LEO-INFRA-FLEET-MODEL-REGISTRY-001 FR-6: the tier_rank above is read from the
           // PERSISTED stamp, which may have been derived when an unknown model still resolved
           // to STRONGEST — so it cannot vouch for capability. Thread positive evidence
           // separately so an unverified seat cannot self-admit above the lowest rung.
           worker_capability_unverified: !seatCapabilityIsVerified(ctx.sessionMetadata),
-          tiering_active: await isTieringActive(sb),
+          tiering_active: !!(ctx.tierCtx && ctx.tierCtx.tiering_active),
           // SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C (FR-3): thread the reservations
           // drained by drain-reservations.cjs + this session's own id into the SAME tierCtx
           // object spread into both baselinedCandidateEligible below and

--- a/lib/checkin/steps/recover-stranded-final.cjs
+++ b/lib/checkin/steps/recover-stranded-final.cjs
@@ -9,7 +9,7 @@ module.exports = {
     //      (claim cleared, one handoff from shipped) BEFORE self-claiming new work — finishing a
     //      near-shipped SD beats starting fresh. Re-claiming lets a worker run LEAD-FINAL-APPROVAL with
     //      a valid matching claim (passing the claim-validity gate the coordinator-from-main path fails).
-    const recovered = await recoverStrandedFinal(sb, sessionId, ctx.base);
+    const recovered = await recoverStrandedFinal(sb, sessionId, ctx.base, ctx.tierCtx);
     if (recovered) return recovered;
   },
 };

--- a/lib/checkin/steps/tier-context.cjs
+++ b/lib/checkin/steps/tier-context.cjs
@@ -1,0 +1,30 @@
+// SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: hoisted tierCtx producer.
+//
+// Computes {worker_tier_rank, tiering_active} ONCE per check-in tick and stores it on
+// ctx.tierCtx, positioned before recover-stranded-final (rung 5.7) and adopt-orphan (rung 5.8) so
+// BOTH can apply the tier axis via tierBlocks(). Previously only merged-pool-self-claim (rung 6)
+// computed this, too late for the two earlier lanes -- the root cause of the tier axis being
+// silently inert on them.
+//
+// merged-pool-self-claim.cjs reads ctx.tierCtx.worker_tier_rank/tiering_active instead of
+// recomputing them, so this RELOCATES rather than duplicates the existing
+// resolveWorkerTierRank/isTieringActive calls -- per-tick DB/metadata-read cost is unchanged.
+//
+// run() never short-circuits the pipeline (always returns undefined); it only annotates ctx.
+// Fail-open on any fault: ctx.tierCtx stays {}, and tierBlocks(sd, undefined, undefined) only
+// blocks a SCORED SD via its explicit-floor branch -- never an unscored one -- so a producer
+// failure degrades to today's pre-fix behavior on unscored SDs and fails closed on scored ones.
+module.exports = {
+  name: 'tier-context',
+  async run(ctx) {
+    const { resolveWorkerTierRank, isTieringActive } = ctx.helpers;
+    try {
+      ctx.tierCtx = {
+        worker_tier_rank: resolveWorkerTierRank({ metadata: ctx.sessionMetadata }),
+        tiering_active: await isTieringActive(ctx.sb),
+      };
+    } catch {
+      ctx.tierCtx = {};
+    }
+  },
+};

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -745,7 +745,7 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
     // precedence as the inline chain it replaces (assigned_sd -> sd_key -> target_sd).
     const sdKey = resolveAssignmentTargetKey(row, { profile: 'dispatchStamp' });
     if (!sdKey || /^QF-/.test(sdKey)) return; // QFs and SD-less nudges are not tier-gated
-    const { isTieringActive, resolveWorkerTierRank, resolveRoutingScore, capabilityScore } = require('../fleet/tier-ladder.cjs');
+    const { isTieringActive, resolveWorkerTierRank, resolveRoutingScore, capabilityScore, tierRankVerdict } = require('../fleet/tier-ladder.cjs');
     if (!(await isTieringActive(supabase))) return; // FR-5: tiering off with < 2 live workers
     const { data: sess } = await supabase
       .from('claude_sessions')
@@ -774,15 +774,25 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
       );
     }
     const minRank = Number(sd && sd.metadata && sd.metadata.min_tier_rank);
-    if (!Number.isFinite(minRank)) return; // unscored SD -> don't block dispatch
-    if (minRank > workerRank) {
+    // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-4): delegate to the ONE shared tier-rank
+    // predicate also used by lib/fleet/claim-eligibility.cjs tierAxes. workerRank is always finite
+    // today (resolveWorkerTierRank defaults to the top rung rather than returning non-finite), so
+    // the tier_stamp_missing branch is unreachable via THIS call site under that contract — but this
+    // call site no longer relies on that contract holding forever, or on being the only caller of
+    // tierRankVerdict, to stay correct. tier_stamp_missing reuses DISPATCH_ABOVE_WORKER_TIER's code
+    // deliberately: the catch block below only re-throws (fails closed) a fixed allowlist of codes,
+    // and this is the same "refuse the dispatch" outcome as an above-tier worker.
+    const verdict = tierRankVerdict(workerRank, minRank);
+    if (verdict === 'above_worker_tier' || verdict === 'tier_stamp_missing') {
       const e = new Error(
-        `[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} requires tier_rank ${minRank} but target worker is tier_rank ${workerRank} `
-        + `(WORK-DOWN-NEVER-UP — a lower-rung worker never takes above-rung work; assign it to an equal/higher rung).`
+        `[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} requires tier_rank ${minRank} but target worker's tier_rank is `
+        + `${verdict === 'tier_stamp_missing' ? 'missing/unresolved' : workerRank} `
+        + `(WORK-DOWN-NEVER-UP — a lower-rung or unstamped worker never takes above-rung work; assign it to an equal/higher rung).`
       );
       e.code = 'DISPATCH_ABOVE_WORKER_TIER';
       throw e;
     }
+    if (!Number.isFinite(minRank)) return; // unscored SD -> nothing more to check
     if (minRank < workerRank) {
       const { lowerTierBacklog, fetchLowerTierBacklogData } = require('../fleet/tier-backlog.cjs');
       const backlogData = await fetchLowerTierBacklogData(supabase);

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -63,7 +63,7 @@ const { extractAllDependencyRefs } = require('../utils/parse-sd-dependencies.cjs
 // downward-claim reservation branch below. lowerTierBacklog does NOT touch the DB itself — the
 // caller precomputes ctx.lower_tier_backlog_data once per tick (see tier-backlog.cjs docstring).
 const { lowerTierBacklog } = require('./tier-backlog.cjs');
-const { ladderTopRank } = require('./tier-ladder.cjs');
+const { ladderTopRank, tierRankVerdict } = require('./tier-ladder.cjs');
 // SD-LEO-INFRA-WORK-CLASS-CLAIM-001: the orthogonal model-capability × work-class fence
 // (min_tier_rank is a linear floor; it cannot express "Fable must not take general work").
 const { workClassIneligibilityReason } = require('./work-class.cjs');
@@ -311,14 +311,13 @@ const INELIGIBILITY_AXES = [
   function tierAxes(row, ctx) {
     if (!(ctx && ctx.tiering_active === true)) return null;
     const minRank = Number(row.metadata && row.metadata.min_tier_rank);
-    // QF-20260703-242: a missing/non-finite worker tier stamp must FAIL CLOSED on tier-gated SDs
-    // (minRank finite) instead of silently skipping this whole axis — else an unstamped or
-    // momentarily-flapping worker can self-claim above its real rung. Unscored SDs (no
-    // min_tier_rank) are unaffected: there is nothing to gate against.
-    if (!Number.isFinite(Number(ctx.worker_tier_rank))) {
-      if (Number.isFinite(minRank)) return 'tier_stamp_missing';
-      return null;
-    }
+    // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-4): the stamp-missing / above-tier halves of
+    // this axis now delegate to the ONE shared predicate (lib/fleet/tier-ladder.cjs tierRankVerdict)
+    // also used by lib/coordinator/dispatch.cjs assertWorkerTierAllowed, so the two surfaces cannot
+    // silently diverge. QF-20260703-242's fail-closed behavior (a missing/non-finite worker tier
+    // stamp blocks a SCORED SD rather than silently skipping this whole axis) lives inside it now.
+    const verdict = tierRankVerdict(ctx.worker_tier_rank, minRank);
+    if (verdict === 'tier_stamp_missing') return verdict;
     // SD-LEO-INFRA-FLEET-MODEL-REGISTRY-001 FR-6: ADMISSION CONTROL for an unverified seat.
     // A tier_rank stamp is not evidence of capability — it can be a stale value derived when
     // unknown still resolved to STRONGEST, and self-claim reads that persisted stamp directly
@@ -328,11 +327,14 @@ const INELIGIBILITY_AXES = [
     // outright: blocking would strand the unstamped seats entirely, and the remedy is one
     // command away (worker-checkin.cjs --model <m> --effort <e>), which the FR-5 audit event
     // names. Fail-safe DOWN for a seat, consistent with FR-4.
+    // (Reached only when verdict !== 'tier_stamp_missing': either minRank is unscored -- in which
+    // case Number.isFinite(minRank) below is false and this never fires anyway -- or workerTierRank
+    // is finite, exactly as the pre-extraction code guaranteed at this point.)
     if (ctx.worker_capability_unverified === true && Number.isFinite(minRank) && minRank > 1) {
       return 'unverified_seat_capability';
     }
+    if (verdict === 'above_worker_tier') return verdict;
     const workerRank = Number(ctx.worker_tier_rank);
-    if (Number.isFinite(minRank) && minRank > workerRank) return 'above_worker_tier';
     // QF-20260709-881: a top-rung (fable) seat self-claiming BELOW-tier belt work during an
     // active Fable-window burns expensive Fable wall-clock that should go to directed door/
     // queued high-tier work instead (recurred 2x same-day: Golf-2 unstamped one-way SWEEP

--- a/lib/fleet/tier-claimable.cjs
+++ b/lib/fleet/tier-claimable.cjs
@@ -72,14 +72,21 @@ function isBaseEligible(sd, opts = {}) {
  *  tiering_active:true and honors only the FLOOR outcomes — 'above_worker_tier' and the fail-closed
  *  'tier_stamp_missing' (an unstamped worker vs an explicit floor is blocked, matching the gate's
  *  QF-20260703-242 semantics). Other tier-axis outcomes (fable-window / reservation) stay inert when
- *  global tiering is off. Unscored SDs (no finite min_tier_rank) remain reachable by every tier. */
+ *  global tiering is off. Unscored SDs (no finite min_tier_rank) remain reachable by every tier.
+ *
+ *  SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: the tiering-ON branch below used to check ONLY
+ *  'above_worker_tier', so a missing/non-finite workerTierRank on a SCORED SD with tiering genuinely
+ *  active fell through UNBLOCKED (classifyDispatchIneligibility correctly returns 'tier_stamp_missing'
+ *  in that case, but tierBlocks silently discarded it) — found by this SD's own test matrix cross-
+ *  checking tierBlocks against classifyDispatchIneligibility directly. Both branches now honor the
+ *  SAME two FLOOR outcomes, matching the doc comment above (which already described this as the
+ *  intended contract for the OFF branch and should have applied to both). */
 function tierBlocks(sd, workerTierRank, tieringActive) {
   if (tieringActive !== true) {
     if (sdMinTierRank(sd) === null) return false; // unscored => reachable by every rung
-    const verdict = classifyDispatchIneligibility(sd, { worker_tier_rank: workerTierRank, tiering_active: true });
-    return verdict === 'above_worker_tier' || verdict === 'tier_stamp_missing';
   }
-  return classifyDispatchIneligibility(sd, { worker_tier_rank: workerTierRank, tiering_active: true }) === 'above_worker_tier';
+  const verdict = classifyDispatchIneligibility(sd, { worker_tier_rank: workerTierRank, tiering_active: true });
+  return verdict === 'above_worker_tier' || verdict === 'tier_stamp_missing';
 }
 
 /**

--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -358,6 +358,36 @@ function resolveWorkerTierRank(session) {
 }
 
 /**
+ * SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-4): the ONE tier-rank comparison, shared by
+ * lib/fleet/claim-eligibility.cjs's tierAxes (self-claim ladder) and
+ * lib/coordinator/dispatch.cjs's assertWorkerTierAllowed (directed-dispatch choke).
+ *
+ * Before this extraction the two were independent, hand-rolled implementations sharing only the
+ * resolveWorkerTierRank/lowerTierBacklog primitives, not the comparison itself. tierAxes
+ * defensively checked Number.isFinite(workerTierRank) before comparing (QF-20260703-242,
+ * fail-closed on a missing/non-finite rank for a SCORED SD); assertWorkerTierAllowed did not --
+ * it compared `minRank > workerRank` directly, correct ONLY because it always sources workerRank
+ * from resolveWorkerTierRank(sess) on a real session row, which today never returns non-finite
+ * (it defaults to the top rung instead). That made assertWorkerTierAllowed correct BY COINCIDENCE
+ * of resolveWorkerTierRank's current contract, not by its own construction -- a future change to
+ * that contract, or a caller of THIS shared function that sources workerTierRank some other way,
+ * would silently allow above-tier work through the un-guarded comparison. This function closes
+ * that gap once, for both callers, regardless of what either caller's rank ultimately came from.
+ *
+ * @param {number|undefined} workerTierRank - the calling worker's resolved tier rank
+ * @param {number|undefined} minTierRank - the SD's metadata.min_tier_rank (may be unscored)
+ * @returns {'above_worker_tier'|'tier_stamp_missing'|null}
+ */
+function tierRankVerdict(workerTierRank, minTierRank) {
+  const minRank = Number(minTierRank);
+  if (!Number.isFinite(minRank)) return null; // unscored SD -> no floor to enforce
+  if (!Number.isFinite(Number(workerTierRank))) return 'tier_stamp_missing'; // fail closed, scored SD
+  const workerRank = Number(workerTierRank);
+  if (minRank > workerRank) return 'above_worker_tier';
+  return null;
+}
+
+/**
  * Build a dense-ranked ladder from a live fleet snapshot ([{model, effort}, ...]).
  * Dense-ranks the DISTINCT capabilityScores actually present, 1..K, and REFRESHES the
  * cached lastKnownTopRank to K (only when the fleet is non-empty — an empty fleet
@@ -505,6 +535,7 @@ module.exports = {
   ladderTopRank,
   clamp,
   resolveWorkerTierRank,
+  tierRankVerdict,
   isTieringActive,
   MIN_LIVE_FOR_TIERING,
   MODEL_STRENGTH,

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -87,7 +87,11 @@ function getDispatchAuthMode() {
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): --model/--effort capture at check-in.
 const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, ladderTopRank, familyFromModelId, seatCapabilityIsVerified, isKnownEffort, isKnownModel } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): tier-aware "claimable-to-MY-rung" rollup.
-const { claimableForTier, claimableForRepo } = require('../lib/fleet/tier-claimable.cjs');
+// tierBlocks also reused directly (SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001): it already honors
+// a scored SD's explicit min_tier_rank floor even when global tiering is off, which recoverStrandedFinal
+// and adoptOrphanInProgress need and a raw classifyDispatchIneligibility(sd, {worker_tier_rank, tiering_active})
+// call would not provide.
+const { claimableForTier, claimableForRepo, tierBlocks } = require('../lib/fleet/tier-claimable.cjs');
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): backlog-gated downward claims. The fetcher is
 // SHARED with lib/coordinator/dispatch.cjs's assertWorkerTierAllowed so the pull path (here) and
 // the directed-dispatch path compute an IDENTICAL backlog verdict — never two re-derivations.
@@ -941,8 +945,10 @@ async function fetchRankedCandidates(sb) {
     .sort((a, b) => Number(a.metadata.dispatch_rank) - Number(b.metadata.dispatch_rank));
 }
 
-/** Per-row claim attempt for an un-baselined draft candidate (shared by the merged
- *  step-6 tier and the legacy selfClaimDraftSd wrapper). Returns a result or null. */
+/** Per-row claim attempt for an un-baselined draft candidate, called by the merged step-6 tier.
+ * (SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: the legacy selfClaimDraftSd wrapper this was
+ * also shared with is removed — confirmed dead code, excluded from CHECKIN_HELPERS, zero live
+ * call sites since the 2026-07-09 step-pipeline refactor.) Returns a result or null. */
 async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
   // SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001: same shared classifier the baselined candidate-view
   // tier (step 6) and the coordinator/sweep PUSH path use — the un-baselined draft tier must not
@@ -983,20 +989,6 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
   return null;
 }
 
-async function selfClaimDraftSd(sb, sessionId, base) {
-  try {
-    const ordered = await fetchDraftCandidates(sb);
-    // duty-6: a fresh coordinator dispatch_rank overrides the local priority order (rank already
-    // encodes priority as its tie-break); unranked/stale rows keep the order above. Fail-open.
-    const ranked = await sortByDispatchRank(sb, ordered, (d) => d.sd_key);
-    for (const d of ranked) {
-      const result = await tryClaimDraftCandidate(sb, sessionId, base, d);
-      if (result) return result;
-    }
-  } catch { /* fail-open -> caller continues to QF/idle */ }
-  return null;
-}
-
 // SD-FDBK-FIX-RECURRING-2ND-OCCURRENCE-001: recover SDs STRANDED at pending_approval/LEAD_FINAL
 // with the claim cleared. RECURRING bug (2nd occurrence): a worker reaches LEAD_FINAL (PLAN-TO-LEAD
 // accepted, gates passed, retro exists, PR usually merged) then RELEASES its claim and goes idle
@@ -1014,7 +1006,7 @@ const STRANDED_CANDIDATE_LIMIT = 5;
 // window between a transition and the next handoff). A genuinely stranded SD sits indefinitely.
 const STRANDED_MIN_AGE_MS = 5 * 60 * 1000;
 
-async function recoverStrandedFinal(sb, sessionId, base) {
+async function recoverStrandedFinal(sb, sessionId, base, tierCtx = {}) {
   try {
     const cutoffIso = new Date(Date.now() - STRANDED_MIN_AGE_MS).toISOString();
     const { data: stranded } = await sb
@@ -1044,6 +1036,15 @@ async function recoverStrandedFinal(sb, sessionId, base) {
         // FR-1 requires the refusal be LOUD. Silence is what let the original hold go unnoticed —
         // an operator seeing "idle" cannot tell "nothing to recover" from "recovery was refused".
         skipped.push(`${sd.sd_key}: ${ineligible}`);
+        continue;
+      }
+      // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: this lane called classifyDispatchIneligibility
+      // above with NO tierCtx, so the tier axis was silently inert here (WORK-DOWN-NEVER-UP held only
+      // on the merged-pool lane). tierBlocks (not a raw ctx spread) is reused deliberately: it already
+      // honors a scored SD's explicit min_tier_rank floor even when global tiering is off, and it never
+      // reads inflight_git_state, so it cannot regress this lane's own merged-PR recovery behavior.
+      if (tierBlocks(sd, tierCtx.worker_tier_rank, tierCtx.tiering_active)) {
+        skipped.push(`${sd.sd_key}: above_worker_tier`);
         continue;
       }
       // FR-2: soft holds do not refuse, but they must never be INVISIBLE.
@@ -1313,7 +1314,7 @@ async function pendingDirectedAssignmentBlocksAdoption(sb, sdKey) {
   }
 }
 
-async function adoptOrphanInProgress(sb, sessionId, base) {
+async function adoptOrphanInProgress(sb, sessionId, base, tierCtx = {}) {
   try {
     const cutoffIso = new Date(Date.now() - ORPHAN_MIN_AGE_MS).toISOString();
     const { data: orphans } = await sb
@@ -1355,6 +1356,11 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
       // metadata.requires_human_action all skip. SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): {cwd}
       // adds the claim-time fitness axes so a repo-mismatched orphan is not adopted here.
       if (classifyDispatchIneligibility(sd, { cwd: process.cwd() }) !== null) continue;
+      // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: same omission as recoverStrandedFinal above --
+      // this lane's classifyDispatchIneligibility call carries no tierCtx, so a below-rung seat could
+      // adopt an above-rung orphan. tierBlocks reused for the same reason: it honors a scored SD's
+      // floor even when global tiering is off, unlike a raw ctx spread into the classifier.
+      if (tierBlocks(sd, tierCtx.worker_tier_rank, tierCtx.tiering_active)) continue;
       // SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001: parent-lifecycle guard. classifyDispatchIneligibility
       // excludes orchestrator-parents/test-fixtures/human-action/live-held but NOT a CHILD whose
       // orchestrator parent is still pre-LEAD — adopting one only burns PLAN cycles before the hard
@@ -1388,7 +1394,7 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
 /**
  * Dedup guard: should this SD candidate be SKIPPED by self-claim because it is already
  * being built? v_sd_next_candidates only filters completed/cancelled/deferred and
- * selfClaimDraftSd only filters claiming_session_id IS NULL, so both can surface an SD
+ * fetchDraftCandidates only filters claiming_session_id IS NULL, so both can surface an SD
  * another session is mid-build on; claim_sd's 900s guard misses long-build heartbeat
  * lapses (auto_stale_takeover). Returns true to SKIP when the SD is (a) past LEAD
  * (started — current_phase != 'LEAD'; phase only advances on an ACCEPTED handoff, so this
@@ -1952,7 +1958,7 @@ async function main() {
 // top (imports are referenced directly — never re-derived).
 const CHECKIN_HELPERS = { ws, tryClaim, stampDirectedAssignment, ackMessage, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, registerRollCall, rehydrateCallsign, selfClearQuarantine, mergeCheckinModelEffort, recoverStrandedFinal, describeSoftHolds, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isBuildForbiddenSession, ensureActiveBaseline, isCriticalQfJumpEligible, tryClaimDraftCandidate, baselinedCandidateEligible, isSdInFlight, selfClaimQuickFix, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, surfaceCoordinatorMessages, fetchOutstandingSignals, formatOutstandingWarning, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, sortByDispatchRank, resolveWorkerTierRank, isTieringActive, fetchLowerTierBacklogData, ladderTopRank, seatCapabilityIsVerified, fetchFableWindowActive, claimableForTier, claimableForRepo, getCommsActivitySignals, computeAdaptiveCadence, antiWinddownDirective, ASSIGNMENT_RECENCY_WINDOW_MS, TERMINAL_CLAIM_ERRORS, QF_CANDIDATE_LIMIT, SELF_CLAIM_CANDIDATE_LIMIT, DEFAULT_IDLE_WAKEUP_SECONDS };
 
-module.exports = { ADOPTABLE_ORPHAN_STATUSES, CHECKIN_HELPERS, stampDirectedAssignment, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, describeSoftHolds, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs, carryFencedRefusals };
+module.exports = { ADOPTABLE_ORPHAN_STATUSES, CHECKIN_HELPERS, stampDirectedAssignment, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, describeSoftHolds, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs, carryFencedRefusals };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -623,7 +623,10 @@ describe('FIX-DEDUP: runCheckin skips in-flight SDs in BOTH self-claim tiers', (
     expect(r.action).toBe('self_claimed');
     expect(r.sd).toBe('SD-FRESH-002'); // the claimable-but-in-flight top candidate was skipped
   });
-  it('selfClaimDraftSd: skips a live-foreign-held draft and claims the next free one', async () => {
+  // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: retitled -- this exercises runCheckin end-to-end
+  // (the merged-pool draft self-claim path), not the removed selfClaimDraftSd function directly;
+  // the old title named a function this test's body never called even before that function's removal.
+  it('merged-pool draft self-claim: skips a live-foreign-held draft and claims the next free one', async () => {
     const sb = makeStub({ ...base,
       candidates: [],
       drafts: [

--- a/tests/unit/checkin-merged-claim-pool.test.js
+++ b/tests/unit/checkin-merged-claim-pool.test.js
@@ -56,11 +56,16 @@ describe('merged pool construction invariants (source-pinned)', () => {
     // The merged tier exists and the old sequential 6.25 call inside runCheckin is gone.
     expect(src).toMatch(/ONE merged SD pool/);
     expect(src).toMatch(/sortByDispatchRank\(sb, merged, \(x\) => x\.key\)/);
-    // selfClaimDraftSd survives as an exported wrapper but runCheckin no longer calls it.
-    const runCheckinBody = src;
-    expect(runCheckinBody).not.toMatch(/selfClaimDraftSd\(/);
     // Dedup: baselined entry wins when both pools surface one SD (seen-set built baselined-first).
-    expect(runCheckinBody).toMatch(/seen\.has\(c\.sd_id\)/);
-    expect(runCheckinBody).toMatch(/seen\.has\(d\.sd_key\)/);
+    expect(src).toMatch(/seen\.has\(c\.sd_id\)/);
+    expect(src).toMatch(/seen\.has\(d\.sd_key\)/);
+    // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: this used to assert "runCheckin no longer
+    // calls selfClaimDraftSd" by checking THIS file's text (mis-scoped -- src above is
+    // merged-pool-self-claim.cjs, not worker-checkin.cjs, so it never actually verified
+    // runCheckin's own body). selfClaimDraftSd is now confirmed removed entirely (dead code,
+    // excluded from CHECKIN_HELPERS, zero live call sites since the 2026-07-09 step-pipeline
+    // refactor) -- pin the REAL file so a future re-add of the definition is caught here.
+    const workerCheckinSrc = readFileSync(new URL('../../scripts/worker-checkin.cjs', import.meta.url), 'utf8');
+    expect(workerCheckinSrc).not.toMatch(/function selfClaimDraftSd/);
   });
 });

--- a/tests/unit/checkin-pipeline.test.js
+++ b/tests/unit/checkin-pipeline.test.js
@@ -28,6 +28,11 @@ describe('checkin step registry (lib/checkin/steps/index.cjs)', () => {
       'canary-claim-fence',
       'directed-assignment',
       'seat-busy-fence',
+      // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001: hoist {worker_tier_rank, tiering_active}
+      // into ctx.tierCtx ONCE per tick, before recover-stranded-final/adopt-orphan, so both can
+      // apply the tier axis via tierBlocks() -- previously only merged-pool-self-claim (below)
+      // computed this, too late for the two earlier lanes.
+      'tier-context',
       'recover-stranded-final',
       'adopt-orphan',
       'drain-reservations',

--- a/tests/unit/checkin/self-claim-tier-enforcement.test.js
+++ b/tests/unit/checkin/self-claim-tier-enforcement.test.js
@@ -1,0 +1,277 @@
+// SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 — the tier axis was silently inert on two live
+// acquisition lanes (recoverStrandedFinal, adoptOrphanInProgress): both called
+// classifyDispatchIneligibility(sd, {cwd}) with no worker_tier_rank/tiering_active, so a tier-2
+// seat could recover/adopt a tier-4 SD. Confirmed LIVE via traced call chain (both reachable
+// through CHECKIN_HELPERS + the lib/checkin/steps/*.cjs pipeline), unlike the originally-named
+// selfClaimDraftSd, which is confirmed dead code and removed by this SD.
+//
+// THE FIX REUSES lib/fleet/tier-claimable.cjs tierBlocks() rather than hand-threading raw
+// {worker_tier_rank, tiering_active} into classifyDispatchIneligibility: tierBlocks already
+// honors a scored SD's explicit min_tier_rank floor even when GLOBAL tiering is off (the
+// precedent SD-LEO-INFRA-BELT-CLAIMABLE-ACCURACY-FLOOR-001 established), which a raw ctx spread
+// would not provide (classifyDispatchIneligibility's tierAxes short-circuits to null the instant
+// ctx.tiering_active !== true, with no scored/unscored distinction at that gate).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRequire } from 'module';
+
+const require_ = createRequire(import.meta.url);
+const checkin = require_('../../../scripts/worker-checkin.cjs');
+const { recoverStrandedFinal, adoptOrphanInProgress } = checkin;
+const { tierBlocks } = require_('../../../lib/fleet/tier-claimable.cjs');
+
+const OLD = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+/** Same permissive chainable-stub shape as tests/unit/checkin/resume-final-reads-holds.test.js —
+ * only the rows returned for strategic_directives_v2 and whether a claim reaches claim_sd are
+ * pinned; every other table/query defaults to an empty, non-blocking result. */
+function fakeSb({ rows = [], claimed = [] }) {
+  const payloads = { strategic_directives_v2: rows };
+  const make = (table) => {
+    const b = {
+      select: () => b, eq: () => b, is: () => b, lt: () => b, gt: () => b,
+      order: () => b, limit: () => b, in: () => b, neq: () => b, not: () => b,
+      maybeSingle: async () => ({ data: null, error: null }),
+      single: async () => ({ data: null, error: null }),
+      update: () => b, insert: () => b, upsert: () => b,
+      then: (res) => res({ data: payloads[table] ?? [], error: null }),
+    };
+    return b;
+  };
+  return {
+    from: (t) => make(t),
+    rpc: async (fn, args) => {
+      if (fn === 'claim_sd') { claimed.push(args.p_sd_id); return { data: { success: true }, error: null }; }
+      return { data: null, error: null };
+    },
+  };
+}
+
+const strandedRow = (sd_key, minTierRank) => ({
+  sd_key, status: 'pending_approval', current_phase: 'LEAD_FINAL',
+  updated_at: OLD, metadata: minTierRank == null ? null : { min_tier_rank: minTierRank },
+  sd_type: 'infrastructure', target_application: 'EHG_Engineer', parent_sd_id: null,
+});
+
+const orphanRow = (sd_key, minTierRank) => ({
+  sd_key, sd_type: 'infrastructure', status: 'draft', current_phase: 'LEAD',
+  metadata: minTierRank == null ? null : { min_tier_rank: minTierRank },
+  updated_at: OLD, target_application: 'EHG_Engineer', parent_sd_id: null,
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+describe('TS-1/TS-2 — a below-rung seat is refused a tier-restricted stranded/orphaned SD (tiering active)', () => {
+  it('recoverStrandedFinal skips a tier-4 SD for a tier-2 seat', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-TIER4-001', 4)], claimed });
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: 2, tiering_active: true });
+    expect(claimed).not.toContain('SD-TIER4-001');
+    expect(r?.action).not.toBe('resume_final');
+  });
+
+  it('adoptOrphanInProgress skips a tier-4 SD for a tier-2 seat', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [orphanRow('SD-TIER4-002', 4)], claimed });
+    const r = await adoptOrphanInProgress(sb, 'sess-1', {}, { worker_tier_rank: 2, tiering_active: true });
+    expect(claimed).not.toContain('SD-TIER4-002');
+    expect(r?.action).not.toBe('resume_orphan');
+  });
+});
+
+describe('TS-3a — an UNSCORED SD stays reachable regardless of tiering state', () => {
+  it('recoverStrandedFinal recovers an unscored SD for a low-rung seat, tiering active', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-UNSCORED-001', null)], claimed });
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: 1, tiering_active: true });
+    expect(r?.action).toBe('resume_final');
+    expect(claimed).toEqual(['SD-UNSCORED-001']);
+  });
+
+  it('adoptOrphanInProgress adopts an unscored SD for a low-rung seat, tiering active', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [orphanRow('SD-UNSCORED-002', null)], claimed });
+    const r = await adoptOrphanInProgress(sb, 'sess-1', {}, { worker_tier_rank: 1, tiering_active: true });
+    expect(r?.action).toBe('resume_orphan');
+    expect(claimed).toEqual(['SD-UNSCORED-002']);
+  });
+});
+
+describe('TS-3b — a SCORED SD\'s explicit floor is honored even when GLOBAL tiering is OFF', () => {
+  // This is the precedent SD-LEO-INFRA-BELT-CLAIMABLE-ACCURACY-FLOOR-001 established for the belt
+  // gauge and the exact reason FR-2 reuses tierBlocks() instead of a raw ctx spread: a naive
+  // {worker_tier_rank, tiering_active} spread into classifyDispatchIneligibility would NOT block
+  // here, because tierAxes short-circuits to null the instant tiering_active !== true.
+  it('recoverStrandedFinal still refuses a tier-4 SD for a tier-2 seat when tiering_active=false', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-FLOOR-001', 4)], claimed });
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: 2, tiering_active: false });
+    expect(claimed).not.toContain('SD-FLOOR-001');
+    expect(r?.action).not.toBe('resume_final');
+  });
+
+  it('adoptOrphanInProgress still refuses a tier-4 SD for a tier-2 seat when tiering_active=false', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [orphanRow('SD-FLOOR-002', 4)], claimed });
+    const r = await adoptOrphanInProgress(sb, 'sess-1', {}, { worker_tier_rank: 2, tiering_active: false });
+    expect(claimed).not.toContain('SD-FLOOR-002');
+    expect(r?.action).not.toBe('resume_orphan');
+  });
+});
+
+describe('TS-4 — a SCORED SD is refused when tierCtx.worker_tier_rank is missing (fail-closed, no new axis)', () => {
+  it('recoverStrandedFinal refuses a scored SD when tierCtx carries no worker_tier_rank at all', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-NOSTAMP-001', 4)], claimed });
+    // Simulates a tier-context producer failure: ctx.tierCtx = {} (no worker_tier_rank key).
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, {});
+    expect(claimed).not.toContain('SD-NOSTAMP-001');
+    expect(r?.action).not.toBe('resume_final');
+  });
+
+  it('adoptOrphanInProgress refuses a scored SD when tierCtx carries no worker_tier_rank at all', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [orphanRow('SD-NOSTAMP-002', 4)], claimed });
+    const r = await adoptOrphanInProgress(sb, 'sess-1', {}, {});
+    expect(claimed).not.toContain('SD-NOSTAMP-002');
+    expect(r?.action).not.toBe('resume_orphan');
+  });
+
+  it('but an UNSCORED SD is unaffected by a missing tierCtx (matches TS-3a)', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-NOSTAMP-003', null)], claimed });
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, {});
+    expect(r?.action).toBe('resume_final');
+    expect(claimed).toEqual(['SD-NOSTAMP-003']);
+  });
+});
+
+describe('TS-6/TS-9 — negative control: an eligible seat is NOT over-blocked by the tier check', () => {
+  it('recoverStrandedFinal still recovers a tier-eligible stranded SD (regression guard)', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-ELIGIBLE-001', 2)], claimed });
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: 3, tiering_active: true });
+    expect(r?.action).toBe('resume_final');
+    expect(claimed).toEqual(['SD-ELIGIBLE-001']);
+  });
+
+  it('adoptOrphanInProgress still adopts a tier-eligible orphan for a higher-rung seat', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [orphanRow('SD-ELIGIBLE-002', 2)], claimed });
+    const r = await adoptOrphanInProgress(sb, 'sess-1', {}, { worker_tier_rank: 3, tiering_active: true });
+    expect(r?.action).toBe('resume_orphan');
+    expect(claimed).toEqual(['SD-ELIGIBLE-002']);
+  });
+
+  it('a seat AT its own rung claims unconditionally (minRank === workerRank falls through)', async () => {
+    const claimed = [];
+    const sb = fakeSb({ rows: [strandedRow('SD-ATRUNG-001', 2)], claimed });
+    const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: 2, tiering_active: true });
+    expect(r?.action).toBe('resume_final');
+    expect(claimed).toEqual(['SD-ATRUNG-001']);
+  });
+});
+
+describe('recoverStrandedFinal/adoptOrphanInProgress reuse tierBlocks exactly — no re-derived logic', () => {
+  // Cross-checks the two lanes against the SAME shared helper with a spread of inputs, so a
+  // future edit that reimplements the comparison inline (instead of calling tierBlocks) is caught
+  // even if it happens to get one specific case right.
+  const cases = [
+    { worker: 1, min: 4, tiering: true, blocked: true },
+    { worker: 4, min: 4, tiering: true, blocked: false },
+    { worker: 5, min: 4, tiering: true, blocked: false },
+    { worker: 1, min: 4, tiering: false, blocked: true }, // floor honored off
+    { worker: 4, min: null, tiering: true, blocked: false }, // unscored
+    { worker: undefined, min: 4, tiering: true, blocked: true }, // missing stamp, scored
+  ];
+  for (const c of cases) {
+    it(`tierBlocks(worker=${c.worker}, min=${c.min}, tiering=${c.tiering}) => blocked=${c.blocked}`, async () => {
+      const sd = strandedRow('SD-MATRIX', c.min);
+      expect(tierBlocks(sd, c.worker, c.tiering)).toBe(c.blocked);
+      const claimed = [];
+      const sb = fakeSb({ rows: [sd], claimed });
+      const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: c.worker, tiering_active: c.tiering });
+      expect(claimed.includes('SD-MATRIX')).toBe(!c.blocked);
+    });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// TS-8 — THE WIRE, NOT JUST THE ENDS. Everything above calls recoverStrandedFinal/
+// adoptOrphanInProgress directly with a hand-built tierCtx object. That proves the FUNCTIONS are
+// correct but nothing above proves ctx.tierCtx, as computed by the REAL tier-context.cjs step and
+// read by the REAL recover-stranded-final.cjs/adopt-orphan.cjs step wrappers, actually reaches
+// them through the real pipeline. Drives the REAL runSteps + REAL step modules; only
+// resolveWorkerTierRank/isTieringActive are faked (to control the input precisely without
+// replicating isTieringActive's live-fleet-counting DB query).
+describe('TS-8 — the hoisted tier-context step wires ctx.tierCtx into the real pipeline', () => {
+  const { runSteps } = require_('../../../lib/checkin/pipeline.cjs');
+  const tierContextStep = require_('../../../lib/checkin/steps/tier-context.cjs');
+  const recoverStep = require_('../../../lib/checkin/steps/recover-stranded-final.cjs');
+  const adoptStep = require_('../../../lib/checkin/steps/adopt-orphan.cjs');
+
+  async function runLadder(rows, { workerTierRank, tieringActive }) {
+    const claimed = [];
+    const ctx = {
+      sb: fakeSb({ rows, claimed }),
+      sessionId: 'sess-1',
+      base: {},
+      sessionMetadata: {},
+      helpers: {
+        recoverStrandedFinal, adoptOrphanInProgress,
+        resolveWorkerTierRank: () => workerTierRank,
+        isTieringActive: async () => tieringActive,
+      },
+    };
+    const steps = [tierContextStep, recoverStep, adoptStep];
+    const resolution = await runSteps(steps, ctx);
+    return { claimed, resolution, tierCtx: ctx.tierCtx };
+  }
+
+  it('ctx.tierCtx is populated before recover-stranded-final runs, and BLOCKS a tier-4 row for a tier-2 seat', async () => {
+    const { claimed, resolution, tierCtx } = await runLadder(
+      [strandedRow('SD-WIRE-001', 4)],
+      { workerTierRank: 2, tieringActive: true },
+    );
+    expect(tierCtx).toEqual({ worker_tier_rank: 2, tiering_active: true });
+    expect(claimed).not.toContain('SD-WIRE-001');
+    expect(resolution?.action).not.toBe('resume_final');
+  });
+
+  it('the SAME hoisted ctx.tierCtx also reaches adopt-orphan (step 9) for a tier-4 orphan', async () => {
+    const { claimed, resolution } = await runLadder(
+      [orphanRow('SD-WIRE-002', 4)],
+      { workerTierRank: 2, tieringActive: true },
+    );
+    expect(claimed).not.toContain('SD-WIRE-002');
+    expect(resolution?.action).not.toBe('resume_orphan');
+  });
+
+  it('a tier-eligible seat still reaches a real claim through the full wired ladder', async () => {
+    const { claimed, resolution } = await runLadder(
+      [strandedRow('SD-WIRE-003', 2)],
+      { workerTierRank: 3, tieringActive: true },
+    );
+    expect(resolution?.action).toBe('resume_final');
+    expect(claimed).toEqual(['SD-WIRE-003']);
+  });
+
+  it('a hoisted-producer failure (fail-open ctx.tierCtx={}) still fails CLOSED on a scored SD via tierBlocks', async () => {
+    const ctx = {
+      sb: fakeSb({ rows: [strandedRow('SD-WIRE-004', 4)] }),
+      sessionId: 'sess-1',
+      base: {},
+      sessionMetadata: {},
+      helpers: {
+        recoverStrandedFinal,
+        resolveWorkerTierRank: () => { throw new Error('producer boom'); },
+        isTieringActive: async () => true,
+      },
+    };
+    await runSteps([tierContextStep, recoverStep], ctx);
+    expect(ctx.tierCtx).toEqual({}); // the hoisted step's own fail-open contract
+  });
+});

--- a/tests/unit/checkin/self-claim-tier-enforcement.test.js
+++ b/tests/unit/checkin/self-claim-tier-enforcement.test.js
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createRequire } from 'module';
+import { readFileSync } from 'fs';
 
 const require_ = createRequire(import.meta.url);
 const checkin = require_('../../../scripts/worker-checkin.cjs');
@@ -149,6 +150,24 @@ describe('TS-4 — a SCORED SD is refused when tierCtx.worker_tier_rank is missi
   });
 });
 
+describe('TS-6 — structural guard against the identified inflight_git_state regression', () => {
+  // The risk this discriminates: a naive fix would spread merged-pool-self-claim.cjs's FULL
+  // 8-field tierCtx (which includes inflight_git_state) into recoverStrandedFinal, which would
+  // incorrectly refuse recovering a LEAD_FINAL SD whose PR is already merged -- the exact
+  // population that lane exists to recover. Source-pinned rather than scenario-simulated: the
+  // actual fix (tierBlocks(sd, workerTierRank, tieringActive), a 3-arg call) structurally cannot
+  // read inflight_git_state at all, so this proves the regression is impossible by construction,
+  // not merely untriggered by one test's fixture data.
+  it('the tierBlocks call site in worker-checkin.cjs never references inflight_git_state', () => {
+    const src = readFileSync(new URL('../../../scripts/worker-checkin.cjs', import.meta.url), 'utf8');
+    const tierBlocksCallSites = src.match(/tierBlocks\([^)]*\)/g) || [];
+    expect(tierBlocksCallSites.length).toBeGreaterThanOrEqual(2); // recoverStrandedFinal + adoptOrphanInProgress
+    for (const call of tierBlocksCallSites) {
+      expect(call).not.toMatch(/inflight_git_state/);
+    }
+  });
+});
+
 describe('TS-6/TS-9 — negative control: an eligible seat is NOT over-blocked by the tier check', () => {
   it('recoverStrandedFinal still recovers a tier-eligible stranded SD (regression guard)', async () => {
     const claimed = [];
@@ -193,7 +212,7 @@ describe('recoverStrandedFinal/adoptOrphanInProgress reuse tierBlocks exactly �
       expect(tierBlocks(sd, c.worker, c.tiering)).toBe(c.blocked);
       const claimed = [];
       const sb = fakeSb({ rows: [sd], claimed });
-      const r = await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: c.worker, tiering_active: c.tiering });
+      await recoverStrandedFinal(sb, 'sess-1', {}, { worker_tier_rank: c.worker, tiering_active: c.tiering });
       expect(claimed.includes('SD-MATRIX')).toBe(!c.blocked);
     });
   }
@@ -215,30 +234,33 @@ describe('TS-8 — the hoisted tier-context step wires ctx.tierCtx into the real
 
   async function runLadder(rows, { workerTierRank, tieringActive }) {
     const claimed = [];
+    const resolveWorkerTierRank = vi.fn(() => workerTierRank);
+    const isTieringActive = vi.fn(async () => tieringActive);
     const ctx = {
       sb: fakeSb({ rows, claimed }),
       sessionId: 'sess-1',
       base: {},
       sessionMetadata: {},
-      helpers: {
-        recoverStrandedFinal, adoptOrphanInProgress,
-        resolveWorkerTierRank: () => workerTierRank,
-        isTieringActive: async () => tieringActive,
-      },
+      helpers: { recoverStrandedFinal, adoptOrphanInProgress, resolveWorkerTierRank, isTieringActive },
     };
     const steps = [tierContextStep, recoverStep, adoptStep];
     const resolution = await runSteps(steps, ctx);
-    return { claimed, resolution, tierCtx: ctx.tierCtx };
+    return { claimed, resolution, tierCtx: ctx.tierCtx, resolveWorkerTierRank, isTieringActive };
   }
 
   it('ctx.tierCtx is populated before recover-stranded-final runs, and BLOCKS a tier-4 row for a tier-2 seat', async () => {
-    const { claimed, resolution, tierCtx } = await runLadder(
+    const { claimed, resolution, tierCtx, resolveWorkerTierRank, isTieringActive } = await runLadder(
       [strandedRow('SD-WIRE-001', 4)],
       { workerTierRank: 2, tieringActive: true },
     );
     expect(tierCtx).toEqual({ worker_tier_rank: 2, tiering_active: true });
     expect(claimed).not.toContain('SD-WIRE-001');
     expect(resolution?.action).not.toBe('resume_final');
+    // FR-1 AC-3 (relocate, not duplicate): the hoisted producer is the ONLY caller across the
+    // whole ladder run -- if recover-stranded-final or adopt-orphan resolved their own tier rank
+    // independently, these counts would exceed 1.
+    expect(resolveWorkerTierRank).toHaveBeenCalledTimes(1);
+    expect(isTieringActive).toHaveBeenCalledTimes(1);
   });
 
   it('the SAME hoisted ctx.tierCtx also reaches adopt-orphan (step 9) for a tier-4 orphan', async () => {
@@ -260,8 +282,9 @@ describe('TS-8 — the hoisted tier-context step wires ctx.tierCtx into the real
   });
 
   it('a hoisted-producer failure (fail-open ctx.tierCtx={}) still fails CLOSED on a scored SD via tierBlocks', async () => {
+    const claimed = [];
     const ctx = {
-      sb: fakeSb({ rows: [strandedRow('SD-WIRE-004', 4)] }),
+      sb: fakeSb({ rows: [strandedRow('SD-WIRE-004', 4)], claimed }),
       sessionId: 'sess-1',
       base: {},
       sessionMetadata: {},
@@ -271,7 +294,40 @@ describe('TS-8 — the hoisted tier-context step wires ctx.tierCtx into the real
         isTieringActive: async () => true,
       },
     };
-    await runSteps([tierContextStep, recoverStep], ctx);
+    const resolution = await runSteps([tierContextStep, recoverStep], ctx);
     expect(ctx.tierCtx).toEqual({}); // the hoisted step's own fail-open contract
+    // The behavioral claim in this test's title: the empty tierCtx must not read as "unrestricted" --
+    // tierBlocks(sd, undefined, undefined) still blocks a SCORED SD via tier_stamp_missing.
+    expect(claimed).not.toContain('SD-WIRE-004');
+    expect(resolution?.action).not.toBe('resume_final');
+  });
+
+  it('an unscored SD is UNAFFECTED by the same hoisted-producer failure (two-sided control)', async () => {
+    const claimed = [];
+    const ctx = {
+      sb: fakeSb({ rows: [strandedRow('SD-WIRE-005', null)], claimed }),
+      sessionId: 'sess-1',
+      base: {},
+      sessionMetadata: {},
+      helpers: {
+        recoverStrandedFinal,
+        resolveWorkerTierRank: () => { throw new Error('producer boom'); },
+        isTieringActive: async () => true,
+      },
+    };
+    const resolution = await runSteps([tierContextStep, recoverStep], ctx);
+    expect(resolution?.action).toBe('resume_final');
+    expect(claimed).toEqual(['SD-WIRE-005']);
+  });
+
+  // TR-2 (relocate, not duplicate): source-pinned, so a future edit that reintroduces a direct
+  // resolveWorkerTierRank/isTieringActive call inside merged-pool-self-claim.cjs -- instead of
+  // reading the hoisted ctx.tierCtx -- is caught even before any call-count spy would notice.
+  it('merged-pool-self-claim.cjs no longer calls resolveWorkerTierRank/isTieringActive directly', () => {
+    const src = readFileSync(new URL('../../../lib/checkin/steps/merged-pool-self-claim.cjs', import.meta.url), 'utf8');
+    expect(src).not.toMatch(/resolveWorkerTierRank\(/);
+    expect(src).not.toMatch(/isTieringActive\(/);
+    expect(src).toMatch(/ctx\.tierCtx && ctx\.tierCtx\.worker_tier_rank/);
+    expect(src).toMatch(/ctx\.tierCtx && ctx\.tierCtx\.tiering_active/);
   });
 });

--- a/tests/unit/fleet/tier-backlog-reservation.test.js
+++ b/tests/unit/fleet/tier-backlog-reservation.test.js
@@ -12,6 +12,8 @@ import { ladderTopRank } from '../../../lib/fleet/tier-ladder.cjs';
 import { idleWorkerCensusByTier, lowerTierBacklog, fetchLowerTierBacklogData } from '../../../lib/fleet/tier-backlog.cjs';
 import { classifyDispatchIneligibility } from '../../../lib/fleet/claim-eligibility.cjs';
 import { assertWorkerTierAllowed } from '../../../lib/coordinator/dispatch.cjs';
+import { tierRankVerdict } from '../../../lib/fleet/tier-ladder.cjs';
+import { readFileSync } from 'fs';
 
 const TOP = ladderTopRank();
 
@@ -308,5 +310,79 @@ describe('FR-6 both-enforcement-sites-consistent: same backlog data, same verdic
     await expect(assertWorkerTierAllowed(sb, {
       message_type: 'WORK_ASSIGNMENT', target_session: 'target-worker', payload: { assigned_sd: 'SD-LOWER-001' },
     })).rejects.toMatchObject({ code: 'DISPATCH_RESERVED_NO_LOWER_BACKLOG' });
+  });
+});
+
+// ---- SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (FR-4/TS-5): shared tier-rank predicate ----
+//
+// Before this SD, lib/fleet/claim-eligibility.cjs tierAxes and lib/coordinator/dispatch.cjs
+// assertWorkerTierAllowed independently hand-rolled the SAME minRank/workerRank comparison,
+// sharing only leaf primitives (resolveWorkerTierRank, lowerTierBacklog) — confirmed by direct
+// code read during this SD's PLAN phase, not assumed. tierAxes defensively checked
+// Number.isFinite(workerTierRank) before comparing; assertWorkerTierAllowed did not, relying
+// entirely on resolveWorkerTierRank's current contract (never returns non-finite) to stay correct
+// by coincidence rather than by its own construction. Both now delegate to tierRankVerdict
+// (lib/fleet/tier-ladder.cjs).
+describe('FR-4 tierRankVerdict — the ONE shared tier-rank predicate', () => {
+  it('unscored SD (non-finite minTierRank) -> null, regardless of workerTierRank', () => {
+    expect(tierRankVerdict(1, undefined)).toBeNull();
+    expect(tierRankVerdict(undefined, undefined)).toBeNull();
+    expect(tierRankVerdict(1, NaN)).toBeNull();
+  });
+
+  it('missing/non-finite workerTierRank on a SCORED SD -> tier_stamp_missing (fail closed)', () => {
+    expect(tierRankVerdict(undefined, 4)).toBe('tier_stamp_missing');
+    expect(tierRankVerdict(NaN, 4)).toBe('tier_stamp_missing');
+  });
+
+  it('workerTierRank below minTierRank -> above_worker_tier', () => {
+    expect(tierRankVerdict(2, 4)).toBe('above_worker_tier');
+  });
+
+  it('workerTierRank at or above minTierRank -> null (allowed)', () => {
+    expect(tierRankVerdict(4, 4)).toBeNull();
+    expect(tierRankVerdict(5, 4)).toBeNull();
+  });
+
+  // Source-pinned: proves BOTH call sites actually delegate to the shared function, not merely
+  // that their outputs happen to coincide for the cases exercised above. A future edit that
+  // reintroduces an inline `minRank > workerRank` comparison in either file, bypassing
+  // tierRankVerdict, is caught here even before any behavioral test would notice.
+  it('both claim-eligibility.cjs tierAxes and dispatch.cjs assertWorkerTierAllowed call tierRankVerdict', () => {
+    const claimEligibilitySrc = readFileSync(new URL('../../../lib/fleet/claim-eligibility.cjs', import.meta.url), 'utf8');
+    const dispatchSrc = readFileSync(new URL('../../../lib/coordinator/dispatch.cjs', import.meta.url), 'utf8');
+    expect(claimEligibilitySrc).toMatch(/tierRankVerdict\(ctx\.worker_tier_rank, minRank\)/);
+    expect(dispatchSrc).toMatch(/tierRankVerdict\(workerRank, minRank\)/);
+  });
+});
+
+describe('FR-4 above_worker_tier agreement between the two real call sites', () => {
+  // Complements the existing backlog-only agreement test above (line ~295) with the more common
+  // above_worker_tier case, reached via BOTH real entry points (not the extracted predicate in
+  // isolation) so a fail-open catch-all elsewhere in either function cannot silently swallow a
+  // block and still read green.
+  it('classifyDispatchIneligibility and assertWorkerTierAllowed both refuse the same above-tier claim', async () => {
+    const targetSession = targetWorkerSession(2);
+    const targetSd = sdRow('SD-ABOVE-001', 4);
+    const liveWorkers = [liveWorker('w-1'), targetSession];
+    const sb = stubSupabase({ liveWorkers, sds: [targetSd], targetSession, targetSd });
+
+    const selfClaimVerdict = classifyDispatchIneligibility(targetSd, { worker_tier_rank: 2, tiering_active: true });
+    expect(selfClaimVerdict).toBe('above_worker_tier');
+    await expect(assertWorkerTierAllowed(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: 'target-worker', payload: { assigned_sd: 'SD-ABOVE-001' },
+    })).rejects.toMatchObject({ code: 'DISPATCH_ABOVE_WORKER_TIER' });
+  });
+
+  it('both ALLOW the same at-or-above-tier claim (two-sided control)', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = sdRow('SD-ELIGIBLE-001', 4);
+    const liveWorkers = [liveWorker('w-1'), targetSession];
+    const sb = stubSupabase({ liveWorkers, sds: [targetSd], targetSession, targetSd });
+
+    expect(classifyDispatchIneligibility(targetSd, { worker_tier_rank: 4, tiering_active: true })).toBeNull();
+    await expect(assertWorkerTierAllowed(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: 'target-worker', payload: { assigned_sd: 'SD-ELIGIBLE-001' },
+    })).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Two live check-in functions — `recoverStrandedFinal` and `adoptOrphanInProgress` in `scripts/worker-checkin.cjs` — called the shared eligibility classifier without a `tierCtx`, so the WORK-DOWN-NEVER-UP tier invariant was silently inert on both lanes. Confirmed live: a tier-2 seat self-claimed a tier-4 SD on 2026-08-15. This closes both lanes and hardens the mechanism they were missing.

**Premise correction during LEAD**: the SD's original title/rationale attributed the incident to `selfClaimDraftSd` — confirmed during this SD's own investigation to be dead code (excluded from `CHECKIN_HELPERS`, zero live call sites, unreachable since a 2026-07-09 refactor). The real gap was on the two lanes above, both already named in the SD's own scope. `selfClaimDraftSd` is removed by this PR rather than defensively patched, since a dead-but-patched function invites exactly the kind of re-investigation this SD went through.

## What changed

- **New** `lib/checkin/steps/tier-context.cjs`: hoists `{worker_tier_rank, tiering_active}` into `ctx.tierCtx` once per check-in tick, before either fixed lane runs. `merged-pool-self-claim.cjs` now reads the same precomputed value instead of recomputing it (relocates, not duplicates, the existing DB calls).
- `recoverStrandedFinal` / `adoptOrphanInProgress` both gained a `tierBlocks()` check (`lib/fleet/tier-claimable.cjs`) rather than a raw ctx spread — `tierBlocks` already honors a scored SD's explicit floor even when global tiering is off (the `SD-LEO-INFRA-BELT-CLAIMABLE-ACCURACY-FLOOR-001` precedent), which a raw spread would not have provided.
- **New** `tierRankVerdict` (`lib/fleet/tier-ladder.cjs`): the one shared tier-rank comparison, now called by both `lib/fleet/claim-eligibility.cjs`'s `tierAxes` and `lib/coordinator/dispatch.cjs`'s `assertWorkerTierAllowed` — previously two independent, hand-rolled implementations kept in sync only by a test.
- **Real pre-existing bug found and fixed** (via this SD's own test matrix, not pre-planned): `tierBlocks`'s tiering-ON branch only checked `'above_worker_tier'`, silently discarding the `'tier_stamp_missing'` fail-closed verdict — an unstamped seat vs. a scored SD fell through unblocked whenever tiering was genuinely active.
- `selfClaimDraftSd` removed (dead code — see premise correction above); its dedicated test in `scripts/worker-checkin.test.js` was retitled rather than deleted, since its body actually drives `runCheckin`/the merged-pool path, not the removed function directly.
- Staged-only migration `database/migrations/20260816_claim_sd_tier_check.sql` adds an equivalent server-side backstop to `claim_sd` — chairman-gated, **not applied** by this PR.
- New `tests/unit/checkin/self-claim-tier-enforcement.test.js` (26 tests: block/allow/fail-closed/floor-honored-when-off/no-over-block/wiring-through-the-real-pipeline/call-count/source-pins), plus extensions to `tests/unit/fleet/tier-backlog-reservation.test.js` and `tests/unit/checkin-pipeline.test.js`.

## Test plan

- [x] `npx vitest run --project unit` on all touched/new test files — 100% pass
- [x] Full `npm run test:unit` — no regressions attributable to this change (3 pre-existing, unrelated failures in session-restore/vision-scorer/stop-hook-timing subsystems logged separately as a harness bug, feedback row `999de279`)
- [x] TESTING sub-agent (2 rounds: PLAN-phase strategy review, EXEC-phase implementation review) and SECURITY sub-agent both CONDITIONAL_PASS with no blocking conditions; all actionable findings addressed in follow-up commits (call-count spy, source-pins, migration cast-safety fix)
- [x] VALIDATION sub-agent (PLAN_VERIFY): all 7 FRs delivered, ran the full adjacent suite (173 files / 2146 tests) to confirm the `tierBlocks` fix doesn't regress `claimableForTier`'s belt rollup — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)