### PR TITLE
fix(QF-20260816-118): chairman-gated-decision-row-guard re-mint after decide (CRITICAL)

### DIFF
--- a/lib/chairman/chairman-gated-decision-row-guard.mjs
+++ b/lib/chairman/chairman-gated-decision-row-guard.mjs
@@ -21,11 +21,14 @@
  *   - No bespoke per-tick throttle: every eligible hit uses the identical envelope. Email
  *     pacing is the EXISTING, unmodified QF-20260703-905 rate cap; durable re-surfacing for
  *     anything not confirmed-sent is the EXISTING, unmodified chairman-decision-sla-sweep.mjs.
- *   - Selection exclusion (FR-1) collapses to ONE check: is there a currently-PENDING
- *     chairman_decisions row associated with this SD, found either by looking up the row
- *     metadata.chairman_decision_id points to, or by content-match (brief_data.context.sd_key
- *     / summary naming the sd_key)? A row that has since resolved (status != 'pending') does
- *     NOT exclude — a resolved decision must not permanently suppress a later re-fence.
+ *   - Selection exclusion (FR-1, widened by QF-20260816-118): is there a chairman_decisions row
+ *     STILL COVERING this SD — PENDING, or DECIDED within a 14-day re-ask interval (rowStillExcludes)
+ *     — found either by looking up the row metadata.chairman_decision_id points to, or by
+ *     content-match (brief_data.context.sd_key / summary naming the sd_key)? A DEFER/GO ruling
+ *     means the SD stays held, not "ask again next tick" (the original PENDING-only check re-minted
+ *     a new row and a new chairman email every single tick after any decision was made — QF-118).
+ *     A row past its re-ask interval does NOT exclude — a resolved decision must not permanently
+ *     suppress a later genuine re-fence.
  */
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
 import { namedDecider, isHumanActionRequested } from '../governance/human-action-decider.mjs';
@@ -36,6 +39,22 @@ import { mergeMetadataKeys } from '../coordinator/safe-metadata-merge.mjs';
 const CHAIRMAN_REASON_RX = /chairman/i;
 const MIN_AGE_MS = 24 * 60 * 60 * 1000;
 const TERMINAL_STATUSES = ['completed', 'cancelled', 'archived', 'deferred'];
