### PR TITLE
fix(SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001): log the tier-context producer's fail-closed fault instead of swallowing it

### DIFF
--- a/lib/checkin/steps/tier-context.cjs
+++ b/lib/checkin/steps/tier-context.cjs
@@ -23,7 +23,13 @@ module.exports = {
         worker_tier_rank: resolveWorkerTierRank({ metadata: ctx.sessionMetadata }),
         tiering_active: await isTieringActive(ctx.sb),
       };
-    } catch {
+    } catch (e) {
+      // SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001 (REGRESSION review): this fault fails EVERY
+      // scored stranded/orphan SD closed fleet-wide (tierBlocks(sd, undefined, undefined) blocks
+      // any SCORED SD) until it clears -- silent here would read as "nothing claimable" with no
+      // trail explaining why. Loud on purpose, mirroring this SD's own fail-closed-must-be-loud
+      // principle for the lanes it fixed.
+      console.log(`[tier-context] producer failed, tierCtx={} (scored SDs fail closed until this clears): ${e.message}`);
       ctx.tierCtx = {};
     }
   },


### PR DESCRIPTION
## Summary

Follow-up to #7103, which merged before this commit reached the branch (auto-merge fired against an earlier head; the commit was pushed after merge and never landed — recovered via cherry-pick onto a fresh branch off main).

REGRESSION review (PLAN_VERIFY phase of SD-LEO-INFRA-SELF-CLAIM-TIER-ENFORCEMENT-001) found `lib/checkin/steps/tier-context.cjs`'s catch branch was silent: a producer fault (`resolveWorkerTierRank`/`isTieringActive` throwing) fails every SCORED stranded/orphan SD closed fleet-wide — correct behavior, but with zero diagnostic trail an operator would see only a mysterious wave of "nothing claimable" with no indication why.

## What changed

One log line on the catch branch, naming the fault and its consequence, mirroring the same-SD's own "fail-closed must be loud" principle already applied to `recoverStrandedFinal`/`adoptOrphanInProgress`.

## Test plan

- [x] `npx vitest run --project unit tests/unit/checkin/self-claim-tier-enforcement.test.js tests/unit/checkin-pipeline.test.js tests/unit/fleet/tier-backlog-reservation.test.js` — 59/59 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)