### PR TITLE
feat(SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001): durable UNAVAILABLE sentinel for an unmeasurable capacity-leg run

### DIFF
--- a/database/chairman-gated/20260816_belt_capacity_verdicts_unavailable_sentinel.sql
+++ b/database/chairman-gated/20260816_belt_capacity_verdicts_unavailable_sentinel.sql
@@ -1,0 +1,128 @@
+-- SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 (FR-1) -- companion ALTER to
+-- database/chairman-gated/20260807_belt_capacity_verdicts.sql. Does NOT edit that file (migrations
+-- in this repo are append-only, matching every other family this session has touched).
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, CHAIRMAN-GATED. DO NOT RUN THIS FILE without chairman sign-off, matching the original
+-- 20260807 file's own established gating convention for this exact table.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+--
+-- THE GAP THIS CLOSES: scoreCapacityLeg (scripts/cron/drive-report-sweep.mjs) reports leg4
+-- unavailable() on ANY failure without persisting any row -- a run that could not be measured is
+-- indistinguishable from a run that was never swept. The literal fix (a verdict=UNAVAILABLE
+-- sentinel row) is blocked today: verdict is NOT NULL text CHECK'd to exactly the four real
+-- verdicts, and belt_depth/demand_soon/deficit are all NOT NULL integer.
+--
+-- WHY A SEPARATE FILE, NOT AN EDIT TO 20260807: that file is itself the historical record of what
+-- was true when this table was created (its own test, tests/unit/capacity-verdict-migration.test.js,
+-- reads it verbatim). Widening it in place would rewrite history. This file is additive-only:
+-- ADD COLUMN, widen one CHECK constraint (drop + recreate, Postgres has no in-place CHECK-widen),
+-- DROP NOT NULL on three columns. No existing row is rewritten, no existing reader's query shape
+-- changes -- verified in the $verify$ block below before COMMIT.
+--
+-- WHY 'UNAVAILABLE' NEVER JOINS VERDICTS (lib/drive-loop/score/leg4-capacity.js): VERDICTS is
+-- dual-purpose there -- persistence vocabulary AND scoreLeg4's own scoring-input guard (line 66).
+-- Admitting UNAVAILABLE into THAT list would make scoreLeg4 accept and SCORE it as 0
+-- (HEALTHY_VERDICTS=['TIGHT']), silently recreating the exact "indistinguishable from a genuine
+-- DEFICIT" defect this SD exists to close. This migration widens ONLY this table's own CHECK
+-- constraint -- a separate, narrower vocabulary that the application-side sentinel writer
+-- (scripts/lib/capacity-verdict-store.mjs, UNAVAILABLE_VERDICT) uses directly, never routed
+-- through scoreLeg4 at all.
+--
+-- ROLLBACK (manual, if needed -- see the paired _DOWN file)
+-- SEC-L1/L2 convention (this session, matching the original file and its sibling migrations):
+-- bounded lock wait, own transaction, trailing PostgREST reload so a rollback leaves the schema
+-- cache consistent with pg_catalog immediately.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+-- ============================================================
+-- 0. PRE-FLIGHT GUARD: refuse to adopt a table this migration did not expect. Mirrors the
+--    original file's own "a pre-condition must refuse to adopt a table it did not create" idiom.
+-- ============================================================
+DO $preflight$
+BEGIN
+  IF to_regclass('public.belt_capacity_verdicts') IS NULL THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: public.belt_capacity_verdicts does not exist -- apply database/chairman-gated/20260807_belt_capacity_verdicts.sql first';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'belt_capacity_verdicts' AND column_name = 'read_failed'
+  ) THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: public.belt_capacity_verdicts.read_failed already exists -- this migration has already applied';
+  END IF;
+END
+$preflight$;
+
+-- ============================================================
+-- 1. read_failed marker (FR-1). Additive, defaulted, backfills every existing row to false --
+--    every row written before this migration was, by definition, a measured run.
+-- ============================================================
+ALTER TABLE public.belt_capacity_verdicts
+  ADD COLUMN read_failed boolean NOT NULL DEFAULT false;
+
+-- ============================================================
+-- 2. Widen the verdict CHECK to also admit the sentinel value. Postgres has no ALTER CONSTRAINT
+--    to widen a CHECK in place -- drop and recreate under the SAME constraint name so nothing
+--    downstream that references the name (there is no such reference today, confirmed by Explore
+--    + validation-agent -- see PRD FR-1 evidence) needs to change.
+-- ============================================================
+ALTER TABLE public.belt_capacity_verdicts
+  DROP CONSTRAINT belt_capacity_verdicts_verdict_check;
+
+ALTER TABLE public.belt_capacity_verdicts
+  ADD CONSTRAINT belt_capacity_verdicts_verdict_check
+  CHECK (verdict IN ('DEFICIT-URGENT', 'DEFICIT', 'TIGHT', 'SURPLUS', 'UNAVAILABLE'));
+
+-- ============================================================
+-- 3. The three measurement columns cannot stay NOT NULL: a read-failure run genuinely has no
+--    belt_depth/demand_soon/deficit to report. A verdict with null measurements on this table now
+--    ALWAYS means read_failed=true (enforced by the writer, not the DB -- see FR-2), never a
+--    normal-path row silently missing data.
+-- ============================================================
+ALTER TABLE public.belt_capacity_verdicts ALTER COLUMN belt_depth DROP NOT NULL;
+ALTER TABLE public.belt_capacity_verdicts ALTER COLUMN demand_soon DROP NOT NULL;
+ALTER TABLE public.belt_capacity_verdicts ALTER COLUMN deficit DROP NOT NULL;
+
+-- ============================================================
+-- 4. Self-verify in-transaction rather than exiting green on a partial apply -- same discipline
+--    as the original file's own $verify$ block.
+-- ============================================================
+DO $verify$
+DECLARE
+  v_count int;
+BEGIN
+  IF (SELECT count(*) FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'belt_capacity_verdicts'
+        AND column_name = 'read_failed' AND data_type = 'boolean' AND is_nullable = 'NO') <> 1 THEN
+    RAISE EXCEPTION 'POSTCONDITION FAILED: read_failed is not boolean NOT NULL';
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.belt_capacity_verdicts'::regclass
+    AND conname = 'belt_capacity_verdicts_verdict_check'
+    AND pg_get_constraintdef(oid) LIKE '%DEFICIT-URGENT%'
+    AND pg_get_constraintdef(oid) LIKE '%UNAVAILABLE%';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'POSTCONDITION FAILED: belt_capacity_verdicts_verdict_check does not admit both the original four verdicts and UNAVAILABLE';
+  END IF;
+
+  IF (SELECT count(*) FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'belt_capacity_verdicts'
+        AND column_name IN ('belt_depth', 'demand_soon', 'deficit') AND is_nullable = 'YES') <> 3 THEN
+    RAISE EXCEPTION 'POSTCONDITION FAILED: belt_depth/demand_soon/deficit are not all nullable';
+  END IF;
+
+  -- Every pre-existing row backfilled read_failed=false and remains a real measured verdict.
+  IF EXISTS (SELECT 1 FROM public.belt_capacity_verdicts WHERE read_failed IS NULL) THEN
+    RAISE EXCEPTION 'POSTCONDITION FAILED: a row has read_failed IS NULL after a NOT NULL DEFAULT false backfill -- should be structurally impossible';
+  END IF;
+END
+$verify$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/database/chairman-gated/20260816_belt_capacity_verdicts_unavailable_sentinel_DOWN.sql
+++ b/database/chairman-gated/20260816_belt_capacity_verdicts_unavailable_sentinel_DOWN.sql
@@ -1,0 +1,62 @@
+-- DOWN migration for database/chairman-gated/20260816_belt_capacity_verdicts_unavailable_sentinel.sql
+-- SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, CHAIRMAN-GATED. DO NOT RUN except to reverse a completed apply of the paired UP migration.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+--
+-- ⚠️  DESTRUCTIVE ON ANY SENTINEL ROW WRITTEN SINCE THE UP MIGRATION APPLIED. Narrowing the verdict
+-- CHECK back to the original four values, and re-adding NOT NULL to belt_depth/demand_soon/deficit,
+-- will FAIL if even one row has verdict='UNAVAILABLE' or a null measurement column -- exactly the
+-- rows this SD exists to create. Those rows are the record of "this run could not be measured";
+-- their inputs were never retained anywhere and CANNOT BE RECOMPUTED after the fact (same
+-- irrecoverability the original 20260807_belt_capacity_verdicts_DOWN.sql already documents for the
+-- table as a whole).
+--
+-- BEFORE RUNNING THIS FILE: take a copy of any read_failed=true rows you want to keep --
+--   CREATE TABLE public.belt_capacity_verdicts_unavailable_backup AS
+--     SELECT * FROM public.belt_capacity_verdicts WHERE read_failed = true;
+-- -- and then either DELETE those rows or otherwise reconcile them, or this migration's own
+-- pre-flight guard below will refuse to run rather than fail with a raw constraint-violation
+-- mid-transaction.
+--
+-- WHAT HAPPENS TO leg4: nothing. scoreCapacityLeg's unavailable()-on-failure contract is
+-- unaffected by this rollback either way -- rolling back only removes the DURABLE RECORD of a
+-- past read failure, it does not change how a future read failure is scored (still unavailable(),
+-- never a fabricated DEFICIT, with or without this migration).
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+DO $preflight$
+DECLARE
+  v_sentinel_count int;
+BEGIN
+  SELECT count(*) INTO v_sentinel_count
+  FROM public.belt_capacity_verdicts
+  WHERE read_failed = true OR verdict = 'UNAVAILABLE'
+     OR belt_depth IS NULL OR demand_soon IS NULL OR deficit IS NULL;
+  IF v_sentinel_count > 0 THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: % sentinel/null-measurement row(s) exist and would be DESTROYED by narrowing this table back -- their inputs cannot be recomputed. Back them up (see this file''s header) and delete or reconcile them before re-running this rollback.', v_sentinel_count;
+  END IF;
+END
+$preflight$;
+
+ALTER TABLE public.belt_capacity_verdicts ALTER COLUMN belt_depth SET NOT NULL;
+ALTER TABLE public.belt_capacity_verdicts ALTER COLUMN demand_soon SET NOT NULL;
+ALTER TABLE public.belt_capacity_verdicts ALTER COLUMN deficit SET NOT NULL;
+
+ALTER TABLE public.belt_capacity_verdicts
+  DROP CONSTRAINT belt_capacity_verdicts_verdict_check;
+
+ALTER TABLE public.belt_capacity_verdicts
+  ADD CONSTRAINT belt_capacity_verdicts_verdict_check
+  CHECK (verdict IN ('DEFICIT-URGENT', 'DEFICIT', 'TIGHT', 'SURPLUS'));
+
+ALTER TABLE public.belt_capacity_verdicts
+  DROP COLUMN read_failed;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -164,7 +164,7 @@ export function withinWindow(nowMs) {
  * denominator rather than scoring them zero. Letting the throw escape would take the ENTIRE drive
  * report down over one leg — strictly worse than today, where leg4 is simply unavailable.
  */
-export async function scoreCapacityLeg({ gatherCapacity, persistVerdict, runId = null } = {}) {
+export async function scoreCapacityLeg({ gatherCapacity, persistVerdict, persistUnavailable = null, runId = null } = {}) {
   try {
     const inputs = await gatherCapacity();
     const computeVerdict = () => computeBeltVerdict({
@@ -225,6 +225,22 @@ export async function scoreCapacityLeg({ gatherCapacity, persistVerdict, runId =
     // unapplied, the write throws PGRST205/42P01, and leg4 reports unavailable exactly as it does
     // today. That outcome is a PASS (FR-5/TS-7), not a regression — recorded here so a later reader
     // does not "fix" it.
+    //
+    // SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 (FR-3): a failure here previously left NO durable
+    // record at all -- a run that could not be measured was indistinguishable from a run that was
+    // never swept. persistUnavailable is OPTIONAL (unlike gatherCapacity/persistVerdict above,
+    // which throw if missing) so any existing caller/test that constructs scoreCapacityLeg without
+    // it keeps behaving byte-identically. When provided, the sentinel write is BEST-EFFORT: its own
+    // try/catch means a SECONDARY failure (e.g. the migration has not applied yet) can never block
+    // returning the PRIMARY unavailable() result below -- the report's house posture (degrade to
+    // unavailable, never crash) must survive even a broken sentinel path.
+    if (typeof persistUnavailable === 'function') {
+      try {
+        await persistUnavailable({ run_id: runId, detail: { source: 'drive-report-sweep', reason: err?.message || String(err) } });
+      } catch (sentinelErr) {
+        console.error(`[scoreCapacityLeg] sentinel persist failed (non-fatal, leg still reports unavailable): ${sentinelErr?.message || sentinelErr}`);
+      }
+    }
     return { leg: LEG4_ID, unavailable: unavailable(`scoreLeg4 could not be scored this run: ${err?.message || err}`) };
   }
 }
@@ -273,7 +289,7 @@ export async function computeLeg2({ readLeg2Cohort, nowMs }) {
  * "finishing" any of them — two are traps where the obvious wiring produces a confidently wrong
  * number rather than an incomplete one.
  */
-export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, persistVerdict, capacityRunId = null, runGitLog, readLeg2Cohort, nowMs, resolveRows }) {
+export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, persistVerdict, persistUnavailable = null, capacityRunId = null, runGitLog, readLeg2Cohort, nowMs, resolveRows }) {
   // SD-LEO-INFRA-PERSIST-BELT-CAPACITY-001 (FR-3): leg4's two injections are REQUIRED here, not
   // defaulted to the real implementations. A default would make this function look wired while the
   // CLI passed nothing — which is precisely how `persist` went missing from runDriveReportSweep and
@@ -375,7 +391,7 @@ export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, 
       // SD-LEO-INFRA-DRIVE-SCORE-LEG2-001 (FR-2/FR-3/FR-5): the ranked-top-5 SNAPSHOT wiring —
       // see computeLeg2 above for the cohort-selection, window-anchor, and failure-isolation logic.
       await computeLeg2({ readLeg2Cohort, nowMs }),
-      await scoreCapacityLeg({ gatherCapacity, persistVerdict, runId: capacityRunId }),
+      await scoreCapacityLeg({ gatherCapacity, persistVerdict, persistUnavailable, runId: capacityRunId }),
     ];
 
     // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): resolve every cited row id against the table ITS OWN
@@ -482,7 +498,7 @@ if (isMainModule(import.meta.url)) {
   const { registerArmedMachinery } = await import('../../lib/machinery-class/armed-registration.js');
   // FR-3 / FR-2: leg4's two injections, resolved at the edge like every other real dependency.
   const { gatherCapacityInputs } = await import('../lib/capacity-inputs.mjs');
-  const { makeCapacityVerdictPersist } = await import('../lib/capacity-verdict-store.mjs');
+  const { makeCapacityVerdictPersist, makeCapacityVerdictUnavailablePersist } = await import('../lib/capacity-verdict-store.mjs');
 
   // BEFORE createClient, not after. This check sat below it and was unreachable dead code:
   // createClient(undefined, undefined) throws "supabaseUrl is required" first. Both orders fail
@@ -506,6 +522,9 @@ if (isMainModule(import.meta.url)) {
       computePlanCheckStatus,
       gatherCapacity: () => gatherCapacityInputs(supabase),
       persistVerdict: makeCapacityVerdictPersist(supabase),
+      // SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 (FR-3): sibling sentinel writer, called only from
+      // scoreCapacityLeg's catch block — see that function's own comment for why it is best-effort.
+      persistUnavailable: makeCapacityVerdictUnavailablePersist(supabase),
       // The SAME window key the report row is written under, so an auditor can join a verdict to
       // the report that cites it. Derived from cliNowMs, not a second clock read.
       capacityRunId: windowKey(cliNowMs),

--- a/scripts/lib/capacity-verdict-store.mjs
+++ b/scripts/lib/capacity-verdict-store.mjs
@@ -146,3 +146,61 @@ export function makeCapacityVerdictPersist(supabase, opts = {}) {
     return data;
   };
 }
+
+/**
+ * SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 (FR-2): the sentinel verdict for a run that could not be
+ * measured at all -- distinct from every real verdict in VERDICTS (lib/drive-loop/score/
+ * leg4-capacity.js). Deliberately NOT added to that list: VERDICTS is dual-purpose there
+ * (persistence vocabulary AND scoreLeg4's own scoring-input guard), so admitting this value into
+ * it would make scoreLeg4 accept and SCORE it as 0 -- silently recreating the exact
+ * "indistinguishable from a genuine DEFICIT" defect this constant exists to close. This value is
+ * only ever written by makeCapacityVerdictUnavailablePersist below, never read by scoreLeg4.
+ */
+export const UNAVAILABLE_VERDICT = 'UNAVAILABLE';
+
+/**
+ * Build the sentinel-row persist function for a leg4 run that could not be measured (FR-2/FR-3).
+ *
+ * Deliberately NOT a branch inside persistCapacityVerdict(): that function's VERDICTS.includes()
+ * and finite-number guards exist specifically so a row with null measurements can never look like
+ * a real, measured verdict (see its own header). A sentinel row's null measurements are the
+ * correct, intended shape here -- routing through the same guarded function would mean either
+ * relaxing those guards (weakening the normal path) or special-casing UNAVAILABLE inside it
+ * (coupling two callers with opposite validation needs into one function). A fully separate,
+ * narrow function keeps both contracts simple and independently reviewable.
+ *
+ * Throws on its own write failure, matching persistCapacityVerdict()'s throw-not-swallow
+ * convention -- the caller (scoreCapacityLeg's catch block) is responsible for treating this as
+ * best-effort, not this function.
+ *
+ * @param {object} supabase
+ * @param {object} [opts]
+ * @param {string} [opts.table] - override for tests
+ * @returns {(row: {run_id?: string|null, detail?: object}) => Promise<object>}
+ */
+export function makeCapacityVerdictUnavailablePersist(supabase, opts = {}) {
+  if (!supabase || typeof supabase.from !== 'function') {
+    throw new Error('makeCapacityVerdictUnavailablePersist(): a supabase client is required');
+  }
+  const table = opts.table || CAPACITY_VERDICT_TABLE;
+
+  return async function persistCapacityVerdictUnavailable(row = {}) {
+    const { run_id = null, detail = null } = row;
+
+    const { data, error } = await supabase
+      .from(table)
+      .insert({ run_id, verdict: UNAVAILABLE_VERDICT, read_failed: true, belt_depth: null, demand_soon: null, deficit: null, detail })
+      .select('id, verdict, read_failed, recorded_at')
+      .single();
+
+    if (error) {
+      const err = new Error(
+        `persistCapacityVerdictUnavailable(): durable sentinel write failed (${error.code || 'no-code'}): ${error.message}.`
+      );
+      err.code = error.code;
+      err.cause = error;
+      throw err;
+    }
+    return data;
+  };
+}

--- a/scripts/one-off/correct-prd-belt-capacity-verdicts-001.mjs
+++ b/scripts/one-off/correct-prd-belt-capacity-verdicts-001.mjs
@@ -1,0 +1,87 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const PRD_ID = 'PRD-SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001';
+
+const { data: prd, error: fetchErr } = await supabase
+  .from('product_requirements_v2')
+  .select('functional_requirements, test_scenarios')
+  .eq('id', PRD_ID)
+  .single();
+if (fetchErr) throw new Error(`fetch failed: ${fetchErr.message}`);
+
+const fr = prd.functional_requirements;
+const ts = prd.test_scenarios;
+
+// T-1 (HIGH, testing-agent evidence 20db50fc-b5aa-4194-95fe-e8bb7ca14eff): the module ALREADY
+// imports VERDICTS at top for the EXISTING persistCapacityVerdict (TR-2 forbids removing it) --
+// "never imports VERDICTS" was factually wrong. Rescope to the NEW function's own source text.
+const fr2 = fr.find((f) => f.id === 'FR-2');
+fr2.acceptance_criteria[1] =
+  "The new function's OWN source (Function.prototype.toString() on makeCapacityVerdictUnavailablePersist's returned closure, or the narrower function it delegates to) does not reference VERDICTS.includes or the finite-number guard helper -- the MODULE as a whole still imports VERDICTS for the pre-existing persistCapacityVerdict, per TR-2, so this assertion is scoped to the new function's own body, not the module's import list.";
+
+const fr5 = fr.find((f) => f.id === 'FR-5');
+fr5.description = fr5.description.replace(
+  'the function never imports VERDICTS or the finite-number guard (a static import-graph assertion',
+  "the new function's OWN source never references VERDICTS or the finite-number guard (a static source-text assertion, scoped to the new function's body -- the module itself still imports VERDICTS for the pre-existing persistCapacityVerdict, per TR-2"
+);
+fr5.acceptance_criteria[0] = fr5.acceptance_criteria[0].replace(
+  "a static assertion that the new function's source does not reference VERDICTS or the finite-number guard helper",
+  "a static assertion that the new function's OWN source text does not reference VERDICTS or the finite-number guard helper (module-level imports for the pre-existing function are out of scope for this assertion)"
+);
+// T-3 (HIGH): the SD's central invariant -- UNAVAILABLE_VERDICT must never re-enter VERDICTS --
+// was unguarded by any test. This is exactly the regression this SD's whole design exists to
+// prevent (see FR-2's description). Pin it explicitly.
+fr5.acceptance_criteria.push(
+  "A permanent regression pin: expect(VERDICTS).not.toContain(UNAVAILABLE_VERDICT) -- guards against a future edit re-introducing the exact defect FR-2 was designed to avoid (UNAVAILABLE being scored by scoreLeg4 as a 0)."
+);
+
+// T-4 (MED): TS-6's "$verify$ would abort" was unfalsifiable as stated. Rephrase to the file's
+// own established, provably-testable convention (static /POSTCONDITION FAILED/ pattern match,
+// mirroring capacity-verdict-migration.test.js's existing style for the original file).
+const ts6 = ts.find((t) => t.id === 'TS-6');
+ts6.expected =
+  'pg_constraint shows exactly 5 admitted verdict values; information_schema.columns shows the 3 measurement columns nullable and read_failed present; a pre-existing CONTROL row (inserted for this check, not assumed to already exist) is unaffected. Static: the alter migration file itself matches /POSTCONDITION FAILED/ and /PRECONDITION FAILED/ (mirroring the original file\'s own established, already-tested convention for asserting its claims in-transaction rather than exiting green on a partial apply).';
+
+// T-5 (MED): FR-1 AC-5 was vacuous if the table happened to be empty when the migration runs --
+// needs a positive CONTROL row, not an assumption one already exists.
+const fr1 = fr.find((f) => f.id === 'FR-1');
+fr1.acceptance_criteria[4] =
+  'A CONTROL row is inserted (via the normal persistCapacityVerdict() path) with a real DEFICIT/DEFICIT-URGENT/TIGHT/SURPLUS verdict BEFORE the migration applies, and is read back with identical values and identical NOT NULL-ness after the migration applies -- never assumed to already exist from other activity.';
+
+// T-7 (LOW): FR-3 AC-4's "must never reach the persist call" reads as a claim about production
+// once persistUnavailable exists there too -- narrow the wording to what the two pre-existing
+// [QF-20260816-435] tests literally assert (they construct scoreCapacityLeg WITHOUT
+// persistUnavailable, so the claim stays true of those tests specifically).
+const fr3 = fr.find((f) => f.id === 'FR-3');
+fr3.acceptance_criteria[3] =
+  "The two pre-existing [QF-20260816-435]-tagged tests in tests/unit/cron/drive-report-sweep.test.js continue to pass unmodified -- both construct scoreCapacityLeg WITHOUT persistUnavailable, so their existing assertion (persistVerdict is never called on a gather failure) remains literally true of those specific test setups.";
+
+// New TS-7: FR-2/FR-5 had NO test_scenario entry at all (testing-agent evidence
+// 20db50fc-b5aa-4194-95fe-e8bb7ca14eff) -- TS-1..3 are scoreCapacityLeg-level (FR-3), TS-4 covers
+// the OLD writer, TS-5/TS-6 cover the migration. The new writer's own insert-shape and
+// throws-on-DB-error paths need their own scenario.
+ts.push({
+  id: 'TS-7',
+  type: 'unit',
+  scenario: 'New sentinel writer (makeCapacityVerdictUnavailablePersist) in isolation',
+  expected: 'A successful call inserts {read_failed:true, verdict:UNAVAILABLE_VERDICT, belt_depth:null, demand_soon:null, deficit:null} and returns the row id; a DB error on insert throws (propagates, is not swallowed); the new function\'s own source text does not reference VERDICTS.includes or the finite-number guard helper.',
+});
+
+// New TS-8: the central-invariant regression pin (T-3), as its own scenario so it is not buried
+// inside FR-5's prose only.
+ts.push({
+  id: 'TS-8',
+  type: 'unit',
+  scenario: 'Regression pin: UNAVAILABLE_VERDICT can never re-enter VERDICTS',
+  expected: "expect(VERDICTS).not.toContain(UNAVAILABLE_VERDICT) -- if a future edit adds UNAVAILABLE to leg4-capacity.js's VERDICTS list, this test fails before scoreLeg4 can silently accept and score it as 0.",
+});
+
+const { error: updateErr } = await supabase
+  .from('product_requirements_v2')
+  .update({ functional_requirements: fr, test_scenarios: ts })
+  .eq('id', PRD_ID);
+if (updateErr) throw new Error(`update failed: ${updateErr.message}`);
+
+console.log('PRD corrected per testing-agent PLAN-phase review (evidence 20db50fc-b5aa-4194-95fe-e8bb7ca14eff).');

--- a/scripts/one-off/correct-sd-belt-capacity-verdicts-001-round2.mjs
+++ b/scripts/one-off/correct-sd-belt-capacity-verdicts-001-round2.mjs
@@ -1,0 +1,64 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_KEY = 'SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001';
+
+const { data: sd, error: fetchErr } = await supabase
+  .from('strategic_directives_v2')
+  .select('id, key_changes, risks')
+  .eq('sd_key', SD_KEY)
+  .single();
+if (fetchErr) throw new Error(`fetch failed: ${fetchErr.message}`);
+
+const keyChanges = [
+  {
+    change: 'Migration lives under database/chairman-gated/ (not database/migrations/) as a companion ALTER to the existing 20260807_belt_capacity_verdicts.sql, matching that file\'s own established gated convention for this specific table (confirmed via its own test file, tests/unit/capacity-verdict-migration.test.js, which asserts "lives under database/chairman-gated/, which is what makes it gated at all"). Adds read_failed boolean NOT NULL DEFAULT false; widens the verdict CHECK to also admit a named UNAVAILABLE_VERDICT constant (exported from capacity-verdict-store.mjs, never a bare string literal); ALTER COLUMN ... DROP NOT NULL on belt_depth, demand_soon, deficit. Ships with a paired _DOWN explicitly warning that rollback would violate the narrowed constraints against any existing UNAVAILABLE/null-measurement rows and must delete or migrate them first (same "DESTROYED / cannot be recomputed / take a backup" convention as the original file\'s own _DOWN).',
+    impact: 'Keeps this table\'s governance consistent with its own established precedent rather than introducing a lighter-weight regular migration for a table the codebase already treats as gated.',
+  },
+  {
+    change: 'Add a second, narrow write path (makeCapacityVerdictUnavailablePersist, exported alongside UNAVAILABLE_VERDICT) in scripts/lib/capacity-verdict-store.mjs -- CONFIRMED by independent LEAD-phase validation as the correct design over the alternative (widening the existing VERDICTS enum in leg4-capacity.js, the pattern the closely-related drive-state-verdict-store.cjs uses for its own analogous UNMEASURABLE case): VERDICTS is dual-purpose (persistence vocabulary AND leg4\'s own scoring-input guard at leg4-capacity.js:66) -- admitting UNAVAILABLE into it would make scoreLeg4 ACCEPT and SCORE it as 0 (HEALTHY_VERDICTS=[\'TIGHT\']), silently recreating the exact "indistinguishable from a genuine DEFICIT" defect that guard exists to prevent. A separate, narrow function that is never wired into scoreLeg4 at all avoids this entirely. Explore confirmed zero other consumers read/branch on belt_capacity_verdicts.verdict.',
+    impact: 'A read-failure run leaves a durable, queryable row without any risk of that row ever being scored as a real (and wrongly zero) capacity verdict.',
+  },
+  {
+    change: 'Wire the new persist function through scoreCapacityLeg\'s existing catch block (scripts/cron/drive-report-sweep.mjs:223-229): on any leg4 failure, best-effort call the sentinel persist (own try/catch so a failed sentinel write can never block returning the unavailable() leg, which remains the report\'s house posture) before returning.',
+    impact: 'Closes the visibility gap Solomon flagged (coordinator directive 2853569a) without changing leg4\'s scoring contract or the report\'s existing "degrade to unavailable, never to zero" posture.',
+  },
+  {
+    change: 'Extend tests/unit/capacity-verdict-migration.test.js (do NOT just add a parallel file) with a new describe block reading the NEW alter migration specifically, asserting its widened CHECK equals [...VERDICTS, UNAVAILABLE_VERDICT] and that belt_depth/demand_soon/deficit lose their NOT NULL -- the ORIGINAL file\'s own existing assertions (still true of that unmodified historical file) are left untouched. LEAD-phase validation caught that without this, the existing "CHECK must be the frozen set, no more no less" test would keep passing against the original file while the live table silently diverges to 5 admitted values -- a guard that stops observing its own subject.',
+    impact: 'Prevents the exact "guard that runs but cannot observe its subject" class of bug this session has independently encountered before -- the migration test stays a live drift-guard instead of becoming a historical-artifact check.',
+  },
+  {
+    change: 'Regression tests in tests/unit/cron/drive-report-sweep.test.js and a new describe block in tests/unit/capacity-verdict-store.test.js: a forced gatherCapacity() throw now produces exactly one belt_capacity_verdicts row with read_failed=true, verdict=UNAVAILABLE_VERDICT, null measurements, AND the leg4 result is still unavailable (never scored); a sentinel-persist failure does not prevent the unavailable() leg from being returned; the two existing [QF-20260816-435]-tagged tests asserting the EXISTING persistVerdict is never called on a gather failure continue to pass unmodified (the sentinel goes through the NEW, separate function only); the normal DEFICIT/TIGHT/SURPLUS path and persistCapacityVerdict()\'s own guards are unchanged.',
+    impact: 'Proves the fix without regressing the deliberate "throws propagate, never silently scored 0" contract this file\'s own header documents extensively, and without weakening any pre-existing pin.',
+  },
+];
+
+const risks = [
+  {
+    risk: sd.risks?.[0]?.risk || 'schema change to a live table',
+    impact: 'low',
+    likelihood: 'low',
+    mitigation: 'Additive-only DDL under database/chairman-gated/ (matching this table\'s own established gating convention, confirmed via its existing migration test file) -- ADD COLUMN, ALTER CONSTRAINT to widen, DROP NOT NULL on 3 columns. No existing row is rewritten, no existing reader\'s query shape changes. $verify$ block confirms the four original verdict values and existing rows are unaffected before COMMIT.',
+  },
+  {
+    risk: 'The pre-existing tests/unit/capacity-verdict-migration.test.js asserts the CHECK constraint is EXACTLY the frozen four values against the ORIGINAL migration file only -- shipping a separate ALTER file without extending this test would leave it passing while silently no longer describing the live schema (caught by LEAD-phase validation-agent before PRD authoring).',
+    impact: 'medium',
+    likelihood: 'high (would have happened without this LEAD-phase catch)',
+    mitigation: 'Extend the SAME test file with a new describe block for the alter migration specifically, asserting against a named UNAVAILABLE_VERDICT constant rather than a magic string, per key_changes above.',
+  },
+  {
+    risk: 'A caller reading belt_capacity_verdicts.verdict without expecting the new UNAVAILABLE value could mis-render an UNAVAILABLE row.',
+    impact: 'low',
+    likelihood: 'low',
+    mitigation: 'Explore + validation-agent both independently confirmed zero other consumers exist (17 total repo references to the table, all writers/tests/retention-config/schema-artifacts -- none read-and-branch on verdict).',
+  },
+];
+
+const { error: updateErr } = await supabase
+  .from('strategic_directives_v2')
+  .update({ key_changes: keyChanges, risks })
+  .eq('id', sd.id);
+if (updateErr) throw new Error(`update failed: ${updateErr.message}`);
+
+console.log(`Round 2 correction applied to ${SD_KEY}.`);

--- a/scripts/one-off/correct-sd-belt-capacity-verdicts-001.mjs
+++ b/scripts/one-off/correct-sd-belt-capacity-verdicts-001.mjs
@@ -1,0 +1,133 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const SD_KEY = 'SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001';
+
+const description =
+  'scoreCapacityLeg (scripts/cron/drive-report-sweep.mjs) reports leg4 unavailable() on ANY failure ' +
+  '(a gatherCapacityInputs read throw, a persist-guard throw, a re-check mismatch) without writing ' +
+  'a belt_capacity_verdicts row -- so a run that could not be measured is indistinguishable from a ' +
+  'run that was never swept at all. Verified live: belt_capacity_verdicts.verdict is NOT NULL with ' +
+  "CHECK (verdict = ANY (ARRAY['DEFICIT-URGENT','DEFICIT','TIGHT','SURPLUS'])), and belt_depth/" +
+  'demand_soon/deficit are all NOT NULL integer -- so even the literal fix (write a row with ' +
+  'verdict=UNAVAILABLE and null measurements) is blocked by schema today, forcing a migration ' +
+  '(classify-quick-fix.js\'s keyword-based schema check does not catch a DISCOVERED schema ' +
+  'necessity, only an explicitly-named one -- flagged separately as a harness-bug candidate by ' +
+  'Golf-3, not re-signaled here). Fix: (1) migration widening the verdict CHECK to admit UNAVAILABLE ' +
+  'and making belt_depth/demand_soon/deficit nullable, plus a read_failed boolean NOT NULL DEFAULT ' +
+  'false column; (2) a NEW, separate write path in capacity-verdict-store.mjs for the sentinel row ' +
+  'that does NOT go through persistCapacityVerdict()\'s frozen-verdict/finite-number guards (those ' +
+  'guards stay exactly as strict for the normal path); (3) scoreCapacityLeg\'s catch block calls the ' +
+  'new sentinel-persist (best-effort, inner try/catch, never lets a secondary write failure block ' +
+  'returning the unavailable() leg result) before returning.';
+
+const keyChanges = [
+  {
+    change: 'Migration: add read_failed boolean NOT NULL DEFAULT false to belt_capacity_verdicts; widen the verdict CHECK constraint to also admit the literal \'UNAVAILABLE\'; make belt_depth, demand_soon, deficit nullable (no measurement exists on a read-failure run).',
+    impact: 'Makes the schema able to represent "we tried to measure this run and could not" as a distinct, queryable state from every real verdict, without weakening the CHECK for the four real verdicts.',
+  },
+  {
+    change: 'Add a second, narrow write path (e.g. makeCapacityVerdictUnavailablePersist) in scripts/lib/capacity-verdict-store.mjs that inserts {run_id, verdict: \'UNAVAILABLE\', read_failed: true, belt_depth: null, demand_soon: null, deficit: null, detail} directly -- does NOT reuse persistCapacityVerdict()\'s VERDICTS.includes/finite-number guards, since those guards correctly REJECT this exact shape for the normal path and must not be relaxed.',
+    impact: 'A read-failure run now leaves a durable, queryable row instead of silently vanishing -- "how long has leg4 been unmeasurable" becomes answerable the same way "how long have we been in DEFICIT" already is.',
+  },
+  {
+    change: 'Wire the new persist function through scoreCapacityLeg\'s existing catch block (scripts/cron/drive-report-sweep.mjs:223-229): on any leg4 failure, best-effort call the sentinel persist (own try/catch so a failed sentinel write can never block returning the unavailable() leg, which remains the report\'s house posture) before returning.',
+    impact: 'Closes the visibility gap Solomon flagged (coordinator directive 2853569a) without changing leg4\'s scoring contract or the report\'s existing "degrade to unavailable, never to zero" posture.',
+  },
+  {
+    change: 'Regression tests: a forced gatherCapacity() throw now produces exactly one belt_capacity_verdicts row with read_failed=true, verdict=UNAVAILABLE, null measurements, AND the leg4 result is still unavailable (never scored); a sentinel-persist failure does not prevent the unavailable() leg from being returned; the normal DEFICIT/TIGHT/SURPLUS path is unchanged (verdict CHECK widening does not weaken the existing four-value guard).',
+    impact: 'Proves the fix without regressing the deliberate "throws propagate, never silently scored 0" contract this file\'s own header documents extensively.',
+  },
+];
+
+const successCriteria = [
+  {
+    criterion: 'A forced gatherCapacityInputs() read failure produces a persisted belt_capacity_verdicts row with read_failed=true and verdict=UNAVAILABLE (not zero rows, not a fabricated DEFICIT).',
+    measure: 'New unit test in tests/unit/cron/drive-report-sweep.test.js: inject a gatherCapacity that throws, assert exactly one row inserted via the sentinel persist mock with {read_failed:true, verdict:\'UNAVAILABLE\', belt_depth:null, demand_soon:null, deficit:null}.',
+  },
+  {
+    criterion: 'scoreCapacityLeg still returns { leg: LEG4_ID, unavailable: ... } on failure -- the sentinel write is additive, it does not change what the caller (aggregateScore) receives or how leg4 is scored.',
+    measure: 'Existing scoreCapacityLeg tests continue to pass unmodified; a new test asserts the returned shape is unchanged when persistUnavailable is (or is not) provided.',
+  },
+  {
+    criterion: 'A sentinel-persist failure (e.g. the migration has not yet been applied, or a transient DB error) never prevents scoreCapacityLeg from returning its unavailable() result -- the report must not go down over a secondary failure while recording a primary one.',
+    measure: 'New unit test: inject a persistUnavailable that itself throws, assert scoreCapacityLeg still resolves (not rejects) with the unavailable leg result.',
+  },
+  {
+    criterion: 'The normal (non-failure) DEFICIT/DEFICIT-URGENT/TIGHT/SURPLUS write path is unchanged -- the CHECK-constraint widening and new nullable columns do not weaken persistCapacityVerdict()\'s existing VERDICTS.includes/finite-number guards or alter its insert shape.',
+    measure: 'Existing capacity-verdict-store.mjs tests continue to pass unmodified; migration\'s own $verify$ block asserts the four original verdict values remain admitted and NOT NULL still holds on verdict itself.',
+  },
+];
+
+const successMetrics = [
+  {
+    metric: 'belt_capacity_verdicts rows with read_failed=true after a forced read-failure test run',
+    target: '1 (was 0 before this fix -- the exact gap this SD closes)',
+  },
+  {
+    metric: 'Pre-existing capacity-verdict-store.mjs / drive-report-sweep.mjs test suite',
+    target: '0 regressions (all pre-existing tests pass unmodified)',
+  },
+  {
+    metric: 'New regression coverage for the sentinel write path (success + secondary-failure cases)',
+    target: '>=3 new tests (sentinel-row-on-read-failure, unavailable-leg-shape-unchanged, sentinel-write-failure-does-not-block-leg-result)',
+  },
+];
+
+const risks = [
+  {
+    risk: 'The migration touches a live, currently-applied table (belt_capacity_verdicts already exists and is written to) rather than a staged/unapplied one -- unlike this session\'s other recent chairman-gated migrations, this one is additive-only (new nullable column, widened CHECK) and does not drop or narrow anything, so the blast radius on existing rows/readers is low, but it is a real schema change to a live table, not a dormant one.',
+    impact: 'low',
+    likelihood: 'low',
+    mitigation: 'Additive-only DDL (ADD COLUMN, ALTER CONSTRAINT to widen, DROP NOT NULL on 3 columns) -- no existing row is rewritten, no existing reader\'s query shape changes. Verify via $verify$ block that the four original verdict values and existing rows are unaffected before COMMIT.',
+  },
+  {
+    risk: 'A caller reading belt_capacity_verdicts.verdict without expecting the new UNAVAILABLE value (e.g. a dashboard that only branches on DEFICIT/TIGHT/SURPLUS) could mis-render an UNAVAILABLE row.',
+    impact: 'low',
+    likelihood: 'medium',
+    mitigation: 'Search for existing readers of this table before merge; the primary known reader is leg4-capacity.js\'s own VERDICTS list, which is a SEPARATE, already-correct guard (it throws on any value outside its own frozen four -- UNAVAILABLE rows are never fed back into scoreLeg4, they only ever originate from the new sentinel path, which never calls scoreLeg4).',
+  },
+];
+
+const smokeTestSteps = [
+  {
+    step_number: 1,
+    instruction: 'Run npx vitest run tests/unit/cron/drive-report-sweep.test.js tests/unit/cron/drive-report-hourly-sweep.test.js tests/unit/capacity-inputs.test.js (plus any new capacity-verdict-store unit test file)',
+    expected_outcome: 'All pre-existing tests pass unmodified, plus new tests for the sentinel-persist-on-read-failure path pass.',
+  },
+  {
+    step_number: 2,
+    instruction: 'After the migration applies, inject a gatherCapacity that throws (or temporarily point capacity-inputs at a nonexistent table) and run the drive-report-sweep cron locally',
+    expected_outcome: 'leg4 reports unavailable exactly as before (no scoring change), AND a new row appears in belt_capacity_verdicts with read_failed=true, verdict=UNAVAILABLE, belt_depth/demand_soon/deficit all null.',
+  },
+  {
+    step_number: 3,
+    instruction: 'Run the normal (healthy) drive-report-sweep path once more after step 2',
+    expected_outcome: 'A normal DEFICIT/DEFICIT-URGENT/TIGHT/SURPLUS row is written exactly as before -- the widened CHECK constraint and new nullable columns do not change the shape or values of a healthy-path row.',
+  },
+];
+
+const { data: existing, error: fetchErr } = await supabase
+  .from('strategic_directives_v2')
+  .select('id')
+  .eq('sd_key', SD_KEY)
+  .single();
+if (fetchErr) throw new Error(`fetch failed: ${fetchErr.message}`);
+
+const { error: updateErr } = await supabase
+  .from('strategic_directives_v2')
+  .update({
+    description,
+    scope: description,
+    key_changes: keyChanges,
+    success_criteria: successCriteria,
+    success_metrics: successMetrics,
+    risks,
+    smoke_test_steps: smokeTestSteps,
+  })
+  .eq('id', existing.id);
+if (updateErr) throw new Error(`update failed: ${updateErr.message}`);
+
+console.log(`Corrected ${SD_KEY} LEAD-phase fields.`);

--- a/scripts/one-off/record-mechanism-verifications-belt-capacity-verdicts-001.mjs
+++ b/scripts/one-off/record-mechanism-verifications-belt-capacity-verdicts-001.mjs
@@ -1,0 +1,84 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_KEY = 'SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001';
+
+const { data: sd, error: fetchErr } = await supabase
+  .from('strategic_directives_v2')
+  .select('id, metadata')
+  .eq('sd_key', SD_KEY)
+  .single();
+if (fetchErr) throw new Error(`fetch failed: ${fetchErr.message}`);
+
+const now = new Date().toISOString();
+const mechanismVerifications = [
+  {
+    claim: "scoreCapacityLeg's catch block returns unavailable() without persisting any row on failure",
+    verified_by: 'LEAD (direct read)',
+    verified_at: 'scripts/cron/drive-report-sweep.mjs:223-229',
+    evidence_row: null,
+  },
+  {
+    claim: 'belt_capacity_verdicts.verdict is NOT NULL text with CHECK admitting only DEFICIT-URGENT/DEFICIT/TIGHT/SURPLUS; belt_depth/demand_soon/deficit are NOT NULL integer; no read_failed column exists',
+    verified_by: 'LEAD (live DB query via pg_constraint/information_schema.columns against the consolidated project)',
+    verified_at: 'database/chairman-gated/20260807_belt_capacity_verdicts.sql',
+    evidence_row: null,
+  },
+  {
+    claim: 'persistCapacityVerdict() (capacity-verdict-store.mjs) throws on any verdict outside VERDICTS or any non-finite belt_depth/demand_soon/deficit, by deliberate, emphatically-documented design',
+    verified_by: 'LEAD (direct read)',
+    verified_at: 'scripts/lib/capacity-verdict-store.mjs:93-119',
+    evidence_row: null,
+  },
+  {
+    claim: 'VERDICTS (leg4-capacity.js) is dual-purpose: persistence vocabulary AND scoreLeg4\'s own scoring-input guard (line 66) — widening it to admit UNAVAILABLE would make scoreLeg4 accept and score it as 0 via HEALTHY_VERDICTS',
+    verified_by: 'validation-agent',
+    verified_at: 'lib/drive-loop/score/leg4-capacity.js:38,46,66',
+    evidence_row: 'a3e53f13-f1ca-4a01-88ed-024acd6fc24c',
+  },
+  {
+    claim: 'drive-state-verdict-store.cjs (explicitly modeled on capacity-verdict-store.mjs) handles its own analogous UNMEASURABLE case via a single closed-enum-widening pattern, the alternative design considered and rejected here',
+    verified_by: 'Explore',
+    verified_at: 'scripts/lib/drive-state-verdict-store.cjs',
+    evidence_row: 'b0e4acde-3f24-45ab-8f16-b9a5d2d145a9',
+  },
+  {
+    claim: 'Zero other code reads-and-branches on belt_capacity_verdicts.verdict beyond leg4-capacity.js\'s own VERDICTS guard (17 total repo references, all writers/tests/retention-config/schema-artifacts)',
+    verified_by: 'Explore + validation-agent (independently cross-checked)',
+    verified_at: 'repo-wide grep for belt_capacity_verdicts',
+    evidence_row: 'b0e4acde-3f24-45ab-8f16-b9a5d2d145a9',
+  },
+  {
+    claim: "tests/unit/capacity-verdict-migration.test.js asserts the CHECK constraint list equals EXACTLY VERDICTS against the ORIGINAL migration file only — a new companion ALTER file would leave this test passing while the live table silently diverges",
+    verified_by: 'validation-agent (LEAD-phase blocker finding), confirmed by LEAD direct read',
+    verified_at: 'tests/unit/capacity-verdict-migration.test.js:70-81',
+    evidence_row: 'a3e53f13-f1ca-4a01-88ed-024acd6fc24c',
+  },
+  {
+    claim: "tests/unit/cron/drive-report-sweep.test.js already has 2 tests tagged [QF-20260816-435] pinning that a failed gather must never call the existing persistVerdict",
+    verified_by: 'Explore',
+    verified_at: 'tests/unit/cron/drive-report-sweep.test.js:873-893',
+    evidence_row: 'b0e4acde-3f24-45ab-8f16-b9a5d2d145a9',
+  },
+  {
+    claim: 'tests/unit/capacity-verdict-store.test.js is the sole existing test file for capacity-verdict-store.mjs',
+    verified_by: 'Explore',
+    verified_at: 'tests/unit/capacity-verdict-store.test.js',
+    evidence_row: 'b0e4acde-3f24-45ab-8f16-b9a5d2d145a9',
+  },
+  {
+    claim: "classify-quick-fix.js's schema-change detection is a keyword-based text scan (forbiddenKeywords: migration, schema change, database, auth, ...) against the QF's own description text — it cannot catch a schema-touching necessity discovered only during implementation, only one the QF author already named explicitly",
+    verified_by: 'LEAD (direct read)',
+    verified_at: 'scripts/classify-quick-fix.js:36-40',
+    evidence_row: null,
+  },
+];
+
+const { error: updateErr } = await supabase
+  .from('strategic_directives_v2')
+  .update({ metadata: { ...(sd.metadata || {}), mechanism_verifications: mechanismVerifications, mechanism_verifications_recorded_at: now } })
+  .eq('id', sd.id);
+if (updateErr) throw new Error(`update failed: ${updateErr.message}`);
+
+console.log(`Recorded ${mechanismVerifications.length} mechanism_verifications for ${SD_KEY}.`);

--- a/tests/unit/capacity-verdict-migration.test.js
+++ b/tests/unit/capacity-verdict-migration.test.js
@@ -21,16 +21,20 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CAPACITY_VERDICT_TABLE } from '../../scripts/lib/capacity-verdict-store.mjs';
+import { CAPACITY_VERDICT_TABLE, UNAVAILABLE_VERDICT } from '../../scripts/lib/capacity-verdict-store.mjs';
 import { VERDICTS } from '../../lib/drive-loop/score/leg4-capacity.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const GATED_DIR = path.resolve(__dirname, '../../database/chairman-gated');
 const UP = path.join(GATED_DIR, '20260807_belt_capacity_verdicts.sql');
 const DOWN = path.join(GATED_DIR, '20260807_belt_capacity_verdicts_DOWN.sql');
+const ALTER_UP = path.join(GATED_DIR, '20260816_belt_capacity_verdicts_unavailable_sentinel.sql');
+const ALTER_DOWN = path.join(GATED_DIR, '20260816_belt_capacity_verdicts_unavailable_sentinel_DOWN.sql');
 
 const upSql = () => fs.readFileSync(UP, 'utf8');
 const downSql = () => fs.readFileSync(DOWN, 'utf8');
+const alterUpSql = () => fs.readFileSync(ALTER_UP, 'utf8');
+const alterDownSql = () => fs.readFileSync(ALTER_DOWN, 'utf8');
 
 describe('FR-1 — the migration ships staged, under the chairman gate, with a paired _DOWN', () => {
   it('lives under database/chairman-gated/, which is what makes it gated at all', () => {
@@ -105,5 +109,68 @@ describe('the DDL and the application code cannot drift apart silently', () => {
       .not.toMatch(/CREATE TABLE\s+IF NOT EXISTS\s+public\./);
     expect(sql, '[CONTROL] and the plain CREATE TABLE statement must actually be there')
       .toMatch(/CREATE TABLE\s+public\.belt_capacity_verdicts\s*\(/);
+  });
+});
+
+describe('SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 FR-4/FR-1/TS-5 — the ALTER file, composed with the original', () => {
+  // This block reads ONLY the new 20260816 alter file, never the original 20260807 file above —
+  // per FR-4's own finding (validation-agent, evidence a3e53f13-f1ca-4a01-88ed-024acd6fc24c), the
+  // original file's assertions stay true of that unmodified file forever, which is exactly why they
+  // cannot observe a drift that lives in a SEPARATE, additive file. This block is the composed check.
+
+  it('lives under database/chairman-gated/, matching the table\'s own established gated convention', () => {
+    expect(fs.existsSync(ALTER_UP), `missing staged ALTER: ${ALTER_UP}`).toBe(true);
+    expect(ALTER_UP.replace(/\\/g, '/')).toMatch(/database\/chairman-gated\//);
+  });
+
+  it('has a paired _DOWN', () => {
+    expect(fs.existsSync(ALTER_DOWN), 'a gated apply with no rollback is a one-way door').toBe(true);
+  });
+
+  it('does NOT edit the original file — additive only, same convention as every other family here', () => {
+    expect(alterUpSql()).not.toMatch(/CREATE TABLE\s+public\.belt_capacity_verdicts\s*\(/);
+  });
+
+  it('widens the verdict CHECK to admit UNAVAILABLE_VERDICT (imported constant, not a literal) IN ADDITION to the original frozen four', () => {
+    const sql = alterUpSql();
+    for (const v of [...VERDICTS, UNAVAILABLE_VERDICT]) {
+      expect(sql, `the widened CHECK is missing ${v}`).toContain(`'${v}'`);
+    }
+    const checkLine = sql.match(/CHECK \(verdict IN \(([^)]*)\)\)/);
+    expect(checkLine, 'the alter file must recreate the verdict CHECK constraint').not.toBeNull();
+    const listed = checkLine[1].match(/'([^']+)'/g).map((s) => s.replace(/'/g, ''));
+    expect(listed, 'the widened CHECK must be exactly the original four plus the sentinel — no more, no less')
+      .toEqual([...VERDICTS, UNAVAILABLE_VERDICT]);
+  });
+
+  it('drops NOT NULL on belt_depth, demand_soon, deficit — a read-failure run has no measurement to report', () => {
+    const sql = alterUpSql();
+    for (const col of ['belt_depth', 'demand_soon', 'deficit']) {
+      expect(sql, `${col} must have its NOT NULL dropped`).toMatch(new RegExp(`ALTER COLUMN\\s+${col}\\s+DROP NOT NULL`));
+    }
+  });
+
+  it('adds read_failed boolean NOT NULL DEFAULT false — every pre-existing row backfills to a real measured run', () => {
+    expect(alterUpSql()).toMatch(/ADD COLUMN\s+read_failed\s+boolean\s+NOT NULL\s+DEFAULT\s+false/i);
+  });
+
+  it('asserts its own claim in-transaction rather than exiting green on a partial apply', () => {
+    const sql = alterUpSql();
+    expect(sql).toMatch(/POSTCONDITION FAILED/);
+    expect(sql, 'a pre-condition must refuse to adopt a table this migration did not expect').toMatch(/PRECONDITION FAILED/);
+  });
+
+  it('the _DOWN warns rollback is destructive to sentinel/null-measurement rows and cannot be recomputed', () => {
+    const sql = alterDownSql();
+    expect(sql).toMatch(/DESTROYED|cannot be recomputed/i);
+    expect(sql, 'it must tell the operator to back up sentinel rows first').toMatch(/backup/i);
+  });
+
+  it('if this file is later edited to NOT widen the CHECK or NOT drop the NOT NULL constraints, this test fails', () => {
+    // Not a real edit — a same-invariant CONTROL restating the point of every assertion above: this
+    // file's own text is what the assertions above depend on, not a separately-tracked expectation.
+    const sql = alterUpSql();
+    expect(sql).toContain(`'${UNAVAILABLE_VERDICT}'`);
+    expect(sql).toMatch(/ALTER COLUMN\s+belt_depth\s+DROP NOT NULL/);
   });
 });

--- a/tests/unit/capacity-verdict-store.test.js
+++ b/tests/unit/capacity-verdict-store.test.js
@@ -19,6 +19,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   makeCapacityVerdictPersist,
+  makeCapacityVerdictUnavailablePersist,
+  UNAVAILABLE_VERDICT,
   CAPACITY_VERDICT_TABLE,
   isTableAbsentError,
   TABLE_ABSENT_CODES,
@@ -224,5 +226,67 @@ describe('CONTRACT — bound to the REAL caller, not to this file\'s idea of one
     const persist = makeCapacityVerdictPersist(client());
     await expect(persist({ verdict: 'TIGHT', runId: 'run-7', detail: {} }))
       .rejects.toThrow(/belt_depth must be a finite number/);
+  });
+});
+
+describe('SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 FR-2/FR-5/TS-7 — the sentinel writer, in isolation', () => {
+  // Deliberately NOT routed through persistCapacityVerdict()'s guards (see that function's own
+  // header and this new function's own doc comment): a sentinel row's null measurements are the
+  // CORRECT shape here, so this writer has no VERDICTS.includes / finite-number check of its own.
+
+  it('a successful call inserts read_failed=true, verdict=UNAVAILABLE_VERDICT, and null measurements', async () => {
+    const captured = {};
+    const persist = makeCapacityVerdictUnavailablePersist(client({ captured }));
+    const written = await persist({ run_id: 'run-9', detail: { source: 'drive-report-sweep', reason: 'boom' } });
+    expect(captured.row).toMatchObject({
+      run_id: 'run-9',
+      verdict: UNAVAILABLE_VERDICT,
+      read_failed: true,
+      belt_depth: null,
+      demand_soon: null,
+      deficit: null,
+    });
+    expect(written.id).toBe('row-1');
+  });
+
+  it('a DB error on insert throws — propagates, is never swallowed', async () => {
+    const persist = makeCapacityVerdictUnavailablePersist(client({ fail: { code: '42501', message: 'permission denied' } }));
+    await expect(persist({ run_id: 'run-9' })).rejects.toThrow(/durable sentinel write failed/);
+  });
+
+  it('fails at CONSTRUCTION when given no client, not at the first write', () => {
+    expect(() => makeCapacityVerdictUnavailablePersist(null)).toThrow(/supabase client is required/);
+  });
+
+  it('writes to the SAME table as the normal-path writer', async () => {
+    const captured = {};
+    await makeCapacityVerdictUnavailablePersist(client({ captured }))({ run_id: 'run-9' });
+    expect(captured.table).toBe(CAPACITY_VERDICT_TABLE);
+  });
+
+  it('[STATIC] the returned closure\'s own source never references VERDICTS.includes or the finite-number guard', () => {
+    // Scoped to the RETURNED FUNCTION's source text, not the module's import list — the module as a
+    // whole still imports VERDICTS for the pre-existing persistCapacityVerdict (TR-2), so asserting
+    // against the module's imports would be trivially false. This is a source-text check, not an
+    // import-graph one: Function.prototype.toString() on the closure itself.
+    const persist = makeCapacityVerdictUnavailablePersist(client());
+    const src = persist.toString();
+    expect(src, 'the sentinel writer must not gate on the reader\'s verdict vocabulary').not.toMatch(/VERDICTS\.includes/);
+    expect(src, 'the sentinel writer must not gate on the finite-number guard — its measurements are deliberately null').not.toMatch(/Number\.isFinite/);
+  });
+});
+
+describe('SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 TS-8 — regression pin: UNAVAILABLE_VERDICT can never re-enter VERDICTS', () => {
+  it('VERDICTS does not contain UNAVAILABLE_VERDICT', () => {
+    // If a future edit adds UNAVAILABLE to leg4-capacity.js's VERDICTS list, this fails before
+    // scoreLeg4 (leg4-capacity.js:66) can silently ACCEPT and SCORE it as 0 — the exact defect
+    // FR-2's separate-writer design exists to prevent, recreated one layer up.
+    expect(VERDICTS).not.toContain(UNAVAILABLE_VERDICT);
+  });
+
+  it('[CONTROL] UNAVAILABLE_VERDICT is a real, non-empty string distinct from every real verdict', () => {
+    expect(typeof UNAVAILABLE_VERDICT).toBe('string');
+    expect(UNAVAILABLE_VERDICT.length).toBeGreaterThan(0);
+    expect(VERDICTS).not.toContain(UNAVAILABLE_VERDICT);
   });
 });

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -1026,15 +1026,22 @@ describe('SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 FR-3 — persistUnavailable, wir
     expect(leg.unavailable.available).toBe(false);
     expect(leg.unavailable.reason).toMatch(/belt query failed/);
 
-    // [STATIC — TESTING sub-agent EXEC-TO-PLAN finding, evidence a17901cc-9e31-424f-a421-c4ac3110bba0]
+    // [STATIC — TESTING sub-agent EXEC-TO-PLAN finding, evidence a17901cc-9e31-424f-a421-c4ac3110bba0,
+    // sharpened per follow-up finding on evidence b78f71ec-3e2c-47e5-bfe4-0798780c4ca1]
     // The behavioral assertions above are BLIND to a mutated default: they pass byte-identically
     // even if `persistUnavailable = null` were replaced with a default that silently fires a write,
     // because both produce the same unavailable() return shape — mutation-verified by the sub-agent
     // (all 156 tests stayed green under that exact mutation). This pins the one thing that actually
     // distinguishes "omitted" from "a smuggled-in default": the source text of the default itself.
-    const src = fs.readFileSync(path.join(repoRoot, 'scripts', 'cron', 'drive-report-sweep.mjs'), 'utf8');
-    expect(src, 'persistUnavailable must default to null, never to a callable — a default that silently '
-      + 'fires would be invisible to every behavioral assertion above').toMatch(/persistUnavailable\s*=\s*null/);
+    //
+    // A FILE-WIDE regex was tried first and the sub-agent proved it blind too, two-sided: this file
+    // ALSO has `persistUnavailable = null` on buildGather's signature (line ~292), so mutating ONLY
+    // scoreCapacityLeg's own default still matched the file-wide pattern via the OTHER site — the
+    // exact same "assertion executes but cannot discriminate which site holds the property" shape.
+    // Scoping to scoreCapacityLeg.toString() itself closes that: it can only ever read the ONE
+    // function this test is about, immune to drift even if a third call site gains the same param.
+    expect(scoreCapacityLeg.toString(), 'persistUnavailable must default to null, never to a callable — a '
+      + 'default that silently fires would be invisible to every behavioral assertion above').toMatch(/persistUnavailable\s*=\s*null/);
   });
 });
 

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -1025,6 +1025,16 @@ describe('SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 FR-3 — persistUnavailable, wir
     const leg = await scoreCapacityLeg({ gatherCapacity, persistVerdict: okPersist([]) });
     expect(leg.unavailable.available).toBe(false);
     expect(leg.unavailable.reason).toMatch(/belt query failed/);
+
+    // [STATIC — TESTING sub-agent EXEC-TO-PLAN finding, evidence a17901cc-9e31-424f-a421-c4ac3110bba0]
+    // The behavioral assertions above are BLIND to a mutated default: they pass byte-identically
+    // even if `persistUnavailable = null` were replaced with a default that silently fires a write,
+    // because both produce the same unavailable() return shape — mutation-verified by the sub-agent
+    // (all 156 tests stayed green under that exact mutation). This pins the one thing that actually
+    // distinguishes "omitted" from "a smuggled-in default": the source text of the default itself.
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts', 'cron', 'drive-report-sweep.mjs'), 'utf8');
+    expect(src, 'persistUnavailable must default to null, never to a callable — a default that silently '
+      + 'fires would be invisible to every behavioral assertion above').toMatch(/persistUnavailable\s*=\s*null/);
   });
 });
 

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -18,7 +18,7 @@
  * NOT caught here — stated rather than papered over.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -968,6 +968,63 @@ describe('FR-3 — leg4 is injected, not declared unavailable', () => {
     );
     expect(src, 'and the citation check must actually be CALLED, not merely imported').toMatch(/await\s+verifyLegCitations\(/);
     expect(src, 'the legs array must call computeLeg2').toMatch(/await\s+computeLeg2\(/);
+  });
+});
+
+/**
+ * SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 — FR-3/TS-1/TS-2/TS-3: persistUnavailable, wired into
+ * scoreCapacityLeg's catch block. Best-effort and optional — see that function's own header
+ * comment for why a secondary sentinel failure must never be allowed to change what the caller
+ * sees, and why the legacy (no persistUnavailable) call shape must stay byte-identical.
+ */
+describe('SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 FR-3 — persistUnavailable, wired into the catch block', () => {
+  const gatherCapacity = async () => { throw new Error('belt query failed'); };
+  const okPersist = (captured) => async (row) => { captured.push(row); return { id: 'verdict-row-1' }; };
+
+  it('TS-1 — a forced gather failure, with persistUnavailable injected, writes exactly one sentinel row and still reports unavailable', async () => {
+    const sentinelCalls = [];
+    const persistVerdictCalls = [];
+    const leg = await scoreCapacityLeg({
+      gatherCapacity,
+      persistVerdict: okPersist(persistVerdictCalls),
+      persistUnavailable: async (row) => { sentinelCalls.push(row); return { id: 'sentinel-row-1' }; },
+      runId: 'drive-2026-08-16',
+    });
+
+    expect(sentinelCalls, 'exactly one sentinel write').toHaveLength(1);
+    expect(sentinelCalls[0]).toMatchObject({ run_id: 'drive-2026-08-16' });
+    expect(sentinelCalls[0].detail?.reason, 'the sentinel row must carry the real failure reason').toMatch(/belt query failed/);
+    expect(persistVerdictCalls, 'the normal-path writer must never be called on a gather failure').toHaveLength(0);
+    expect(leg.leg).toBe('leg4_capacity');
+    expect(leg.unavailable.available).toBe(false);
+    expect(leg.unavailable.reason).toMatch(/belt query failed/);
+    expect(leg.points, 'a sentinel write must never produce points').toBeUndefined();
+  });
+
+  it('TS-2 — persistUnavailable itself throwing does not propagate; scoreCapacityLeg still resolves with unavailable()', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const leg = await scoreCapacityLeg({
+        gatherCapacity,
+        persistVerdict: okPersist([]),
+        persistUnavailable: async () => { throw new Error('sentinel table not migrated yet'); },
+      });
+      expect(leg.unavailable.available).toBe(false);
+      expect(leg.unavailable.reason, 'the PRIMARY (gather) failure reason must survive the SECONDARY sentinel failure').toMatch(/belt query failed/);
+      expect(consoleErrorSpy, 'the secondary failure must be logged, not silently dropped').toHaveBeenCalled();
+      expect(consoleErrorSpy.mock.calls[0][0]).toMatch(/sentinel table not migrated yet/);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('TS-3 — scoreCapacityLeg constructed WITHOUT persistUnavailable (legacy call shape) attempts no sentinel write of any kind', async () => {
+    // Byte-identical to every pre-existing test in the FR-3 block above (none of which pass
+    // persistUnavailable and all still pass unmodified) — named explicitly here rather than left
+    // implicit across other tests' incidental omission of the parameter.
+    const leg = await scoreCapacityLeg({ gatherCapacity, persistVerdict: okPersist([]) });
+    expect(leg.unavailable.available).toBe(false);
+    expect(leg.unavailable.reason).toMatch(/belt query failed/);
   });
 });
 

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -30,7 +30,7 @@ import { CLAIM_WINDOW_MS as LEG2_CLAIM_WINDOW_MS } from '../../../lib/drive-loop
 import { armedProcessKey } from '../../../lib/machinery-class/armed-registration.js';
 import { produceDriveReport } from '../../../scripts/drive-report-produce.mjs';
 import { LAST_RUN_FIELD } from '../../../lib/drive-loop/report-posture.js';
-import { makeCapacityVerdictPersist } from '../../../scripts/lib/capacity-verdict-store.mjs';
+import { makeCapacityVerdictPersist, makeCapacityVerdictUnavailablePersist } from '../../../scripts/lib/capacity-verdict-store.mjs';
 import { gatherCapacityInputs } from '../../../scripts/lib/capacity-inputs.mjs';
 import { hourlyWindowKey } from '../../../scripts/cron/drive-report-hourly-sweep.mjs';
 
@@ -1112,6 +1112,47 @@ describe('[BOUND] scoreCapacityLeg against the REAL writer, not a stub', () => {
     });
     expect(leg.unavailable.available).toBe(false);
     expect(leg.points).toBeUndefined();
+  });
+
+  // SD-LEO-FIX-BELT-CAPACITY-VERDICTS-001 (FR-3, REAL_CALLEE_ATTESTATION): the same class of blind
+  // spot this header already records, recurring at the NEW seam if left uncovered. The [TS-1/TS-2/
+  // TS-3] block above injects only a hand-rolled persistUnavailable stub, and FR-5's coverage in
+  // capacity-verdict-store.test.js exercises makeCapacityVerdictUnavailablePersist in isolation — so
+  // nothing before this test actually ran scoreCapacityLeg against the REAL sentinel writer.
+  it('the REAL sentinel writer + scoreCapacityLeg together — not a stub on either side', async () => {
+    const captured = {};
+    const leg = await scoreCapacityLeg({
+      gatherCapacity: async () => { throw new Error('belt query failed'); },
+      persistVerdict: makeCapacityVerdictPersist(client()),
+      persistUnavailable: makeCapacityVerdictUnavailablePersist(client({ captured })),
+      runId: 'drive-2026-08-16',
+    });
+
+    expect(captured.table).toBe('belt_capacity_verdicts');
+    expect(captured.row, 'the real sentinel writer must receive exactly the shape scoreCapacityLeg sends').toMatchObject({
+      run_id: 'drive-2026-08-16', verdict: 'UNAVAILABLE', read_failed: true, belt_depth: null, demand_soon: null, deficit: null,
+    });
+    expect(leg.leg).toBe('leg4_capacity');
+    expect(leg.unavailable.available).toBe(false);
+    expect(leg.unavailable.reason).toMatch(/belt query failed/);
+    expect(leg.points, 'a sentinel write must never produce points').toBeUndefined();
+  });
+
+  it('[MUTATION GUARD] a real sentinel-write failure is logged but never blocks the primary unavailable() result', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const leg = await scoreCapacityLeg({
+        gatherCapacity: async () => { throw new Error('belt query failed'); },
+        persistVerdict: makeCapacityVerdictPersist(client()),
+        persistUnavailable: makeCapacityVerdictUnavailablePersist(client({ fail: { code: '42501', message: 'permission denied' } })),
+        runId: 'drive-2026-08-16',
+      });
+      expect(leg.unavailable.available).toBe(false);
+      expect(leg.unavailable.reason).toMatch(/belt query failed/);
+      expect(consoleErrorSpy, 'a real sentinel-write failure must still be logged, not silently dropped').toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

scoreCapacityLeg (`scripts/cron/drive-report-sweep.mjs`) reported leg4 `unavailable()` on ANY gather/persist failure without writing any row — a run that could not be measured was indistinguishable from a run that was never swept.

- **FR-1**: staged, chairman-gated ALTER migration widening `belt_capacity_verdicts`' verdict CHECK to admit `UNAVAILABLE` (companion to `20260807_belt_capacity_verdicts.sql`, additive-only) and dropping `NOT NULL` on `belt_depth`/`demand_soon`/`deficit`, with a paired `_DOWN`.
- **FR-2**: new, separate `makeCapacityVerdictUnavailablePersist` writer in `capacity-verdict-store.mjs`. Deliberately NOT routed through `persistCapacityVerdict()`'s `VERDICTS.includes`/finite-number guards, and `UNAVAILABLE_VERDICT` is deliberately NOT added to `leg4-capacity.js`'s `VERDICTS` list — that list is dual-purpose there (also `scoreLeg4`'s own scoring-input guard), so admitting it would make `scoreLeg4` accept and SCORE it as 0, silently recreating the exact defect this SD closes one layer down.
- **FR-3**: `persistUnavailable` wired into `scoreCapacityLeg`'s catch block as an OPTIONAL, best-effort sentinel write — a secondary failure there can never block returning the primary `unavailable()` result, and the legacy no-`persistUnavailable` call shape stays byte-identical.
- **FR-4/FR-5**: extended (not duplicated) the existing migration drift-guard and writer test files, plus a permanent regression pin (`VERDICTS` must never contain `UNAVAILABLE_VERDICT`).

PRD corrected mid-PLAN by testing-agent review (evidence `20db50fc-b5aa-4194-95fe-e8bb7ca14eff`): rescoped two assertions from module-imports to the new function's own source text, added the missing regression pin, and replaced two unfalsifiable acceptance criteria with provable static-pattern-match / CONTROL-row conventions.

### PR size justification

829 LOC total — 467 LOC application code + tests, plus 368 LOC of LEAD/PLAN-phase one-off SD/PRD correction scripts kept as audit trail (`scripts/one-off/*`). The 5 FRs are tightly coupled: FR-1 without FR-2/FR-3 ships an unused column, FR-2/FR-3 without FR-1 have no schema to write to. No subset ships independently without leaving either dead schema or an untested path.

### Migration ceremony note

`database/chairman-gated/20260816_belt_capacity_verdicts_unavailable_sentinel.sql` is **staged, not applied** — requires chairman sign-off per this table's own established gated convention (matching the original `20260807_belt_capacity_verdicts.sql`). Until applied, `scoreCapacityLeg`'s sentinel write attempt fails closed with `PGRST205`/`42P01` (table-absent), caught by FR-3's own best-effort try/catch, and the leg continues reporting `unavailable()` exactly as it does today — a PASS, not a regression (see FR-2/TS-7 in the PRD).

## Test plan

- [x] `tests/unit/cron/drive-report-sweep.test.js` — 0 regressions, new FR-3/TS-1/TS-2/TS-3 coverage
- [x] `tests/unit/capacity-verdict-store.test.js` — 0 regressions, new FR-2/FR-5/TS-7 + TS-8 regression-pin coverage
- [x] `tests/unit/capacity-verdict-migration.test.js` — 0 regressions, new FR-4/TS-5 composed-schema coverage
- [x] `tests/unit/cron/drive-report-hourly-sweep.test.js` — 0 regressions
- [x] `tests/unit/capacity-inputs.test.js` — 0 regressions
- [x] 156 tests pass total across the named regression surface
- [x] `npm run schema:lint` (--diff) — 0 new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)