### PR TITLE
fix(QF-20260816-107): route system errors through completion-action recording

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -258,7 +258,14 @@ export class HandoffOrchestrator {
           // handoff is still visible in the audit trail without burning failure metrics.
           console.log('📝 Handoff recorded as WAIT (recorder.recordWait not available — using blocked+metadata fallback)');
         }
-      } else if (!result.systemError) {
+      } else if (result.systemError) {
+        // QF-20260816-107: BaseExecutor can RETURN ResultBuilder.systemError(...) instead
+        // of throwing (e.g. executeSpecific's catch at BaseExecutor.js:838) — the prior
+        // '!result.systemError' guard silently dropped these on the floor (no row in
+        // either table). The thrown-error path is still handled separately below at the
+        // catch block (line ~299-303); this covers the RETURNED-error path.
+        await this.recorder.recordSystemError(normalizedType, sdId, result.message || result.error || 'Unknown system error');
+      } else {
         await this.recorder.recordFailure(normalizedType, sdId, result, template);
       }
 

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -664,6 +664,20 @@ export class HandoffRecorder {
     // SD-VENTURE-STAGE0-UI-001: Resolve to UUID for FK constraints
     const sdUuid = await this._resolveToUUID(sdId);
 
+    // QF-20260816-107: parity with recordFailure (line ~371) — completion actions
+    // (e.g. LEAD-FINAL-APPROVAL) must record system errors to leo_handoff_executions,
+    // not sd_phase_handoffs, whose to_phase CHECK constraint + phase-transition
+    // analytics are wrong for a completion action and reproduce the same
+    // "100% rejected" distortion FR-1 fixed for recordFailure.
+    if (isCompletionAction(handoffType)) {
+      return this._recordCompletionActionFailure({
+        executionId, handoffType, sdId, sdUuid,
+        result: { message: errorMessage, reasonCode: 'SYSTEM_ERROR', systemError: true },
+        template: null,
+        normalizedScore: 0
+      });
+    }
+
     const execution = {
       id: executionId,
       sd_id: sdUuid,

--- a/tests/unit/handoff/handoff-orchestrator.test.js
+++ b/tests/unit/handoff/handoff-orchestrator.test.js
@@ -304,6 +304,46 @@ describe('HandoffOrchestrator', () => {
       expect(result.error).toBe('Database connection lost');
       expect(recorder.recordSystemError).toHaveBeenCalledOnce();
     });
+
+    it('QF-20260816-107: records system error when executor RETURNS a systemError result (does not throw)', async () => {
+      const recorder = {
+        recordSuccess: vi.fn(() => Promise.resolve()),
+        recordFailure: vi.fn(() => Promise.resolve()),
+        recordSystemError: vi.fn(() => Promise.resolve())
+      };
+
+      // BaseExecutor.executeSpecific's own catch path can RETURN
+      // ResultBuilder.systemError(...) instead of throwing — the prior
+      // '!result.systemError' guard silently dropped this on the floor (no
+      // recordFailure call because systemError was truthy, no recordSystemError
+      // call because nothing threw).
+      const returningExecutor = createMockExecutor({
+        success: false,
+        systemError: true,
+        error: 'executeSpecific internal failure',
+        message: 'executeSpecific internal failure',
+        reasonCode: 'SYSTEM_ERROR'
+      });
+
+      const orchestrator = createTestOrchestrator({
+        recorder,
+        executors: {
+          'LEAD-FINAL-APPROVAL': returningExecutor,
+          'LEAD-TO-PLAN': createMockExecutor(),
+          'PLAN-TO-EXEC': createMockExecutor(),
+          'EXEC-TO-PLAN': createMockExecutor(),
+          'PLAN-TO-LEAD': createMockExecutor()
+        }
+      });
+
+      const result = await orchestrator.executeHandoff('LEAD-FINAL-APPROVAL', 'SD-TEST-001');
+
+      expect(result.success).toBe(false);
+      expect(result.systemError).toBe(true);
+      expect(recorder.recordSystemError).toHaveBeenCalledOnce();
+      expect(recorder.recordSystemError).toHaveBeenCalledWith('LEAD-FINAL-APPROVAL', 'SD-TEST-001', 'executeSpecific internal failure');
+      expect(recorder.recordFailure).not.toHaveBeenCalled();
+    });
   });
 
   // =========================================================================

--- a/tests/unit/medium-effort-hardening.test.js
+++ b/tests/unit/medium-effort-hardening.test.js
@@ -290,6 +290,54 @@ describe('FR-1: HandoffRecorder.recordFailure routing', async () => {
   });
 });
 
