### PR TITLE
fix(QF-20260816-262): scale legacy 0-1 confidence to 0-100 before insert

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -253,7 +253,13 @@ export function normalizeConfidence(results, options = {}) {
 
   // Case 3: Only confidence (legacy)
   if (hasConfidence) {
-    const value = results.confidence;
+    const raw = results.confidence;
+    // QF-20260816-262: the documented legacy shape is a 0-1 fraction, but the DB
+    // column is a 0-100 integer -- confidence:0.95 passed validateConfidenceValue
+    // (a finite number in [0, 100]) unscaled, then hard-failed the insert with
+    // 'invalid input syntax for type integer: 0.95'. Scale a 0-1 value up before
+    // validating/storing.
+    const value = typeof raw === 'number' && raw <= 1 ? Math.round(raw * 100) : raw;
     const validation = validateConfidenceValue(value);
     if (!validation.valid) {
       return {
@@ -265,7 +271,7 @@ export function normalizeConfidence(results, options = {}) {
     return {
       value,
       source: 'confidence_legacy',
-      warning: `confidence.legacy_mapped: Using legacy 'confidence' field. Sub-agent should emit 'confidence_score'. (SD: ${sdId}, sub-agent: ${subAgentCode})`
+      warning: `confidence.legacy_mapped: Using legacy 'confidence' field${value !== raw ? ` (scaled ${raw} -> ${value})` : ''}. Sub-agent should emit 'confidence_score'. (SD: ${sdId}, sub-agent: ${subAgentCode})`
     };
   }
 

--- a/tests/unit/sub-agent-executor/normalize-confidence.test.js
+++ b/tests/unit/sub-agent-executor/normalize-confidence.test.js
@@ -54,6 +54,41 @@ describe('normalizeConfidence', () => {
     });
   });
 
+  describe('TS-2b: QF-20260816-262 - legacy 0-1 fraction scales to 0-100 integer', () => {
+    it('scales a 0-1 legacy confidence fraction up by *100 and rounds', () => {
+      const results = { confidence: 0.95 };
+      const result = normalizeConfidence(results, defaultOptions);
+
+      expect(result.value).toBe(95);
+      expect(Number.isInteger(result.value)).toBe(true);
+      expect(result.source).toBe('confidence_legacy');
+      expect(result.warning).toContain('confidence.legacy_mapped');
+      expect(result.warning).toContain('scaled 0.95 -> 95');
+    });
+
+    it('scales confidence:1 (full legacy scale) to 100', () => {
+      const results = { confidence: 1 };
+      const result = normalizeConfidence(results, defaultOptions);
+
+      expect(result.value).toBe(100);
+    });
+
+    it('scales confidence:0 to 0 (unchanged either way)', () => {
+      const results = { confidence: 0 };
+      const result = normalizeConfidence(results, defaultOptions);
+
+      expect(result.value).toBe(0);
+    });
+
+    it('leaves an already-0-100-scale legacy confidence untouched', () => {
+      const results = { confidence: 73 };
+      const result = normalizeConfidence(results, defaultOptions);
+
+      expect(result.value).toBe(73);
+      expect(result.warning).not.toContain('scaled');
+    });
+  });
+
   describe('TS-3: Dual-field input prefers confidence_score', () => {
     it('should use confidence_score when both fields present and emit warning', () => {
       const results = { confidence_score: 90, confidence: 10 };


### PR DESCRIPTION
## Summary
- `normalizeConfidence()`'s legacy-compat branch (Case 3: only `confidence` provided) passed the documented 0-1 legacy fraction straight through unscaled — `confidence:0.95` passed `validateConfidenceValue()` (a finite number in [0,100]) but then hard-failed the DB insert with `invalid input syntax for type integer: 0.95`
- Reproduced firsthand (signal e06fbf7e, Golf storing Explore evidence for `SD-LEO-INFRA-COMPLETION-TIER-SCRIPT-EXIT-001`), independently found by a VALIDATION sub-agent pass
- Fix: scale `value<=1` by `*100` and round before validating/storing; an already-0-100-scale legacy value (e.g. `confidence:73`) passes through unchanged

## Test plan
- [x] New tests: `0.95→95`, `1→100` (full-scale boundary), `0→0`, and the unchanged-`73` regression case
- [x] Full `tests/unit/sub-agent-executor/` suite: 73/73 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)