### PR TITLE
fix(QF-20260816-282): resolveHoldProvenance respects unfenced_at release

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -670,7 +670,15 @@ function resolveHoldProvenance(metadata) {
   };
   const canonical = s(m.requires_human_action_reason);
   if (canonical) {
-    return { reason: canonical, set_by: s(m.requires_human_action_by), set_at: s(m.requires_human_action_at), source_key: 'requires_human_action_reason' };
+    // QF-20260816-282: a hold that has been RELEASED (unfenced_at stamped at/after the
+    // reason was set) must not keep firing just because the reason text is preserved as an
+    // audit trail. Still-held iff unfenced_at is absent, or predates the reason stamp.
+    const setAtMs = Date.parse(m.requires_human_action_at);
+    const unfencedAtMs = Date.parse(m.unfenced_at);
+    const stillHeld = !Number.isFinite(unfencedAtMs) || (Number.isFinite(setAtMs) && unfencedAtMs < setAtMs);
+    if (stillHeld) {
+      return { reason: canonical, set_by: s(m.requires_human_action_by), set_at: s(m.requires_human_action_at), source_key: 'requires_human_action_reason' };
+    }
   }
   const notClaimable = s(m.not_worker_claimable_reason);
   if (notClaimable) {

--- a/tests/unit/fleet/hold-provenance.test.js
+++ b/tests/unit/fleet/hold-provenance.test.js
@@ -87,6 +87,48 @@ describe('resolveHoldProvenance — coalesces every known writer key', () => {
   });
 });
 
+describe('resolveHoldProvenance — QF-20260816-282: unfenced_at releases a preserved requires_human_action_reason', () => {
+  it('a released hold (unfenced_at postdates the reason stamp) is NOT reported as still held', () => {
+    const p = resolveHoldProvenance({
+      requires_human_action_reason: 'CHAIRMAN GATE, preserved as audit trail',
+      requires_human_action_by: 'charlie-83f3be6a-LEAD',
+      requires_human_action_at: '2026-07-28T09:44:50.040Z',
+      unfenced_at: '2026-08-15T14:23:45.752Z',
+      unfenced_by: 'adam 60bb9219 (chairman verbal by SMS)',
+    });
+    expect(p).toBeNull();
+  });
+
+  it('a preserved reason with unfenced_at PREDATING the reason stamp is still held (release predates the fence — stale/invalid)', () => {
+    const p = resolveHoldProvenance({
+      requires_human_action_reason: 'fence set after an earlier unfence timestamp',
+      requires_human_action_at: '2026-08-15T14:23:45.752Z',
+      unfenced_at: '2026-07-28T09:44:50.040Z',
+    });
+    expect(p).not.toBeNull();
+    expect(p.source_key).toBe('requires_human_action_reason');
+  });
+
+  it('a preserved reason with NO unfenced_at at all is still held (the pre-fix, still-correct default)', () => {
+    const p = resolveHoldProvenance({
+      requires_human_action_reason: 'never released',
+      requires_human_action_at: '2026-07-28T09:44:50.040Z',
+    });
+    expect(p).not.toBeNull();
+  });
+
+  it('a released requires_human_action hold falls through to a still-active secondary hold key', () => {
+    const p = resolveHoldProvenance({
+      requires_human_action_reason: 'released chairman gate',
+      requires_human_action_at: '2026-07-28T09:44:50.040Z',
+      unfenced_at: '2026-08-15T14:23:45.752Z',
+      not_worker_claimable_reason: 'PARKED VENTURE — separate, still-active hold',
+    });
+    expect(p.source_key).toBe('not_worker_claimable_reason');
+    expect(p.reason).toBe('PARKED VENTURE — separate, still-active hold');
+  });
+});
+
 describe('formatHoldProvenance — one-line render', () => {
   it('composes reason + by + at, and attests when provenance is absent', () => {
     expect(formatHoldProvenance({ reason: 'parked', set_by: 'coord-1', set_at: '2026-07-03' })).toBe('parked — by coord-1 @ 2026-07-03');


### PR DESCRIPTION
## Summary
- `resolveHoldProvenance()` in `lib/fleet/claim-eligibility.cjs` fired on the mere presence of `metadata.requires_human_action_reason` text, regardless of whether the hold had since been released.
- When a hold is released (`unfenced_at` + chairman decision stamped) but the reason text is deliberately preserved as an audit trail, `post-merge-handoff-orchestrator.js`'s `classifyState()` still refused to auto-advance the SD.
- Witnessed live: `SD-LEO-INFRA-CLOSE-REMAINING-SECURITY-001` was unfenced by chairman decision `dcee581f` (GO, 2026-08-15) — `unfenced_at` postdates `requires_human_action_at` — yet the auto-handoff chain still refused, requiring a direct `handoff.js` invocation as a workaround.
- Fix: the canonical `requires_human_action_reason` branch now only returns a hold when `unfenced_at` is absent, or predates the reason stamp. A released hold falls through to any other still-active hold key (`not_worker_claimable_reason` etc.) rather than short-circuiting entirely.
- Coordinator ruling (signal `30fea88a`): the earlier Tier-3 security-keyword escalation on this QF was a measured false positive (matched the *witness SD name* in the description, not the change surface) — de-escalated to Tier-2, ruling text is in the QF's own description.

## Test plan
- [x] 4 new tests in `tests/unit/fleet/hold-provenance.test.js`: release via a postdating `unfenced_at`; a pre-existing `unfenced_at` that predates the reason (still held); no `unfenced_at` at all (still held, pre-fix behavior unchanged); fall-through to a separate still-active hold key.
- [x] Verified non-vacuous: reverted `stillHeld` to a bare `true`, confirmed 2 of the 4 new tests fail, restored the fix, confirmed all pass again.
- [x] Full `tests/unit/fleet/` suite: 160 files, 2021 tests, 1 pre-existing skip — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)