### PR TITLE
fix(QF-20260816-723): fail-closed table-existence probe in verifyMigrationsApplied

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -58,6 +58,26 @@ export function projectGateResultsForPersistence(gateResults) {
   });
 }
 
+/**
+ * QF-20260816-723: classify a single-table existence probe result. FAIL-CLOSED — only a
+ * clean read or a definitive "table exists but unreadable" signal counts as found; any
+ * OTHER error (transient fetch-failed, RLS misconfiguration, 5xx) must not be silently
+ * read as "found", or an unapplied migration's table probe can pass by coincidence and
+ * mask the UNAPPLIED_MIGRATIONS rejection this check exists to trigger.
+ *
+ * Pure and exported for direct unit testing (no DB, no orchestrator instance needed).
+ *
+ * @param {{code?: string, message?: string}|null} error - the Supabase PostgREST error, or null
+ * @returns {'found'|'missing'|'missing_unexpected'} 'missing_unexpected' additionally warrants
+ *   a warning naming the error, since it is not a recognized not-found shape.
+ */
+export function classifyTableProbeError(error) {
+  if (!error) return 'found';
+  if (error.code === 'PGRST116' || /permission denied/i.test(error.message || '')) return 'found';
+  if (/Could not find|does not exist/i.test(error.message || '')) return 'missing';
+  return 'missing_unexpected';
+}
+
 // Domain imports
 import { getRequiredGates } from './gates.js';
 import {
@@ -1216,10 +1236,14 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
             for (const match of matches) {
               const tableName = match[1].toLowerCase();
               const { error } = await this.supabase.from(tableName).select('*').limit(0);
-              if (error && error.message.includes('Could not find')) {
-                result.missingTables.push(tableName);
-              } else {
+              const verdict = classifyTableProbeError(error);
+              if (verdict === 'found') {
                 result.foundTables.push(tableName);
+              } else {
+                result.missingTables.push(tableName);
+                if (verdict === 'missing_unexpected') {
+                  console.warn(`[LeadFinalApproval] verifyMigrationsApplied: unexpected error probing table "${tableName}", treating as missing (fail-closed): ${error.message}`);
+                }
               }
             }
           } catch (e) {

--- a/tests/unit/handoff/lead-final-verify-migrations-fail-closed.test.js
+++ b/tests/unit/handoff/lead-final-verify-migrations-fail-closed.test.js
@@ -1,0 +1,33 @@
+// QF-20260816-723 (C3 #7099 bug_002). verifyMigrationsApplied's table-existence probe
+// treated ANY non-"Could not find" error as table-exists (fail-open) — a transient
+// fetch-failed/RLS/5xx during the probe masked an unapplied migration and let the
+// UNAPPLIED_MIGRATIONS rejection be silently skipped. classifyTableProbeError is the
+// extracted, pure classification the loop now delegates to; these pin fail-closed behavior.
+import { describe, it, expect } from 'vitest';
+import { classifyTableProbeError } from '../../../scripts/modules/handoff/executors/lead-final-approval/index.js';
+
+describe('classifyTableProbeError', () => {
+  it('no error -> found', () => {
+    expect(classifyTableProbeError(null)).toBe('found');
+  });
+
+  it('PGRST116 -> found (exists, unreadable)', () => {
+    expect(classifyTableProbeError({ code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' })).toBe('found');
+  });
+
+  it('permission denied -> found (exists, unreadable)', () => {
+    expect(classifyTableProbeError({ message: 'permission denied for table foo' })).toBe('found');
+  });
+
+  it('"Could not find" -> missing', () => {
+    expect(classifyTableProbeError({ message: 'Could not find the table \'public.foo\' in the schema cache' })).toBe('missing');
+  });
+
+  it('"does not exist" -> missing', () => {
+    expect(classifyTableProbeError({ message: 'relation "foo" does not exist' })).toBe('missing');
+  });
+
+  it('unexpected error (e.g. fetch failed) -> missing_unexpected, never silently found', () => {
+    expect(classifyTableProbeError({ message: 'fetch failed' })).toBe('missing_unexpected');
+  });
+});


### PR DESCRIPTION
## Summary
- `verifyMigrationsApplied`'s table-existence probe classified ANY error whose message didn't literally contain "Could not find" as table-exists (fail-open) — a transient `fetch failed`, RLS misconfiguration, or 5xx during the probe silently masked an unapplied migration, letting an SD complete past the `UNAPPLIED_MIGRATIONS` rejection this check exists to trigger
- Extracted a pure, exported `classifyTableProbeError()`: no error → found; `PGRST116`/permission-denied → found (exists, unreadable); "Could not find"/"does not exist" → missing; any other error → missing, with a warning naming the error
- C3 #7099 bug_002

## Test plan
- [x] New unit test `tests/unit/handoff/lead-final-verify-migrations-fail-closed.test.js` covers all 6 branches (no error, PGRST116, permission denied, Could not find, does not exist, unexpected error)
- [x] Ran alongside the two nearby existing lead-final-approval test files — 19/19 passing
- [x] Diff scoped to exactly 2 files (index.js classifier extraction + new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)