### PR TITLE
ceremony(2026-08-16): chairman approval stamps on the 13 applied DDL files

### DIFF
--- a/database/chairman-gated/20260803_session_coordination_scope_anon_reads.sql
+++ b/database/chairman-gated/20260803_session_coordination_scope_anon_reads.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on Group 5 at terminal, 2026-08-16 ceremony)
 -- SD-LEO-INFRA-COORDINATION-BUS-ACCESS-001 (FR-1)
 -- Scope anon reads off the coordination bus.
 --

--- a/database/chairman-gated/20260804_ai_quality_tuning_symmetric_guards.sql
+++ b/database/chairman-gated/20260804_ai_quality_tuning_symmetric_guards.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on Group 4 at terminal, 2026-08-16 ceremony)
 -- SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001 — FR-3: give the tuner symmetric guards.
 -- CHAIRMAN-GATED. The builder STAGES; the chairman APPLIES. Do not self-apply, including inside a
 -- transaction that is rolled back — an apply attempt against a gated object is still an apply attempt.

--- a/database/chairman-gated/20260812_venture_ingest_key_binding.sql
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on the G6 trio at terminal, 2026-08-16 ceremony)
 -- SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 — per-venture secret-bound ingest RPCs
 --
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════

--- a/database/chairman-gated/20260812_venture_operating_burn_tenant_predicate.sql
+++ b/database/chairman-gated/20260812_venture_operating_burn_tenant_predicate.sql
@@ -12,7 +12,7 @@
 -- chairman-gated ceremony below, per this repo's separation-of-duties convention (worker authors
 -- and stages; the chairman's own terminal, under his own git identity, performs the apply).
 --
--- @approved-by: <unfilled -- set by the chairman's own apply session, matching his git user.email,
+-- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony)
 --                per apply-migration.js's self-consistency check (header email == invoker's git
 --                email + a matching, unconsumed, <1h MIGRATION_APPLY_TOKEN). This file does not
 --                apply itself.>

--- a/database/chairman-gated/20260812_venture_operating_burn_tenant_predicate.sql
+++ b/database/chairman-gated/20260812_venture_operating_burn_tenant_predicate.sql
@@ -12,7 +12,8 @@
 -- chairman-gated ceremony below, per this repo's separation-of-duties convention (worker authors
 -- and stages; the chairman's own terminal, under his own git identity, performs the apply).
 --
--- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony)
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' at terminal, 2026-08-16 ceremony)
 --                per apply-migration.js's self-consistency check (header email == invoker's git
 --                email + a matching, unconsumed, <1h MIGRATION_APPLY_TOKEN). This file does not
 --                apply itself.>

--- a/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
+++ b/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on the G6 trio at terminal, 2026-08-16 ceremony)
 -- SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001 — drop the dead, unbounded telegram anon-INSERT policy
 --
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════

--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on the G6 trio at terminal, 2026-08-16 ceremony)
 -- SD-LEO-FIX-CLOSE-ANON-VENTURE-001 — ownership-bound RPC replacing venture_user_insert_feedback
 --
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════

--- a/database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
+++ b/database/chairman-gated/20260817_chairman_all_decision_signals_merged.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on Group 3 at terminal, 2026-08-16 ceremony)
 -- QF-20260816-456 — MERGE of two rival chairman-gated views of chairman_all_decision_signals
 -- into ONE, ahead of the 2026-08-17 chairman ceremony. Supersedes both:
 --   database/chairman-gated/20260803_chairman_queue_truthful_render.sql   ("File A")

--- a/database/migrations/20260718_switchon_rls_narrow_authenticated_read_STAGED.sql
+++ b/database/migrations/20260718_switchon_rls_narrow_authenticated_read_STAGED.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on Group 2 at terminal, 2026-08-16 ceremony)
 -- Narrows the switchon_auto_actions / switchon_decision_audit authenticated-read RLS
 -- policies from an unconditional USING (true) to fn_is_chairman()-gated reads.
 -- SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-C follow-up.

--- a/database/migrations/20260721_chairman_decisions_channel_STAGED.sql
+++ b/database/migrations/20260721_chairman_decisions_channel_STAGED.sql
@@ -1,3 +1,4 @@
+-- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ~15:00Z, ceremony runbook 2026-08-17 moved up per chairman)
 -- Chairman-decisions AUDIT CHANNEL column — records WHICH channel a chairman decision was made
 -- over, so an SMS-decided stage-gate approval is distinguishable from an authenticated-console one
 -- on the SAME chairman_decisions row (audit parity).

--- a/database/migrations/20260721_chairman_decisions_channel_STAGED.sql
+++ b/database/migrations/20260721_chairman_decisions_channel_STAGED.sql
@@ -1,4 +1,5 @@
--- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ~15:00Z, ceremony runbook 2026-08-17 moved up per chairman)
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' at terminal, 2026-08-16 ceremony)
 -- Chairman-decisions AUDIT CHANNEL column — records WHICH channel a chairman decision was made
 -- over, so an SMS-decided stage-gate approval is distinguishable from an authenticated-console one
 -- on the SAME chairman_decisions row (audit parity).

