### PR TITLE
fix(QF-20260816-506): poll deferred PRD creation by idToUse, not sd_key

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -948,10 +948,14 @@ export class HandoffOrchestrator {
           // lint): 'prd_id' is a phantom column (live 42703) — the PK is 'id'. The phantom
           // select errored into the catch below on EVERY poll, so PRD-creation verification
           // always timed out silently.
+          // QF-20260816-506: the spawn at line ~925 writes with idToUse (sd.id || sdId,
+          // resolved UUID form), but this poll queried by the outer sdId (sd_key form) —
+          // add-prd-to-database.js persists sd_id as the UUID, so a sd_key-keyed poll never
+          // matched and every detached-mode PRD generation burned the full 90s window.
           const { data } = await this.supabase
             .from('product_requirements_v2')
             .select('id')
-            .eq('sd_id', sdId)
+            .eq('sd_id', idToUse)
             .limit(1);
 
           if (data && data.length > 0) {

--- a/tests/unit/handoff/orchestrator-deferred-prd-poll-id.test.js
+++ b/tests/unit/handoff/orchestrator-deferred-prd-poll-id.test.js
@@ -1,0 +1,30 @@
+/**
+ * QF-20260816-506. _executeDeferredPrdGeneration's detached-mode (LLM_PRD_INLINE=false)
+ * spawn writes with idToUse (sd.id || sdId, resolved UUID form) but the verification poll
+ * used to query by the outer sdId (sd_key form) — add-prd-to-database.js persists sd_id as
+ * the UUID, so a sd_key-keyed poll never matched a PRD that had, in fact, already been
+ * created, burning the full 90s window and printing a misleading retry instruction.
+ *
+ * Full behavioral coverage (actually driving the detached spawn + poll loop) requires
+ * mocking node:child_process, which reliably crashes vitest's fork-pool worker in this repo
+ * (verified directly: any vi.mock('child_process', ...) — regardless of shape — produces
+ * "Worker exited unexpectedly" with zero tests run). Reflecting on the real runtime function
+ * object (not a text-file grep) is the safe alternative: it fails if the fix regresses, is
+ * immune to unrelated edits elsewhere in the file, and requires no Node-builtin mocking.
+ */
+import { describe, it, expect } from 'vitest';
+import { HandoffOrchestrator } from '../../../scripts/modules/handoff/HandoffOrchestrator.js';
+
+describe('QF-20260816-506: _executeDeferredPrdGeneration polls by idToUse, not the outer sd_key', () => {
+  it('the PRD-creation poll queries sd_id by idToUse, matching the spawn call', () => {
+    const src = HandoffOrchestrator.prototype._executeDeferredPrdGeneration.toString();
+
+    // idToUse is defined once, at the top of the method, from sd.id || sdId.
+    expect(src).toMatch(/const\s+idToUse\s*=\s*sd\.id\s*\|\|\s*sdId/);
+
+    // The verification poll's .eq('sd_id', ...) must reference idToUse.
+    const eqMatch = src.match(/\.eq\(\s*['"]sd_id['"]\s*,\s*(\w+)\s*\)/);
+    expect(eqMatch).not.toBeNull();
+    expect(eqMatch[1]).toBe('idToUse');
+  });
+});


### PR DESCRIPTION
## Summary
- `_executeDeferredPrdGeneration`'s detached-mode (`LLM_PRD_INLINE=false`) spawn writes with `idToUse` (`sd.id || sdId`, resolved UUID form), but the verification poll queried `product_requirements_v2` by the outer `sdId` (sd_key form).
- `add-prd-to-database.js` persists `sd_id` as the UUID, so a sd_key-keyed poll never matched — every detached-mode PRD generation burned the full 90s polling window and printed a misleading "PRD not created / retry" instruction for a PRD that had, in fact, already been created successfully.
- One-line fix: `.eq('sd_id', sdId)` → `.eq('sd_id', idToUse)`.

## Test plan
- [x] New regression test `tests/unit/handoff/orchestrator-deferred-prd-poll-id.test.js` — reflects on the real `_executeDeferredPrdGeneration` function source (`.toString()` + regex) to assert the poll's `.eq('sd_id', ...)` call references `idToUse`. Full behavioral coverage would require mocking `node:child_process`, which reliably crashes vitest's fork-pool worker in this repo (confirmed via direct experimentation) — reflection is the safe alternative.
- [x] Verified non-vacuous: reverted the fix, confirmed the test fails (`Expected: "idToUse", Received: "sdId"`), restored the fix, confirmed it passes.
- [x] Full `tests/unit/handoff/` suite: 95 files, 892 passed, 1 skipped (pre-existing skip, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)