### PR TITLE
fix(QF-20260816-210): HandoffRecorder score ladder — null/undefined and 0 both normalized to 100

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -88,6 +88,7 @@ import {
 import { getRemediation } from './remediations.js';
 import { clearState as clearAutoProceedState } from '../../auto-proceed-state.js';
 import { recorderIdentity, recorderIdentities } from '../../recording/HandoffRecorder.js';
+import { NOT_MEASURED_SCORE } from '../../gates/fr-delivery-classifier.js';
 import { recordSdCompleted } from '../../../../../lib/learning/outcome-tracker.js';
 // SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3: completion-boundary instrumentation
 import { stampCompletion, stampExecutionContext } from '../../../../../lib/fleet/claim-stamp.cjs';
@@ -1094,9 +1095,12 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         .order('created_at', { ascending: false })
         .limit(1);
       const srcId = lheRows && lheRows[0] ? lheRows[0].id : null;
+      const srcScoreMeasured = !!((lheRows && lheRows[0] && lheRows[0].validation_score != null)
+        || (gateResults && gateResults.actualScore != null));
       const srcScore = (lheRows && lheRows[0] && lheRows[0].validation_score != null)
         ? lheRows[0].validation_score
-        : (gateResults && gateResults.actualScore != null ? gateResults.actualScore : 100);
+        : (gateResults && gateResults.actualScore != null ? gateResults.actualScore : NOT_MEASURED_SCORE);
+      const srcScoreSource = srcScoreMeasured ? 'measured' : 'not_measured';
 
       // F1/FR-3: surface genuine retro known-issues on the resume/reconcile path too, combined
       // with (never replacing) the existing honest provenance note. combineKnownIssuesWithProvenance
@@ -1125,7 +1129,7 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
           completeness_report: { validation_score: srcScore, source: 'leo_handoff_executions' },
           validation_score: srcScore,
           validation_passed: true,
-          validation_details: { reconciled_by: 'LeadFinalApprovalExecutor already-completed path', sd_ref: 'SD-REFILL-0038AO42' },
+          validation_details: { reconciled_by: 'LeadFinalApprovalExecutor already-completed path', sd_ref: 'SD-REFILL-0038AO42', score_source: srcScoreSource },
           accepted_at: new Date().toISOString(),
           created_by: 'ADMIN_OVERRIDE',
           metadata: { canonical_reconcile_write: true, resume_path: true, source_execution_id: srcId, sd_ref: 'SD-REFILL-0038AO42' }

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -20,6 +20,7 @@ import ContentBuilder from '../content/ContentBuilder.js';
 import ValidationOrchestrator from '../validation/ValidationOrchestrator.js';
 import { withRetry, isRetryable, RETRY_PRESETS } from '../../resilience/retry-executor.js';
 import { captureFailurePattern } from '../failure-pattern-capture.js';
+import { NOT_MEASURED_SCORE } from '../gates/fr-delivery-classifier.js';
 
 /**
  * Handoff types that are COMPLETION actions, not phase transitions.
@@ -137,6 +138,7 @@ export class HandoffRecorder {
     // Use normalizedScore (weighted average) if available, otherwise calculate from totalScore/maxScore
     // This fixes the bug where summed scores (266) were being clamped to 100
     let rawScore;
+    let scoreSource = 'measured';
     if (result.normalizedScore !== undefined) {
       rawScore = result.normalizedScore;
     } else if (result.qualityScore !== undefined) {
@@ -144,11 +146,14 @@ export class HandoffRecorder {
     } else if (result.totalScore !== undefined && result.maxScore !== undefined && result.maxScore > 0) {
       rawScore = Math.round((result.totalScore / result.maxScore) * 100);
     } else {
-      rawScore = result.totalScore || 100;
+      rawScore = result.totalScore ?? NOT_MEASURED_SCORE;
+      if (result.totalScore === undefined || result.totalScore === null) {
+        scoreSource = 'not_measured';
+      }
     }
     const normalizedScore = this._normalizeValidationScore(rawScore);
 
-    console.log(`🔍 Validation score: ${rawScore}% (normalized: ${normalizedScore}%)`);
+    console.log(`🔍 Validation score: ${rawScore}% (normalized: ${normalizedScore}%, source: ${scoreSource})`);
 
     const execution = {
       id: executionId,
@@ -172,7 +177,8 @@ export class HandoffRecorder {
           warning_count: (result.warnings || []).length
         },
         verified_at: new Date().toISOString(),
-        verifier: 'unified-handoff-system.js'
+        verifier: 'unified-handoff-system.js',
+        score_source: scoreSource
       },
       accepted_at: new Date().toISOString(),
       created_by: recorderIdentity()
@@ -751,6 +757,7 @@ export class HandoffRecorder {
 
       // Use normalizedScore (weighted average) if available, otherwise calculate from totalScore/maxScore
       let rawScore;
+      let scoreSource = 'measured';
       if (result.normalizedScore !== undefined) {
         rawScore = result.normalizedScore;
       } else if (result.qualityScore !== undefined) {
@@ -758,7 +765,10 @@ export class HandoffRecorder {
       } else if (result.totalScore !== undefined && result.maxScore !== undefined && result.maxScore > 0) {
         rawScore = Math.round((result.totalScore / result.maxScore) * 100);
       } else {
-        rawScore = result.totalScore || 100;
+        rawScore = result.totalScore ?? NOT_MEASURED_SCORE;
+        if (result.totalScore === undefined || result.totalScore === null) {
+          scoreSource = 'not_measured';
+        }
       }
       const normalizedScore = this._normalizeValidationScore(rawScore);
 
@@ -898,7 +908,7 @@ export class HandoffRecorder {
         status: 'pending_acceptance', // Always start as pending, update to accepted below
         validation_score: normalizedScore,
         validation_passed: result.success !== false,
-        validation_details: result.validation || {},
+        validation_details: { ...(result.validation || {}), score_source: scoreSource },
         metadata,
         created_by: HANDOFF_SYSTEM_TAG // sd_phase_handoffs DB guard allowlists the system tag; session identity lives on leo_handoff_executions.created_by
       };

--- a/tests/unit/handoff/handoff-recorder-score-source.test.js
+++ b/tests/unit/handoff/handoff-recorder-score-source.test.js
@@ -1,0 +1,79 @@
+/**
+ * QF-20260816-210: HandoffRecorder score ladder used `result.totalScore || 100` — a
+ * legitimate totalScore:0 was indistinguishable from "not measured", and both cases
+ * silently normalized to 100 (looks like a full pass). Fixed to `?? NOT_MEASURED_SCORE`
+ * (75, shared sentinel from fr-delivery-classifier.js) and stamps
+ * validation_details.score_source so a not-measured row is never mistaken for a
+ * verified one downstream.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HandoffRecorder } from '../../../scripts/modules/handoff/recording/HandoffRecorder.js';
+import { NOT_MEASURED_SCORE } from '../../../scripts/modules/handoff/gates/fr-delivery-classifier.js';
+
+function createMockSupabase() {
+  const inserts = {};
+  function chainFor(table) {
+    const chain = {
+      select: () => chain,
+      insert: (data) => { (inserts[table] ||= []).push(data); return chain; },
+      update: () => chain,
+      delete: () => chain,
+      eq: () => chain,
+      or: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      single: () => (table === 'strategic_directives_v2'
+        ? { data: { id: 'SD-TEST-001' }, error: null }
+        : { data: null, error: null }),
+      maybeSingle: () => ({ data: null, error: null }),
+      then: (resolve) => resolve({ data: [], error: null })
+    };
+    return chain;
+  }
+  return { supabase: { from: chainFor }, inserts };
+}
+
+function newRecorder(supabase) {
+  return new HandoffRecorder(supabase, {
+    contentBuilder: { build: () => ({}), logElements: () => {} },
+    validationOrchestrator: { preValidateData: async () => ({ valid: true, errors: [] }) }
+  });
+}
+
+describe('QF-20260816-210: HandoffRecorder validation_score normalization', () => {
+  it('empty result -> NOT_MEASURED_SCORE (75), score_source=not_measured', async () => {
+    const { supabase, inserts } = createMockSupabase();
+    await newRecorder(supabase).recordSuccess('EXEC-TO-PLAN', 'SD-TEST-001', {});
+
+    const lhe = inserts.leo_handoff_executions[0];
+    expect(lhe.validation_score).toBe(NOT_MEASURED_SCORE);
+    expect(lhe.validation_details.score_source).toBe('not_measured');
+
+    const artifact = inserts.sd_phase_handoffs[0];
+    expect(artifact.validation_score).toBe(NOT_MEASURED_SCORE);
+    expect(artifact.validation_details.score_source).toBe('not_measured');
+  });
+
+  it('totalScore: 0 stays 0 (?? not ||), score_source=measured', async () => {
+    const { supabase, inserts } = createMockSupabase();
+    await newRecorder(supabase).recordSuccess('EXEC-TO-PLAN', 'SD-TEST-001', { totalScore: 0 });
+
+    const lhe = inserts.leo_handoff_executions[0];
+    expect(lhe.validation_score).toBe(0);
+    expect(lhe.validation_details.score_source).toBe('measured');
+
+    const artifact = inserts.sd_phase_handoffs[0];
+    expect(artifact.validation_score).toBe(0);
+    expect(artifact.validation_details.score_source).toBe('measured');
+  });
+
+  it('totalScore/maxScore ratio -> 80, unaffected by the sentinel fix', async () => {
+    const { supabase, inserts } = createMockSupabase();
+    await newRecorder(supabase).recordSuccess('EXEC-TO-PLAN', 'SD-TEST-001', { totalScore: 8, maxScore: 10 });
+
+    const lhe = inserts.leo_handoff_executions[0];
+    expect(lhe.validation_score).toBe(80);
+    expect(lhe.validation_details.score_source).toBe('measured');
+  });
+});

--- a/tests/unit/lfa-already-completed-reconcile.test.js
+++ b/tests/unit/lfa-already-completed-reconcile.test.js
@@ -18,6 +18,7 @@ import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { LeadFinalApprovalExecutor } from '../../scripts/modules/handoff/executors/lead-final-approval/index.js';
+import { NOT_MEASURED_SCORE } from '../../scripts/modules/handoff/gates/fr-delivery-classifier.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC = readFileSync(
@@ -82,6 +83,7 @@ describe('LFA already-completed canonical reconcile (SD-REFILL-0038AO42)', () =>
     expect(payload.created_by).toBe('ADMIN_OVERRIDE'); // completed SD => is_working_on=false => must bypass claim guard
     expect(payload.to_phase).toBe('LEAD'); // APPROVAL->LEAD coercion (CHECK-safe)
     expect(payload.validation_score).toBe(99); // sourced from accepted LHE, not the gate fallback
+    expect(payload.validation_details.score_source).toBe('measured');
     expect(payload.metadata.source_execution_id).toBe('lhe-1');
   });
 
@@ -92,13 +94,15 @@ describe('LFA already-completed canonical reconcile (SD-REFILL-0038AO42)', () =>
     expect(supabase._calls.inserts).toHaveLength(0);
   });
 
-  it('falls back to score 100 when no accepted LHE row and no gate score', async () => {
+  it('QF-20260816-210: falls back to NOT_MEASURED_SCORE (75), not 100, when no accepted LHE row and no gate score', async () => {
     const supabase = makeSupabase({ existingSph: null, lheRows: [], insertError: null });
     const exec = makeExecutor(supabase);
     await exec._reconcileCanonicalLfaRow(SD, undefined);
     expect(supabase._calls.inserts).toHaveLength(1);
-    expect(supabase._calls.inserts[0].payload.validation_score).toBe(100);
-    expect(supabase._calls.inserts[0].payload.metadata.source_execution_id).toBeNull();
+    const { payload } = supabase._calls.inserts[0];
+    expect(payload.validation_score).toBe(NOT_MEASURED_SCORE);
+    expect(payload.validation_details.score_source).toBe('not_measured');
+    expect(payload.metadata.source_execution_id).toBeNull();
   });
 
   it('is NON-FATAL: a rejected insert does not throw (verification still succeeds)', async () => {


### PR DESCRIPTION
## Summary
- Both `HandoffRecorder.js` score ladders fell back to `result.totalScore || 100`, so a genuine `totalScore: 0` and a totally empty result object both silently recorded `validation_score: 100` — a not-measured row was indistinguishable from a verified full pass.
- Same shape in `LeadFinalApprovalExecutor._reconcileCanonicalLfaRow`'s `srcScore` fallback.
- `||` → `??` so a real `0` survives; the null/undefined fallback now uses the shared `NOT_MEASURED_SCORE` sentinel (75, from `fr-delivery-classifier.js`) instead of `100`.
- Each write site now stamps `validation_details.score_source = 'measured' | 'not_measured'`.

C3 #7099 bug_008.

## Test plan
- [x] New unit test `tests/unit/handoff/handoff-recorder-score-source.test.js` exercises `recordSuccess` end-to-end (both ladders) via a mock Supabase client: `{}` → 75/`not_measured`, `{totalScore:0}` → 0/`measured`, `{totalScore:8,maxScore:10}` → 80/`measured`.
- [x] Updated `tests/unit/lfa-already-completed-reconcile.test.js`'s pre-existing "falls back to score 100" test to assert the corrected `NOT_MEASURED_SCORE` (75) + `score_source` behavior instead of pinning the old bug.
- [x] `npm run test:unit` — full suite: 3188 passed / 4 pre-existing failures (all confirmed unrelated load/timeout flakiness via isolated re-run, none touch files in this diff).
- [x] No e2e/UI surface — backend-only scoring logic, no browser-observable behavior.