### PR TITLE
fix(QF-20260816-014): escape PRD prose before RegExp in infrastructure-consumer-check

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/infrastructure-consumer-check.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/infrastructure-consumer-check.js
@@ -23,6 +23,16 @@
 import { safeTruncate } from '../../../../../../lib/utils/safe-truncate.js';
 
 /**
+ * QF-20260816-014: itemName below is free-text PRD prose, not an author-defined pattern —
+ * escape regex metacharacters before interpolating into a RegExp source, or FR text
+ * containing parens/brackets throws (observed: 'Unmatched )', 'Range out of order in
+ * character class').
+ */
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Reason codes for gate failures (FR-2, FR-3)
  */
 const REASON_CODES = {
@@ -271,7 +281,7 @@ function checkItemHasConsumer(itemName, content, config) {
   }
 
   // Check if item name appears in consumer context
-  const itemRegex = new RegExp(`(use|query|from|call|invoke|execute).*${itemName}`, 'i');
+  const itemRegex = new RegExp(`(use|query|from|call|invoke|execute).*${escapeRegExp(itemName)}`, 'i');
   if (itemRegex.test(content)) {
     evidence.push({
       type: 'item_usage',
@@ -875,4 +885,4 @@ export async function generateFollowUpSD(parentSd, gaps, supabase) {
 }
 
 // Export reason codes for external use
-export { REASON_CODES };
+export { REASON_CODES, checkItemHasConsumer, escapeRegExp };

--- a/tests/unit/handoff/infrastructure-consumer-check-regex-escape.test.js
+++ b/tests/unit/handoff/infrastructure-consumer-check-regex-escape.test.js
@@ -1,0 +1,39 @@
+// QF-20260816-014. checkItemHasConsumer interpolated free-text PRD prose (itemName) directly
+// into `new RegExp(...)` without escaping metacharacters. Any FR containing parens/brackets
+// threw and fail-opened the gate: 'Unmatched )' (SD-LEO-INFRA-COMPLETION-TIER-SCRIPT-EXIT-001,
+// signal 21f9ea4d) and 'Range out of order in character class'
+// (SD-LEO-INFRA-PRE-PLAN-CRITIQUE-PRD-TRUNCATION-001, signal cfa13b3c).
+import { describe, it, expect } from 'vitest';
+import { checkItemHasConsumer, escapeRegExp } from '../../../scripts/modules/handoff/executors/plan-to-exec/gates/infrastructure-consumer-check.js';
+
+const MINIMAL_CONFIG = { consumerHints: [] };
+
+describe('escapeRegExp', () => {
+  it('escapes every regex metacharacter', () => {
+    expect(escapeRegExp('.*+?^${}()|[]\\')).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeRegExp('plain text 123')).toBe('plain text 123');
+  });
+});
+
+describe('checkItemHasConsumer — QF-20260816-014 crash reproductions', () => {
+  it('does not throw on an unmatched paren in itemName (Unmatched ")" repro)', () => {
+    const itemName = 'compute the score (deprecated in favor of the new ladder';
+    expect(() => checkItemHasConsumer(itemName, 'some content', MINIMAL_CONFIG)).not.toThrow();
+  });
+
+  it('does not throw on an unbalanced character class in itemName (Range out of order repro)', () => {
+    const itemName = 'validate range [z-a] input';
+    expect(() => checkItemHasConsumer(itemName, 'some content', MINIMAL_CONFIG)).not.toThrow();
+  });
+
+  it('still detects a real item_usage match after escaping', () => {
+    const itemName = 'my_table(v2)';
+    const content = 'the service will query my_table(v2) directly';
+    const result = checkItemHasConsumer(itemName, content, MINIMAL_CONFIG);
+    expect(result.hasConsumer).toBe(true);
+    expect(result.evidence.some((e) => e.type === 'item_usage')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `checkItemHasConsumer()` interpolated free-text PRD FR prose (`itemName`) directly into `new RegExp(...)` without escaping metacharacters — any FR containing parens/brackets threw and silently fail-opened the gate (2 seats hit within 10 minutes: `SD-LEO-INFRA-COMPLETION-TIER-SCRIPT-EXIT-001` signal 21f9ea4d "Unmatched )", `SD-LEO-INFRA-PRE-PLAN-CRITIQUE-PRD-TRUNCATION-001` signal cfa13b3c "Range out of order in character class")
- Added `escapeRegExp()` and applied it at the interpolation site (line 274)
- Audited line 214's `new RegExp(pattern, 'gi')` for the same class — NOT affected, `pattern` there is always an author-defined `RegExp` literal from `INFRASTRUCTURE_PATTERNS`, never PRD-sourced text

## Test plan
- [x] New unit tests reproduce both exact crash signatures — confirmed both throw without the fix (verified pre-fix behavior directly before writing the tests)
- [x] Confirmed a real `item_usage` match still fires post-escape (not vacuous)
- [x] Full `tests/unit/handoff/` suite: 887/888 passing (1 pre-existing skip), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)