--- a/database/migrations/20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql
+++ b/database/migrations/20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql
@@ -1,4 +1,5 @@
--- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony, moved up from 08-17 per chairman)
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' at terminal, 2026-08-16 ceremony)
 -- SMS decision-class whitelist SEED — register 'blocking stage-gate approval' as an SMS-eligible
 -- decision class (owner-run at the chairman ceremony).
 -- SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B (FR-3; child B of the high-consequence-stage

--- a/database/migrations/20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql
+++ b/database/migrations/20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql
@@ -1,3 +1,4 @@
+-- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony, moved up from 08-17 per chairman)
 -- SMS decision-class whitelist SEED — register 'blocking stage-gate approval' as an SMS-eligible
 -- decision class (owner-run at the chairman ceremony).
 -- SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B (FR-3; child B of the high-consequence-stage

--- a/database/migrations/20260728_adherence_ledger_check_class_STAGED.sql
+++ b/database/migrations/20260728_adherence_ledger_check_class_STAGED.sql
@@ -1,4 +1,5 @@
--- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony, moved up from 08-17 per chairman)
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' at terminal, 2026-08-16 ceremony)
 -- SD-LEO-INFRA-ROLE-SESSION-SELF-001 / FR-2 — declare WHICH KIND OF GREEN a ledger row is.
 -- ============================================================================================
 -- WHY. A role-session adherence review returned CLEAN on the night of a self-reported execution

--- a/database/migrations/20260728_adherence_ledger_check_class_STAGED.sql
+++ b/database/migrations/20260728_adherence_ledger_check_class_STAGED.sql
@@ -1,3 +1,4 @@
+-- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony, moved up from 08-17 per chairman)
 -- SD-LEO-INFRA-ROLE-SESSION-SELF-001 / FR-2 — declare WHICH KIND OF GREEN a ledger row is.
 -- ============================================================================================
 -- WHY. A role-session adherence review returned CLEAN on the night of a self-reported execution

--- a/database/migrations/20260728_anon_authenticated_audience_and_narrowing_STAGED.sql
+++ b/database/migrations/20260728_anon_authenticated_audience_and_narrowing_STAGED.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' on Group 2 at terminal, 2026-08-16 ceremony)
 -- SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 — recorded audience + the third narrowing.
 --
 -- *** TIER-2. CHAIRMAN-GATED APPLY. DO NOT AUTO-APPLY. ***

--- a/database/migrations/20260728_chairman_override_dedup_STAGED.sql
+++ b/database/migrations/20260728_chairman_override_dedup_STAGED.sql
@@ -1,4 +1,5 @@
--- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony, moved up from 08-17 per chairman)
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval transcribed by Adam per chairman ruling 2026-08-07; chairman 'run it' at terminal, 2026-08-16 ceremony)
 -- SD-LEO-INFRA-ROLE-SESSION-SELF-001 / FR-4 — one row per boundary crossing, even under a race.
 -- ============================================================================================
 -- lib/governance/chairman-override-record.js checks for an existing override_key before it

--- a/database/migrations/20260728_chairman_override_dedup_STAGED.sql
+++ b/database/migrations/20260728_chairman_override_dedup_STAGED.sql
@@ -1,3 +1,4 @@
+-- @approved-by: codestreetlabs@gmail.com (transcribed by Adam per chairman ruling 2026-08-07; approval: chairman terminal 'run it' on Group 1, 2026-08-16 ceremony, moved up from 08-17 per chairman)
 -- SD-LEO-INFRA-ROLE-SESSION-SELF-001 / FR-4 — one row per boundary crossing, even under a race.
 -- ============================================================================================
 -- lib/governance/chairman-override-record.js checks for an existing override_key before it

--- a/tests/unit/chairman/merged-decision-signals-view.test.js
+++ b/tests/unit/chairman/merged-decision-signals-view.test.js
@@ -155,8 +155,8 @@ describe('MERGE-6: staging discipline', () => {
     }
   });
 
-  it('carries no approved-by attestation', () => {
-    expect(sql).not.toMatch(/^-- @approved-by:/m);
+  it('carries the chairman approved-by attestation in guard bare-email format (stamped at the 2026-08-16 ceremony; before apply this test asserted absence)', () => {
+    expect(sql).toMatch(/^-- @approved-by: \S+@\S+$/m);
   });
 
   it('ships a DOWN file with the exact pre-merge definition (all three original defects present)', () => {


### PR DESCRIPTION
All 13 files of the 2026-08-16 DDL ceremony (moved up from 08-17 at the chairman's direction) were applied to prod live at the terminal — chairman per-group 'run it', per-file token, per-file catalog readback, final behavioural VERIFY PASS on the ownership RPC. This PR records the @approved-by stamps (bare email + citation per the 2026-08-07 transcription ruling). No logic changes — headers only.

Applied: chairman_decisions.channel, adherence check_class, sms whitelist seed, chairman_override dedup idx, operating_burn tenant RLS, switchon RLS narrow ×2, research-intel narrowing+comments, MERGED chairman_all_decision_signals (security_invoker, control green), ai-quality symmetric guards, session_coordination scoping (round-trip green), venture ingest-key binding, telegram INSERT revoke, feedback ownership RPC (acceptance --verify PASS).

Excluded on purpose: current_wave trigger (live violating row), superseded bound_anon_ingress, retired rival view files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)