### PR TITLE
fix(QF-20260816-725): handoff_fail_count fallback used a nonexistent Knex idiom

### DIFF
--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -121,6 +121,48 @@ export class HandoffRecorder {
   }
 
   /**
+   * QF-20260816-725: increment handoff_fail_count for fleet telemetry. Two bugs fixed here:
+   * (1) the RPC's {error} return was never checked — supabase-js resolves rpc() normally
+   *     (does not throw) even when the function doesn't exist (PGRST202), so the old
+   *     try/catch around a bare `await this.supabase.rpc(...)` never triggered its fallback;
+   *     confirmed live: increment_handoff_fail_count does NOT exist in the schema cache.
+   * (2) the fallback called `this.supabase.raw(...)`, a Knex.js idiom that does not exist on
+   *     the supabase-js client — it threw a TypeError synchronously while building the
+   *     .update() call, which the outer catch silently swallowed. Replaced with a real
+   *     read-then-update sequence.
+   * Best-effort telemetry: every failure here is logged and swallowed, never thrown.
+   * @param {string} sdId - Strategic Directive ID
+   */
+  async _incrementHandoffFailCount(sdId) {
+    try {
+      const { error: rpcError } = await this.supabase.rpc('increment_handoff_fail_count', { p_sd_id: sdId });
+      if (!rpcError) return;
+
+      const { data: session, error: readError } = await this.supabase
+        .from('claude_sessions')
+        .select('handoff_fail_count')
+        .eq('sd_key', sdId)
+        .eq('status', 'active')
+        .maybeSingle();
+      if (readError || !session) {
+        console.warn(`   [handoff-fail-count] Non-blocking: RPC unavailable (${rpcError.message}) and fallback read ${readError ? `failed: ${readError.message}` : 'found no active session for this SD'}`);
+        return;
+      }
+
+      const { error: updateError } = await this.supabase
+        .from('claude_sessions')
+        .update({ handoff_fail_count: (session.handoff_fail_count || 0) + 1 })
+        .eq('sd_key', sdId)
+        .eq('status', 'active');
+      if (updateError) {
+        console.warn(`   [handoff-fail-count] Non-blocking: fallback update failed: ${updateError.message}`);
+      }
+    } catch (err) {
+      console.warn(`   [handoff-fail-count] Non-blocking: ${err.message}`);
+    }
+  }
+
+  /**
    * Record a successful handoff execution
    * @param {string} handoffType - Handoff type
    * @param {string} sdId - Strategic Directive ID
@@ -448,20 +490,7 @@ export class HandoffRecorder {
 
       // SD-MAN-INFRA-WORKER-WORKTREE-SELF-001: Increment handoff_fail_count for fleet telemetry
       // SD-LEO-FIX-HANDOFF-QUERY-BATCHING-001: Batch update replaces N+1 loop
-      try {
-        await this.supabase.rpc('increment_handoff_fail_count', { p_sd_id: sdId });
-      } catch (rpcErr) {
-        // Fallback: single UPDATE with increment expression if RPC doesn't exist
-        try {
-          await this.supabase
-            .from('claude_sessions')
-            .update({ handoff_fail_count: this.supabase.raw('COALESCE(handoff_fail_count, 0) + 1') })
-            .eq('sd_key', sdId)
-            .eq('status', 'active');
-        } catch (fallbackErr) {
-          console.warn(`   [handoff-fail-count] Non-blocking: ${fallbackErr.message}`);
-        }
-      }
+      await this._incrementHandoffFailCount(sdId);
 
       // SD-MAN-FEAT-CORRECTIVE-VISION-GAP-072 US-001: Governance audit trail
       // Log every handoff execution (failure) to validation_audit_log for compliance review
@@ -549,11 +578,7 @@ export class HandoffRecorder {
       console.log(`📝 Failure recorded: ${executionId} (completion action → leo_handoff_executions)`);
 
       // Same fleet telemetry + governance audit as the phase-transition path
-      try {
-        await this.supabase.rpc('increment_handoff_fail_count', { p_sd_id: sdId });
-      } catch (rpcErr) {
-        console.warn(`   [handoff-fail-count] Non-blocking: ${rpcErr.message}`);
-      }
+      await this._incrementHandoffFailCount(sdId);
       await this._logGovernanceAudit(handoffType, sdUuid, {
         status: 'rejected',
         score: normalizedScore,

--- a/tests/unit/handoff/recorder-fail-count-fallback.test.js
+++ b/tests/unit/handoff/recorder-fail-count-fallback.test.js
@@ -1,0 +1,86 @@
+// QF-20260816-725. HandoffRecorder._incrementHandoffFailCount fixed two silent bugs:
+// (1) the RPC's {error} return was never checked, so a missing increment_handoff_fail_count
+//     function (confirmed absent live: PGRST202) never triggered any fallback at all;
+// (2) the fallback itself called supabase.raw(...), a Knex.js idiom absent from supabase-js,
+//     which threw synchronously and was swallowed by the outer catch.
+import { describe, it, expect } from 'vitest';
+import { HandoffRecorder } from '../../../scripts/modules/handoff/recording/HandoffRecorder.js';
+
+function makeRecorder({ rpcError = null, sessionRow = { handoff_fail_count: 2 }, readError = null, updateError = null } = {}) {
+  const calls = { rpc: [], update: [] };
+  const supabase = {
+    rpc: (name, args) => {
+      calls.rpc.push({ name, args });
+      return Promise.resolve({ data: null, error: rpcError });
+    },
+    from(table) {
+      return {
+        select() { return this; },
+        update(row) {
+          calls.update.push({ table, row });
+          return { eq: () => ({ eq: () => Promise.resolve({ data: null, error: updateError }) }) };
+        },
+        eq() { return this; },
+        maybeSingle: () => Promise.resolve({ data: sessionRow, error: readError }),
+      };
+    },
+  };
+  const recorder = new HandoffRecorder(supabase, {
+    contentBuilder: {},
+    validationOrchestrator: {},
+  });
+  return { recorder, calls };
+}
+
+describe('QF-20260816-725: HandoffRecorder._incrementHandoffFailCount', () => {
+  it('RPC succeeds -> no fallback read/update attempted', async () => {
+    const { recorder, calls } = makeRecorder({ rpcError: null });
+    await recorder._incrementHandoffFailCount('SD-T-001');
+    expect(calls.rpc).toHaveLength(1);
+    expect(calls.update).toHaveLength(0);
+  });
+
+  it('RPC returns an error (e.g. PGRST202, function missing) -> fallback read-then-update increments the counter', async () => {
+    const { recorder, calls } = makeRecorder({
+      rpcError: { message: 'Could not find the function public.increment_handoff_fail_count(p_sd_id) in the schema cache' },
+      sessionRow: { handoff_fail_count: 2 },
+    });
+    await recorder._incrementHandoffFailCount('SD-T-001');
+    expect(calls.update).toHaveLength(1);
+    expect(calls.update[0].row).toEqual({ handoff_fail_count: 3 });
+  });
+
+  it('RPC error + no active session found -> does not throw, no update attempted', async () => {
+    const { recorder, calls } = makeRecorder({
+      rpcError: { message: 'function missing' },
+      sessionRow: null,
+    });
+    await expect(recorder._incrementHandoffFailCount('SD-T-001')).resolves.toBeUndefined();
+    expect(calls.update).toHaveLength(0);
+  });
+
+  it('RPC error + fallback read also errors -> does not throw', async () => {
+    const { recorder } = makeRecorder({
+      rpcError: { message: 'function missing' },
+      readError: { message: 'connection reset' },
+    });
+    await expect(recorder._incrementHandoffFailCount('SD-T-001')).resolves.toBeUndefined();
+  });
+
+  it('RPC error + fallback update errors -> does not throw', async () => {
+    const { recorder } = makeRecorder({
+      rpcError: { message: 'function missing' },
+      updateError: { message: 'constraint violation' },
+    });
+    await expect(recorder._incrementHandoffFailCount('SD-T-001')).resolves.toBeUndefined();
+  });
+
+  it('handoff_fail_count starts NULL -> treated as 0, fallback sets it to 1', async () => {
+    const { recorder, calls } = makeRecorder({
+      rpcError: { message: 'function missing' },
+      sessionRow: { handoff_fail_count: null },
+    });
+    await recorder._incrementHandoffFailCount('SD-T-001');
+    expect(calls.update[0].row).toEqual({ handoff_fail_count: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
C3 #7099 bug_001, Adam-verified. Two silent bugs, both confirmed live:

1. `await this.supabase.rpc('increment_handoff_fail_count', ...)` never checked the RPC's `{error}` return. supabase-js resolves `rpc()` normally (does not throw) even when the function is missing from the schema cache — confirmed live: `increment_handoff_fail_count` does NOT exist (PGRST202). So the try/catch around the bare await never triggered its fallback, ever.
2. The fallback itself called `this.supabase.raw('COALESCE(...) + 1')` — a Knex.js idiom that does not exist on the supabase-js client. It threw a `TypeError` synchronously while building the `.update()` call arguments, silently swallowed by the outer catch. The fleet telemetry counter has therefore never incremented via either path.

Extracted a single `_incrementHandoffFailCount(sdId)` helper (both call sites now share it) that checks the RPC's real error return and, on failure, does an actual read-then-update — no Knex idioms. Best-effort throughout: every failure mode is logged and swallowed, never thrown, matching the original non-blocking-telemetry intent.

## Test plan
- [x] New test file covers: RPC success (no fallback attempted), RPC error with a working fallback (count actually increments), no active session found, fallback read error, fallback update error, and a NULL starting count treated as 0
- [x] Full `tests/unit/handoff/` + `medium-effort-hardening.test.js`: 929/930 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)