+// ── QF-20260816-107: recordSystemError routing (parity with recordFailure) ──
+describe('QF-20260816-107: HandoffRecorder.recordSystemError routing', async () => {
+  const { HandoffRecorder } = await import('../../scripts/modules/handoff/recording/HandoffRecorder.js');
+
+  function makeRecorder() {
+    const inserts = [];
+    const supabase = {
+      from: (table) => ({
+        insert: (row) => {
+          inserts.push({ table, row });
+          return { select: () => Promise.resolve({ data: [row], error: null }) };
+        },
+      }),
+      rpc: () => Promise.resolve({ data: null, error: null }),
+    };
+    const recorder = new HandoffRecorder(supabase, {
+      contentBuilder: { buildRejection: () => ({ executive_summary: 'r' }) },
+      validationOrchestrator: { preValidateData: async () => ({ valid: true, errors: [] }) },
+    });
+    recorder._resolveToUUID = async () => '00000000-0000-0000-0000-000000000001';
+    recorder._logGovernanceAudit = async () => {};
+    return { recorder, inserts };
+  }
+
+  it('completion action (LEAD-FINAL-APPROVAL) system error -> leo_handoff_executions, NOT sd_phase_handoffs', async () => {
+    const { recorder, inserts } = makeRecorder();
+    const id = await recorder.recordSystemError('LEAD-FINAL-APPROVAL', 'SD-T-001', 'Database connection lost');
+    expect(id).toBeTruthy();
+    const tables = inserts.map((i) => i.table);
+    expect(tables).toContain('leo_handoff_executions');
+    expect(tables).not.toContain('sd_phase_handoffs');
+    const row = inserts.find((i) => i.table === 'leo_handoff_executions').row;
+    expect(row.status).toBe('rejected');
+    expect(row.rejection_reason).toBe('Database connection lost');
+  });
+
+  it('phase transition (PLAN-TO-EXEC) system error -> sd_phase_handoffs unchanged', async () => {
+    const { recorder, inserts } = makeRecorder();
+    await recorder.recordSystemError('PLAN-TO-EXEC', 'SD-T-001', 'Database connection lost');
+    const tables = inserts.map((i) => i.table);
+    expect(tables).toContain('sd_phase_handoffs');
+    expect(tables).not.toContain('leo_handoff_executions');
+    const row = inserts.find((i) => i.table === 'sd_phase_handoffs').row;
+    expect(row.status).toBe('failed');
+    expect(row.rejection_reason).toBe('Database connection lost');
+  });
+});
+
 // ── FR-4: track-model-usage token flags parse (light contract pin) ───────────
 describe('FR-4: track-model-usage token capture', () => {
   it('source carries the explicit-token path, transcript fallback, and fail-soft', async () => {


### PR DESCRIPTION
## Summary
Two independent gaps in system-error recording (C3 #7099 bug_003, Adam-verified):

1. `HandoffRecorder.recordSystemError` had no `isCompletionAction` dispatch (`recordFailure` has one, added by `SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001` FR-1) — LEAD-FINAL-APPROVAL system errors wrote a failed row into `sd_phase_handoffs` instead of `leo_handoff_executions`, reproducing the exact "100% rejected" analytics distortion FR-1 fixed for `recordFailure`.
2. `HandoffOrchestrator`'s `else if (!result.systemError)` guard meant that when an executor **returns** `ResultBuilder.systemError(...)` instead of throwing (e.g. `BaseExecutor.executeSpecific`'s own catch path), none of the three branches (success / waitVerdict / failure) fired — the error vanished with no row in either table.

Fix: `recordSystemError` now dispatches to `_recordCompletionActionFailure` for completion actions; the orchestrator gets an explicit `else if (result.systemError)` branch that calls `recordSystemError` for the returned-error path (the thrown-error path via the outer try/catch is unaffected).

## Test plan
- [x] `tests/unit/medium-effort-hardening.test.js`: 2 new tests pin `recordSystemError`'s routing (completion action → `leo_handoff_executions`, phase transition → `sd_phase_handoffs` unchanged) via a real insert-tracking Supabase stub
- [x] `tests/unit/handoff/handoff-orchestrator.test.js`: added a returned-systemError test alongside the existing thrown-error test — this file is currently quarantined (`tests/quarantine-manifest.json`, unrelated pre-existing "assertion-drift" since 2026-06-11); verified the new test's logic is sound by running it copied to a non-excluded path
- [x] Full `tests/unit/handoff/` + `medium-effort-hardening.test.js` suite: 940/941 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)