### PR TITLE
fix(QF-20260816-923): thread sessionId into validationContext for descope self-approval guard

### DIFF
--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -438,7 +438,12 @@ export class BaseExecutor {
         // SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001: without this, subagent-evidence-gate.js's
         // REQUIRED_SUBAGENTS[ctx.handoffType] always resolved to [] (undefined key), so
         // GATE_SUBAGENT_EVIDENCE has been fail-open fleet-wide since introduction.
-        handoffType: this.handoffType
+        handoffType: this.handoffType,
+        // QF-20260816-923: without this, fr-delivery-classifier.js's descopeFor()
+        // self-approval guard (`requesterSessionId && approver === requesterSessionId`) was
+        // dead code on every production handoff — requesterSessionId was always null, so a
+        // worker's own session could descope an FR "approved" by that same session.
+        sessionId: options?.autoProceedSessionId || process.env.CLAUDE_SESSION_ID || null
       };
 
       // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5/TR-4: surface prior consecutive-wait

--- a/scripts/modules/handoff/gates/fr-delivery-classifier.js
+++ b/scripts/modules/handoff/gates/fr-delivery-classifier.js
@@ -116,6 +116,14 @@ export function isValidatedStory(story) {
 /** Approver-gated descope lookup for an FR id. requesterSessionId is excluded as a self-approver. */
 export function descopeFor(sdMetadata, frId, requesterSessionId = null) {
   const list = (sdMetadata && Array.isArray(sdMetadata.descoped_frs)) ? sdMetadata.descoped_frs : [];
+  // QF-20260816-923: requesterSessionId was null on every production handoff (BaseExecutor's
+  // validationContext never set it), so the self-approval check below never even ran — a
+  // worker could descope an FR "approved" by itself with no guard firing at all. Now that
+  // sessionId is threaded through, warn loudly on the identity-unknown case rather than
+  // silently trusting it, so a caller that still can't identify itself is visible in logs.
+  if (!requesterSessionId) {
+    console.warn('[fr-delivery-classifier] descopeFor: requesterSessionId is unknown — the self-approval guard cannot run for this check');
+  }
   return list.find((d) => {
     if (!d || (d.fr_id !== frId && d.id !== frId)) return false;
     const approver = typeof d.approved_by === 'string' ? d.approved_by.trim() : '';

--- a/tests/unit/handoff/base-executor-validation-context-session-id.test.js
+++ b/tests/unit/handoff/base-executor-validation-context-session-id.test.js
@@ -1,0 +1,124 @@
+/**
+ * QF-20260816-923: BaseExecutor's validationContext never carried a sessionId, so
+ * fr-delivery-classifier.js's descopeFor() self-approval guard
+ * (`requesterSessionId && approver === requesterSessionId`) was dead code on every
+ * production handoff — a worker's own session could descope an FR "approved" by
+ * that same session with no guard ever firing.
+ *
+ * Reuses the drivable-execute() harness from base-executor-failed-gate-wire.test.js
+ * (TESTING sub-agent's proof that BaseExecutor.execute() does not require standing
+ * up the whole gate pipeline to unit test).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../lib/sd/type-detection.js', () => ({ isOrchestratorSync: () => false }));
+vi.mock('../../../lib/claim/ownership-detection.js', () => ({ getClaimHolder: async () => null }));
+vi.mock('../../../lib/handoff/gate-skip-detection.js', () => ({ shouldSkipForType: () => ({ skip: false, reason: '' }) }));
+vi.mock('../../../lib/claim-validity-gate.js', () => ({
+  assertValidClaim: async () => ({ ownership: 'claim_holder' }),
+  ClaimIdentityError: class ClaimIdentityError extends Error {},
+}));
+vi.mock('../../../scripts/modules/handoff/claim-gate-decision.js', () => ({
+  evaluateClaimCheckForHandoff: () => ({ block: false, alreadyCompleted: false, detail: '' }),
+}));
+vi.mock('../../../lib/rca/index.js', () => ({
+  triggerRCAOnFailure: async () => {}, buildGateContext: (x) => x,
+}));
+vi.mock('../../../scripts/modules/handoff/gate-policy-resolver.js', () => ({
+  applyGatePolicies: async (_sb, gates) => ({ filteredGates: gates, fallbackUsed: false }),
+}));
+vi.mock('../../../scripts/modules/handoff/gates/dfe-escalation-gate.js', () => ({
+  createDFEEscalationGate: () => ({ name: 'DFE_ESCALATION_GATE', validator: async () => ({ passed: true }) }),
+}));
+vi.mock('../../../scripts/modules/handoff/shared-git-context.js', () => ({ SharedGitContext: class {} }));
+vi.mock('../../../scripts/modules/handoff/gate-verdict-cache.js', () => ({
+  isCacheAllowed: () => false, loadPriorGateResults: async () => null,
+  mergePassResults: (p) => p, logCacheTelemetry: async () => {},
+}));
+vi.mock('../../../scripts/modules/handoff/skip-and-continue.js', () => ({
+  shouldSkipAndContinue: () => ({ shouldSkip: false, reason: 'not eligible' }),
+  executeSkipAndContinue: async () => ({}),
+}));
+
+const { BaseExecutor } = await import('../../../scripts/modules/handoff/executors/BaseExecutor.js');
+
+function stubSupabase() {
+  const term = Promise.resolve({ data: null, error: null });
+  const chain = new Proxy(function () {}, {
+    get: (_t, prop) => {
+      if (prop === 'then') return term.then.bind(term);
+      if (prop === 'catch') return term.catch.bind(term);
+      if (prop === 'finally') return term.finally.bind(term);
+      return () => chain;
+    },
+    apply: () => chain,
+  });
+  return { from: () => chain, rpc: () => term };
+}
+
+const SD = { id: 'sd-uuid-1', sd_key: 'SD-POC-001', sd_type: 'infrastructure', status: 'active', metadata: {} };
+
+class ProbeExecutor extends BaseExecutor {
+  get handoffType() { return 'PLAN-TO-LEAD'; }
+  async _checkAndExecutePendingMigrations() { return null; }
+  async _checkMultiSessionClaimConflict() { return { pass: true }; }
+  async setup() { return { success: true }; }
+  async _claimSDForSession() { return { success: true }; }
+  async _autoTriggerDatabaseSubAgent() {}
+  async _displayHandoffStartDirectives() {}
+  async _displayOnFailureDirectives() {}
+  async _loadPriorWaitState() { return null; }
+  async getRequiredGates() { return []; }
+  getRemediation() { return 'remediation text'; }
+}
+
+function makeExecutor(buildGatesFromRulesSpy) {
+  return new ProbeExecutor({
+    supabase: stubSupabase(),
+    sdRepo: { getById: async () => SD },
+    prdRepo: null,
+    validationOrchestrator: {
+      buildGatesFromRules: buildGatesFromRulesSpy,
+      validateGates: async () => ({ passed: true, gateResults: {}, totalScore: 100, totalMaxScore: 100, issues: [], warnings: [] }),
+    },
+  });
+}
+
+describe('QF-20260816-923: BaseExecutor validationContext.sessionId', () => {
+  it('threads options.autoProceedSessionId into validationContext.sessionId', async () => {
+    let capturedContext = null;
+    const spy = vi.fn(async (_gates, _handoffType, ctx) => { capturedContext = ctx; return []; });
+    await makeExecutor(spy).execute('SD-POC-001', { autoProceedSessionId: 'session-abc-123' });
+
+    expect(capturedContext).not.toBeNull();
+    expect(capturedContext.sessionId).toBe('session-abc-123');
+  });
+
+  it('falls back to process.env.CLAUDE_SESSION_ID when autoProceedSessionId is absent', async () => {
+    const prev = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = 'env-session-xyz';
+    try {
+      let capturedContext = null;
+      const spy = vi.fn(async (_gates, _handoffType, ctx) => { capturedContext = ctx; return []; });
+      await makeExecutor(spy).execute('SD-POC-001', {});
+
+      expect(capturedContext.sessionId).toBe('env-session-xyz');
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = prev;
+    }
+  });
+
+  it('is null (not undefined) when neither source is available -- identity-unknown, not identity-omitted', async () => {
+    const prev = process.env.CLAUDE_SESSION_ID;
+    delete process.env.CLAUDE_SESSION_ID;
+    try {
+      let capturedContext = null;
+      const spy = vi.fn(async (_gates, _handoffType, ctx) => { capturedContext = ctx; return []; });
+      await makeExecutor(spy).execute('SD-POC-001', {});
+
+      expect(capturedContext.sessionId).toBeNull();
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = prev;
+    }
+  });
+});

--- a/tests/unit/handoff/gates/fr-delivery-classifier.test.js
+++ b/tests/unit/handoff/gates/fr-delivery-classifier.test.js
@@ -1,7 +1,7 @@
 // Tests for SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001
 // Real per-FR delivery classification + default-OFF warn-only enforcement + approver descope.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   isFrTraceabilityEnforced,
   frIdOf,
@@ -71,6 +71,30 @@ describe('FR-4: descopeFor — approver-gated', () => {
     expect(descopeFor(md, 'FR-007', 'other-session')).toBeTruthy();
   });
   it('null when no descope list', () => expect(descopeFor({}, 'FR-1')).toBeNull());
+
+  // QF-20260816-923: requesterSessionId was always null in production (BaseExecutor's
+  // validationContext never set it) -- the self-approval guard above never ran. Now that
+  // sessionId is threaded through, an identity-unknown call must warn loudly rather than
+  // silently trust the descope.
+  it('QF-20260816-923: warns loudly when requesterSessionId is unknown (self-approval guard cannot run)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(descopeFor(md, 'FR-005')).toBeTruthy(); // still honored (warn-only per QF scope)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('requesterSessionId is unknown'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('QF-20260816-923: does NOT warn when requesterSessionId is provided', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      descopeFor(md, 'FR-007', 'other-session');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 // Injectable supabase stub: returns FRs from the PRD query and stories from user_stories.


### PR DESCRIPTION
## Summary
C3 #7099 bug_006, Adam-verified: `fr-delivery-classifier.js`'s `descopeFor()` self-approval guard (`requesterSessionId && approver === requesterSessionId`) was dead code on every production handoff — `BaseExecutor`'s `validationContext` never set `sessionId`, so the FR gate's `ctx.sessionId || ctx.session_id || null` always resolved to null and the comparison never fired. A worker could descope an FR "approved" by its own session with no guard ever running.

- Threads `options.autoProceedSessionId` (falling back to `process.env.CLAUDE_SESSION_ID`) into `validationContext.sessionId`
- `descopeFor()` now warns loudly when `requesterSessionId` is still unknown rather than silently trusting the descope — kept warn-only (not fail-closed) since the gate itself is warn-only today (`LEO_FR_TRACEABILITY_ENFORCE=off`) and `approved_by` is usually a role name, not a session id; hardening to a hard refusal risked breaking legitimate non-interactive descopes for a self-approval risk that's bounded, not actively exploited

## Test plan
- [x] `base-executor-validation-context-session-id.test.js` (new): proves the threading end-to-end via the drivable-`execute()` harness (options value, env fallback, and the neither-available null case)
- [x] `fr-delivery-classifier.test.js`: pins the warn-loudly behavior
- [x] Full `tests/unit/handoff/`: 892/893 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)