+// QF-20260816-118: a DECIDED row (Adam terminalized GO/DEFER) must keep excluding its SD for a
+// bounded re-ask interval -- the ruling means "stays held", not "ask again next tick". Excluding
+// forever would reintroduce the original silent-fence bug this module exists to close, so this is
+// a window, not a permanent suppression.
+const REASK_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+/** Does this chairman_decisions row still cover its SD -- pending, or decided within the
+ *  re-ask interval? decided_by is required (not just status!=='pending') so an unrelated
+ *  metadata touch that bumps updated_at can never masquerade as a real decision. */
+function rowStillExcludes(row, now) {
+  if (!row) return false;
+  if (row.status === 'pending') return true;
+  if (!row.decided_by) return false;
+  const decidedAt = Date.parse(row.updated_at);
+  return Number.isFinite(decidedAt) && now.getTime() - decidedAt < REASK_INTERVAL_MS;
+}
 
 /** PURE: does this SD's metadata name the chairman as decider (either OR-arm)? */
 export function isChairmanGated(metadata) {
@@ -62,7 +81,11 @@ export function buildDecisionEnvelope(sd) {
     decisionType: 'session_question',
     blocking: true,
     raisedBy: 'adam',
-    recommendation: m.unfence_condition || m.adam_recommendation || 'GO/DEFER — Adam to recommend',
+    // QF-20260816-118: unfence_condition is the CONDITION under which the fence lifts, not a
+    // recommendation -- folding it into `recommendation` made the chairman-facing email read it
+    // as Adam's own advice. recommendation is Adam's actual recommendation only (or an honest
+    // "no recommendation yet" default); the condition text lives in context, clearly labeled.
+    recommendation: m.adam_recommendation || 'GO/DEFER — Adam to recommend',
     context: {
       sd_key: sd.sd_key,
       options: ['GO', 'DEFER'],
@@ -70,6 +93,7 @@ export function buildDecisionEnvelope(sd) {
       default_if_no_reply: 'DEFER',
       batch: 'chairman-gated-decision-row-guard',
       kind: 'sd_unfence_go_defer',
+      unfence_condition: m.unfence_condition || null,
     },
   };
 }
@@ -111,34 +135,40 @@ function summaryNamesSdKey(summary, sdKey) {
 }
 
 /**
- * Given a candidate SD, resolve whether a currently-PENDING chairman_decisions row is already
- * associated with it — by id-lookup (metadata.chairman_decision_id) OR content-match. Returns
- * the pending row's id if found (for backfill), null if the SD is a genuine hit. FAILS CLOSED
- * on a query error (EXEC-TO-PLAN evidence f03f1509/3f372743, TESTING-F3/SEC-F2): an earlier
- * version silently discarded query errors and proceeded as "no pending row found", which on a
- * transient DB error would mint a DUPLICATE chairman_decisions row for an SD that already has
- * one, reporting nothing. An error here means "cannot determine" — never "not excluded".
- * @returns {Promise<{ excluded: boolean, backfillId: string|null, error: string|null }>}
+ * Given a candidate SD, resolve whether an EXISTING chairman_decisions row still covers it —
+ * PENDING, or DECIDED within the re-ask interval (QF-20260816-118, rowStillExcludes) — by
+ * id-lookup (metadata.chairman_decision_id) OR content-match. Returns the covering row's id (for
+ * backfill) and, if it was decided, its decided-at timestamp (for the chairman_decision_at
+ * stamp); null/null if the SD is a genuine hit. FAILS CLOSED on a query error (EXEC-TO-PLAN
+ * evidence f03f1509/3f372743, TESTING-F3/SEC-F2): an earlier version silently discarded query
+ * errors and proceeded as "no covering row found", which on a transient DB error would mint a
+ * DUPLICATE chairman_decisions row for an SD that already has one, reporting nothing. An error
+ * here means "cannot determine" — never "not excluded".
+ * @returns {Promise<{ excluded: boolean, backfillId: string|null, decidedAt: string|null, error: string|null }>}
  */
-async function resolveExistingPendingDecision(supabase, sd) {
+async function resolveExistingPendingDecision(supabase, sd, now) {
   const stampedId = sd.metadata?.chairman_decision_id;
   if (stampedId) {
-    const { data, error } = await supabase.from('chairman_decisions').select('id, status').eq('id', stampedId).maybeSingle();
-    if (error) return { excluded: true, backfillId: null, error: `id_lookup_failed: ${error.message}` };
-    if (data?.status === 'pending') return { excluded: true, backfillId: null, error: null };
-    // stale/absent id: falls through to the content-match check below.
+    const { data, error } = await supabase.from('chairman_decisions').select('id, status, updated_at, decided_by').eq('id', stampedId).maybeSingle();
+    if (error) return { excluded: true, backfillId: null, decidedAt: null, error: `id_lookup_failed: ${error.message}` };
+    if (rowStillExcludes(data, now)) {
+      return { excluded: true, backfillId: null, decidedAt: data.status === 'pending' ? null : data.updated_at, error: null };
+    }
+    // stale/absent id, or a decided row past its re-ask interval: falls through to content-match.
   }
   const { data: byContent, error: contentError } = await supabase
     .from('chairman_decisions')
-    .select('id, status, summary, brief_data')
-    .eq('status', 'pending')
+    .select('id, status, summary, brief_data, updated_at, decided_by')
     .or(`brief_data->context->>sd_key.eq.${sd.sd_key},summary.ilike.%${sd.sd_key}%`);
-  if (contentError) return { excluded: true, backfillId: null, error: `content_match_failed: ${contentError.message}` };
+  if (contentError) return { excluded: true, backfillId: null, decidedAt: null, error: `content_match_failed: ${contentError.message}` };
   const match = (byContent || []).find(
-    (row) => row.brief_data?.context?.sd_key === sd.sd_key || summaryNamesSdKey(row.summary, sd.sd_key)
+    (row) => (row.brief_data?.context?.sd_key === sd.sd_key || summaryNamesSdKey(row.summary, sd.sd_key))
+      && rowStillExcludes(row, now)
   );
-  if (match) return { excluded: true, backfillId: stampedId === match.id ? null : match.id, error: null };
-  return { excluded: false, backfillId: null, error: null };
+  if (match) {
+    return { excluded: true, backfillId: stampedId === match.id ? null : match.id, decidedAt: match.status === 'pending' ? null : match.updated_at, error: null };
+  }
+  return { excluded: false, backfillId: null, decidedAt: null, error: null };
 }
 
 /**
@@ -171,7 +201,7 @@ export async function runChairmanGatedDecisionRowGuard(supabase, opts = {}) {
   // disproportionate to a low-probability edge case guarded by this codebase's own SD-creation
   // tooling always setting sd_key.
   for (const sd of eligible) {
-    const { excluded, backfillId, error: resolveError } = await resolveExistingPendingDecision(supabase, sd);
+    const { excluded, backfillId, decidedAt, error: resolveError } = await resolveExistingPendingDecision(supabase, sd, now);
 
     if (resolveError) {
       // FAIL CLOSED (EXEC-TO-PLAN evidence f03f1509/3f372743): a query error means "cannot
@@ -183,12 +213,18 @@ export async function runChairmanGatedDecisionRowGuard(supabase, opts = {}) {
     }
 
     if (excluded) {
-      if (backfillId) {
-        const stamp = await mergeMetadataKeys(sd.sd_key, { chairman_decision_id: backfillId });
+      // QF-20260816-118: opportunistically stamp both the (possibly-backfilled) decision id and,
+      // when the covering row was DECIDED (not merely pending), chairman_decision_at — the
+      // audit trail for the re-ask interval. One merge call when both apply.
+      const stampPatch = {};
+      if (backfillId) stampPatch.chairman_decision_id = backfillId;
+      if (decidedAt) stampPatch.chairman_decision_at = decidedAt;
+      if (Object.keys(stampPatch).length) {
+        const stamp = await mergeMetadataKeys(sd.sd_key, stampPatch);
         if (!stamp.merged) {
           errors.push({ sd_key: sd.sd_key, error: stamp.error || 'stamp_merge_failed' });
           console.error(`QUIET_TICK_CHAIRMAN_GATED_STAMP_ERROR=adam sd_key=${sd.sd_key} error="${stamp.error || 'stamp_merge_failed'}"`);
-        } else {
+        } else if (backfillId) {
           backfilled += 1;
         }
       }

--- a/tests/unit/chairman/chairman-gated-decision-row-guard-envelope.test.js
+++ b/tests/unit/chairman/chairman-gated-decision-row-guard-envelope.test.js
@@ -80,3 +80,29 @@ describe('TS-6: regression guard — the recorded envelope is durably actionable
     // ...which is exactly why buildDecisionEnvelope's own decision_type is asserted directly above, not inferred from the predicates.
   });
 });
+
+describe('QF-20260816-118 regression: unfence_condition is a CONDITION, never rendered as a recommendation', () => {
+  it('recommendation comes from adam_recommendation only — unfence_condition never appears there', () => {
+    const sd = { sd_key: 'SD-COND-001', created_at: new Date().toISOString(), metadata: { unfence_condition: 'once Q3 pricing is finalized' } };
+    const envelope = buildDecisionEnvelope(sd);
+    expect(envelope.recommendation).not.toContain('once Q3 pricing is finalized');
+    expect(envelope.recommendation).toBe('GO/DEFER — Adam to recommend'); // no adam_recommendation set -> honest default
+    expect(envelope.context.unfence_condition).toBe('once Q3 pricing is finalized');
+  });
+
+  it('adam_recommendation, when present, drives recommendation regardless of unfence_condition', () => {
+    const sd = {
+      sd_key: 'SD-COND-002', created_at: new Date().toISOString(),
+      metadata: { unfence_condition: 'once Q3 pricing is finalized', adam_recommendation: 'GO — no blockers found' },
+    };
+    const envelope = buildDecisionEnvelope(sd);
+    expect(envelope.recommendation).toBe('GO — no blockers found');
+    expect(envelope.context.unfence_condition).toBe('once Q3 pricing is finalized');
+  });
+
+  it('unfence_condition is null in context when the SD metadata does not set one', () => {
+    const sd = { sd_key: 'SD-COND-003', created_at: new Date().toISOString(), metadata: {} };
+    const envelope = buildDecisionEnvelope(sd);
+    expect(envelope.context.unfence_condition).toBeNull();
+  });
+});

--- a/tests/unit/chairman/chairman-gated-decision-row-guard.test.js
+++ b/tests/unit/chairman/chairman-gated-decision-row-guard.test.js
@@ -68,9 +68,11 @@ function makeFakeSupabase({ sds = [], decisions = [] } = {}) {
             return { data: row || null, error: null };
           },
           then: (resolve) => {
-            // status='pending' + content match handled by caller (resolveExistingPendingDecision
-            // filters client-side); return the full pending set here.
-            resolve({ data: decisions.filter((d) => d.status === 'pending'), error: null });
+            // QF-20260816-118: the real query no longer filters status server-side (a DECIDED
+            // row must also be fetchable so rowStillExcludes can honor its re-ask interval) —
+            // content match + still-excludes filtering both happen client-side in
+            // resolveExistingPendingDecision. Return every decision here, matching that shape.
+            resolve({ data: decisions, error: null });
           },
         };
         return api;
@@ -340,6 +342,80 @@ describe('TS-11: a stale chairman_decision_id (pointing to a resolved row) does 
     expect(result.hits).toBe(1);
     expect(recordPendingDecisionMock).toHaveBeenCalledTimes(1);
     expect(mergeMetadataKeysMock).toHaveBeenCalledWith('SD-REFENCE-001', { chairman_decision_id: 'dec-new' });
+  });
+});
+
+describe('QF-20260816-118 regression: a DECIDED row keeps excluding within the re-ask interval', () => {
+  it('a row decided 1 hour ago (status=deferred, decided_by set) excludes — no new row, no new email', async () => {
+    const decidedAt = new Date(NOW.getTime() - 60 * 60 * 1000).toISOString(); // 1h ago
+    const sd = sdRow({
+      sd_key: 'SD-JUST-DECIDED-001',
+      metadata: { requires_human_action: true, human_decider: 'chairman', chairman_decision_id: 'dec-decided' },
+    });
+    const sb = makeFakeSupabase({
+      sds: [sd],
+      decisions: [{ id: 'dec-decided', status: 'deferred', decided_by: 'chairman', updated_at: decidedAt }],
+    });
+
+    const result = await runChairmanGatedDecisionRowGuard(sb, { now: NOW });
+
+    expect(result.hits).toBe(0);
+    expect(recordPendingDecisionMock).not.toHaveBeenCalled();
+    // chairman_decision_at is stamped from the decided row's own updated_at (audit trail for the interval).
+    expect(mergeMetadataKeysMock).toHaveBeenCalledWith('SD-JUST-DECIDED-001', { chairman_decision_at: decidedAt });
+  });
+
+  it('a row decided 15 days ago (past the 14d re-ask interval) does NOT exclude — mints a new row', async () => {
+    const decidedAt = new Date(NOW.getTime() - 15 * 24 * 60 * 60 * 1000).toISOString(); // 15d ago
+    const sd = sdRow({
+      sd_key: 'SD-STALE-DECISION-001',
+      metadata: { requires_human_action: true, human_decider: 'chairman', chairman_decision_id: 'dec-old' },
+    });
+    recordPendingDecisionMock.mockResolvedValue({ recorded: true, id: 'dec-refresh', escalated: true });
+    const sb = makeFakeSupabase({
+      sds: [sd],
+      decisions: [{ id: 'dec-old', status: 'deferred', decided_by: 'chairman', updated_at: decidedAt }],
+    });
+
+    const result = await runChairmanGatedDecisionRowGuard(sb, { now: NOW });
+
+    expect(result.hits).toBe(1);
+    expect(recordPendingDecisionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-pending row with NO decided_by (a bare status flip, not a real decision) does NOT exclude', async () => {
+    const sd = sdRow({
+      sd_key: 'SD-NO-DECIDER-001',
+      metadata: { requires_human_action: true, human_decider: 'chairman', chairman_decision_id: 'dec-nodecider' },
+    });
+    recordPendingDecisionMock.mockResolvedValue({ recorded: true, id: 'dec-new2', escalated: true });
+    const sb = makeFakeSupabase({
+      sds: [sd],
+      decisions: [{ id: 'dec-nodecider', status: 'deferred', updated_at: NOW.toISOString() }], // no decided_by
+    });
+
+    const result = await runChairmanGatedDecisionRowGuard(sb, { now: NOW });
+
+    expect(result.hits).toBe(1);
+    expect(recordPendingDecisionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('the same decided row is found via content-match when no id is stamped (backfill still works post-decision)', async () => {
+    const decidedAt = new Date(NOW.getTime() - 60 * 60 * 1000).toISOString();
+    const sd = sdRow({ sd_key: 'SD-CONTENT-DECIDED-001' }); // no chairman_decision_id stamped
+    const sb = makeFakeSupabase({
+      sds: [sd],
+      decisions: [{
+        id: 'dec-content', status: 'deferred', decided_by: 'chairman', updated_at: decidedAt,
+        brief_data: { context: { sd_key: 'SD-CONTENT-DECIDED-001' } }, summary: '[FENCED-SD GO/DEFER SD-CONTENT-DECIDED-001]',
+      }],
+    });
+
+    const result = await runChairmanGatedDecisionRowGuard(sb, { now: NOW });
+
+    expect(result.hits).toBe(0);
+    expect(recordPendingDecisionMock).not.toHaveBeenCalled();
+    expect(mergeMetadataKeysMock).toHaveBeenCalledWith('SD-CONTENT-DECIDED-001', { chairman_decision_id: 'dec-content', chairman_decision_at: decidedAt });
   });
 });
 


### PR DESCRIPTION
## Summary
- `resolveExistingPendingDecision` only excluded on `status='pending'` — once Adam decided a row (GO/DEFER/reject), the SD's own fence metadata was untouched, so the very next probe tick found no pending row and minted a brand-new one + a new chairman email. Live-reproduced: SD `SD-LEO-INFRA-LEO-LAUNCHER-LIVE-ACTIVATION-CHECKPOINT-3-001`, decision `fab64495` decided 12:39:51Z, row `c30300df` re-minted 12:45:12Z.
- Fix: a new `rowStillExcludes(row, now)` predicate excludes on PENDING, or on DECIDED (`decided_by` set, non-pending status) within a 14-day re-ask interval measured from the row's `updated_at` (verified live: `chairman_decisions` has a `trg_chairman_decision_updated_at` trigger that genuinely bumps `updated_at` on decide, not just on insert). Applied to both the id-lookup and content-match exclusion arms. `metadata.chairman_decision_at` is now opportunistically stamped alongside `chairman_decision_id` whenever the covering row was decided, as an audit trail.
- Second defect: `buildDecisionEnvelope` folded `metadata.unfence_condition` into `recommendation`, so the chairman-facing email rendered a CONDITION as if it were Adam's own advice. Fixed: `recommendation` now comes from `metadata.adam_recommendation` only (else an honest "Adam to recommend" default); `unfence_condition` moved to `context.unfence_condition`.
- Descoped (flagged, not silently dropped, per the QF's own note): re-raising immediately when the fence *reason* changes (rather than waiting out the full 14-day interval) needs a new reason-snapshot field on the SD and is a real refinement, but isn't needed to close the CRITICAL re-mint bug — the interval-based exclusion alone fully stops the reported incident. Flagging for the SD owner as a possible follow-up QF/SD.
- Also descoped per the QF's own text: batching multiple hits into one email per sweep (volume/cap concern, not correctness) — separate from this bug.

## Test plan
- [x] All 25 pre-existing tests across the 4 chairman-gated-decision-row-guard test files still pass unmodified in behavior (only the test fixture's fake DB layer was widened to stop pre-filtering to pending-only, matching the real query's new shape)
- [x] 7 new tests: decided-row-within-interval excludes (no mint, chairman_decision_at stamped); decided-row-past-14d re-raises; a non-pending row with no `decided_by` (not a real decision) does not exclude; content-match backfill still works post-decision; `unfence_condition` never appears in `recommendation` (3 tests covering default/override/absent cases)
- [x] Cross-checked the fix against the live incident data (read-only): confirmed `chairman_decisions.updated_at` is genuinely trigger-maintained on decide, confirmed the exact SD/row ids from the bug report, confirmed my exclusion logic would have prevented the re-mint
- [x] `all-paths-producers.test.js` and `outbound-sink-conformance.test.js` (both touch this file) still pass
- [x] `schema-reference-lint --diff` clean