### PR TITLE
feat(SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001): gh read verbs in RCA retry classifier + escape-hatch fixes

### DIFF
--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 5d1eb9c164d345cc -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: 62462685934eac79 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 6473b055b1c344b5 -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: b9e5690e39e0bafc -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 739f7f8bb4753f13 -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: cbb69f3d6456d8ca -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -294,5 +294,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-08-11 4:01:47 AM*
+*DIGEST generated: 2026-08-16 12:06:43 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 67092da26643a7ae -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: 3cd9fb6440c59da9 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +159,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-08-11 4:01:47 AM*
+*DIGEST generated: 2026-08-16 12:06:43 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 0eac6122d57cd225 -->
+<!-- file_content_hash: 4c02b1e901b8b55f -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-08-16 8:21:11 PM
+**Generated**: 2026-08-16 12:09:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2019,6 +2019,25 @@ git log origin/main --oneline -10 -- <suspected-missing-path>
 If the merges show recent activity on the path in question, the "missing" code may simply be behind an unmerged/unpulled commit from another session — a routine staleness gap, not a real defect or an incomplete sibling SD.
 
 > Why: In a heavily-parallel multi-session fleet, merges land every few minutes. A 9-minute-stale worktree once made another session's in-flight PR (#5783, landing the exact function an SD's rationale depended on) look like a phantom-completed sibling SD, costing real investigation time chasing a non-issue. This pre-check is cheap (one `git fetch` + `git log`) relative to the cost of a false "code is missing" conclusion driving wrong downstream decisions (SD-LEO-FIX-PAYMENT-RAIL-RETRO-001).
+
+## Sanctioned Read-Only CI-Wait Pattern
+
+When you need to block-wait on CI (e.g. during a fix-CI-fix loop), use the built-in `gh` watch subcommands instead of a manual poll loop:
+
+```bash
+# Wait on a specific PR's checks
+gh pr checks <PR#> --repo <owner/repo> --watch
+
+# Wait on a specific workflow run
+gh run watch <run-id>
+```
+
+Both are read-only from the RCA retry-guard's perspective. `gh pr checks --watch` has been allowlist-exempt since QF-20260704-784 (it is not newly enabled by this section) and is now also covered by the classifier's `gh pr checks` pattern. `gh run watch` is covered by the classifier's `gh run watch` pattern; as a single blocking invocation it does not itself generate repeat signatures the way a manual poll loop does.
+
+**Do NOT** hand-roll a poll loop (`while ! gh pr checks ...; do sleep N; done`) — each individual invocation is a separate tool call, and while `gh pr checks` itself is exempt, the surrounding shell loop or a non-exempt variant of the same idea can still accumulate toward the 3-strike guard on unrelated command shapes.
+
+> Why: `gh run list`, `gh pr view`, and other legitimate CI-polling reads had zero coverage in the retry-guard's read-only classifier (`READ_ONLY_LEADING_RE`) before SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001 — 13 narrow one-off allow-list patches landed in 8 weeks instead of a classifier-level fix (QF-20260704-784 for `gh pr checks` alone, after 3 workers tripped it in 90 minutes). Documenting the sanctioned watch-based pattern here, rather than leaving it as a hook source-code comment, means a worker learns it by instruction instead of by accident.
+
 
 ## Database Schema Constraints Reference
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 97c64ec522e89d12 -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: 4c5b94aef7677340 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-08-11 4:01:47 AM*
+*DIGEST generated: 2026-08-16 12:06:43 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: aa559568b677ee7e -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: c48cc8c3951f1d9a -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-08-11 4:01:47 AM*
+*DIGEST generated: 2026-08-16 12:06:43 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 1e2b0144b44537b8 -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: 76de8e37e99eb248 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-08-11 4:01:47 AM*
+*DIGEST generated: 2026-08-16 12:06:43 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-11T09:01:47.097Z -->
-<!-- git_commit: dfb9f70c -->
-<!-- db_snapshot_hash: 8de3099c543fb99b -->
-<!-- file_content_hash: 160a2f06859eb85b -->
+<!-- generated_at: 2026-08-16T16:06:43.346Z -->
+<!-- git_commit: 4bf7f0ea -->
+<!-- db_snapshot_hash: fb220123b858e54d -->
+<!-- file_content_hash: 9dc92353b2529bbd -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-08-16T02:04:54.807Z",
-  "git_commit": "64f719b2",
-  "db_snapshot_hash": "8de3099c543fb99b",
+  "generated_at": "2026-08-16T16:09:32.354Z",
+  "git_commit": "4bf7f0ea",
+  "db_snapshot_hash": "fb220123b858e54d",
   "files": {
     "CLAUDE.md": {
       "type": "full",
@@ -9,7 +9,7 @@
       "bytes": 19704,
       "estimated_tokens": 4892,
       "content_hash": "91b0c479ced58edc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
@@ -17,7 +17,7 @@
       "bytes": 95007,
       "estimated_tokens": 23604,
       "content_hash": "0cd4571f12fb4066",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_CORE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
@@ -25,7 +25,7 @@
       "bytes": 58622,
       "estimated_tokens": 14607,
       "content_hash": "f6545eed8564bb74",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_LEAD.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_LEAD_MANUAL.md": {
       "type": "full",
@@ -33,7 +33,7 @@
       "bytes": 8863,
       "estimated_tokens": 2205,
       "content_hash": "8217f0e7462c52cc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_LEAD_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_LEAD_MANUAL.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
@@ -41,7 +41,7 @@
       "bytes": 55186,
       "estimated_tokens": 13733,
       "content_hash": "8d5cdc5b31dc2a03",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_PLAN.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_PLAN_MANUAL.md": {
       "type": "full",
@@ -49,15 +49,15 @@
       "bytes": 38461,
       "estimated_tokens": 9589,
       "content_hash": "8fc4b18e9dd439dd",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_PLAN_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_PLAN_MANUAL.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 90914,
-      "bytes": 91344,
-      "estimated_tokens": 22729,
-      "content_hash": "0eac6122d57cd225",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_EXEC.md"
+      "chars": 92543,
+      "bytes": 92977,
+      "estimated_tokens": 23136,
+      "content_hash": "4c02b1e901b8b55f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
@@ -65,7 +65,7 @@
       "bytes": 48975,
       "estimated_tokens": 12112,
       "content_hash": "fb9335ffaaf908e9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_ADAM.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_ADAM_MANUAL.md": {
       "type": "full",
@@ -73,7 +73,7 @@
       "bytes": 15843,
       "estimated_tokens": 3925,
       "content_hash": "7e17b4da1a72f526",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_ADAM_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_ADAM_MANUAL.md"
     },
     "CLAUDE_ADAM_PROVENANCE.md": {
       "type": "full",
@@ -81,7 +81,7 @@
       "bytes": 6989,
       "estimated_tokens": 1732,
       "content_hash": "3b7033af88daa0a9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_ADAM_PROVENANCE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_ADAM_PROVENANCE.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
@@ -89,7 +89,7 @@
       "bytes": 26581,
       "estimated_tokens": 6595,
       "content_hash": "79c7380b191bc95a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_COORDINATOR.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
@@ -97,7 +97,7 @@
       "bytes": 61854,
       "estimated_tokens": 15328,
       "content_hash": "c9d4172856d8d983",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_SOLOMON.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_SOLOMON_MANUAL.md": {
       "type": "full",
@@ -105,75 +105,75 @@
       "bytes": 11325,
       "estimated_tokens": 2807,
       "content_hash": "9006ddf1fcc0a31b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_SOLOMON_MANUAL.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_SOLOMON_MANUAL.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9612,
       "bytes": 9654,
       "estimated_tokens": 2403,
-      "content_hash": "67092da26643a7ae",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_DIGEST.md"
+      "content_hash": "3cd9fb6440c59da9",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 13748,
       "bytes": 13862,
       "estimated_tokens": 3437,
-      "content_hash": "739f7f8bb4753f13",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "cbb69f3d6456d8ca",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5552,
       "bytes": 5572,
       "estimated_tokens": 1388,
-      "content_hash": "aa559568b677ee7e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "c48cc8c3951f1d9a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8542,
       "bytes": 8582,
       "estimated_tokens": 2136,
-      "content_hash": "1e2b0144b44537b8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "76de8e37e99eb248",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10965,
       "bytes": 11047,
       "estimated_tokens": 2742,
-      "content_hash": "97c64ec522e89d12",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "4c5b94aef7677340",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 17736,
       "bytes": 18068,
       "estimated_tokens": 4434,
-      "content_hash": "5d1eb9c164d345cc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "62462685934eac79",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 6091,
       "bytes": 6161,
       "estimated_tokens": 1523,
-      "content_hash": "6473b055b1c344b5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "b9e5690e39e0bafc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
       "chars": 3969,
       "bytes": 4011,
       "estimated_tokens": 993,
-      "content_hash": "160a2f06859eb85b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-143\\CLAUDE_SOLOMON_DIGEST.md"
+      "content_hash": "9dc92353b2529bbd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "0316070eb9d83933",
+    "global": "615bc1c4f762422b",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -445,7 +445,8 @@
       "622": "94a8df85a96ad041",
       "626": "f9a040104b9c6234",
       "627": "c1f5247af6cc9d08",
-      "629": "fbba3f3dba64e4a4"
+      "629": "fbba3f3dba64e4a4",
+      "630": "7851b31f692ec87c"
     },
     "meta": {
       "94": {
@@ -1802,6 +1803,11 @@
         "section_type": "solomon_manual",
         "target_file": null,
         "title": "Solomon Manual — reference and procedure (companion)"
+      },
+      "630": {
+        "section_type": "sanctioned_ci_wait_pattern",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Sanctioned Read-Only CI-Wait Pattern"
       }
     }
   }

--- a/lib/hooks/auto-signal-threshold.cjs
+++ b/lib/hooks/auto-signal-threshold.cjs
@@ -130,4 +130,34 @@ function shouldHardBlock({ attempts, bypassed, progressStalled } = {}) {
   return true;
 }
 
-module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs, shouldHardBlock };
+/**
+ * Compute the Control-3 progress fingerprint (claimed SD + phase + progress), or `undefined`
+ * when there is no real progress signal to track.
+ *
+ * SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001: previously this was inlined at pre-tool-enforce.cjs
+ * with `?? ''` fallbacks that ALWAYS produced a string, degenerating to the CONSTANT `'::'` for
+ * every no-SD-claimed session (coordinator/Adam/monitoring loops — exactly the population that
+ * polls CI most). recordAndCount (retry-state-manager.cjs) WRITES that constant as the stored
+ * baseline the first time a repeated signature is seen. If the SAME session later claims an SD,
+ * the next real fingerprint differs from the stale `'::'` baseline → progressStalled reads
+ * `false` (demonstrable progress) → shouldHardBlock/shouldEmitAutoSignal above are SUPPRESSED on
+ * a command that may still be genuinely stuck. This is teeth erosion via a one-time coincidental
+ * state transition, not a harmless no-op.
+ *
+ * Returns `undefined` (never a degenerate string) when `claimedSdKey` is falsy or `progress` is
+ * not a genuine finite number. recordAndCount already treats a non-string progressFingerprint as
+ * "no signal" (its own `typeof === 'string'` guard skips Control 3 entirely), so no baseline is
+ * ever written while unclaimed — closing the defect at the source rather than downstream.
+ *
+ * PURE (no I/O) — extracted here (not left inline in pre-tool-enforce.cjs) specifically so it is
+ * unit-testable without executing the hook, mirroring shouldHardBlock/shouldEmitAutoSignal above.
+ *
+ * @param {{ claimedSdKey?: string|null, phase?: string|null, progress?: number|null|undefined }} opts
+ * @returns {string|undefined}
+ */
+function computeProgressFingerprint({ claimedSdKey, phase, progress } = {}) {
+  if (!claimedSdKey || typeof progress !== 'number' || !Number.isFinite(progress)) return undefined;
+  return `${claimedSdKey}:${phase ?? ''}:${progress}`;
+}
+
+module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs, shouldHardBlock, computeProgressFingerprint };

--- a/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
+++ b/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
@@ -83,6 +83,34 @@ describe('L4 — post-tool-rca-outcome.cjs', () => {
     expect(written.stdout_sha).toBe(digestStdoutTail('SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason'));
   });
 
+  it('FR-3 (SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001): a realistic Claude-Code-shaped Bash tool_response (no exit_code/code/status field, ever) captures exit_code:null, not a fabricated number', () => {
+    // This is the layer distinction the PRD's FR-3 narrows to: retry-state-manager.cjs's
+    // recordAndCount() succeeding-poll exit_code===0 branch is ALREADY fully tested at the
+    // logic layer (tests/unit/retry-state-manager-polling-exemption.test.js) -- given a
+    // numeric exit_code:0 it correctly exempts. What is untested is the CAPTURE layer: does
+    // Claude Code's real Bash tool_response ever actually contain a numeric exit_code/code/
+    // status field for this test to see? The shape below mirrors the real payload shape used
+    // elsewhere in this file (stdout/stderr/interrupted/isImage/noOutputExpected) with
+    // deliberately NO numeric exit field, matching production. If this test ever needs a
+    // numeric field to pass, that is itself the signal that this harness now reports a real
+    // exit code and the succeeding-poll branch's forward-compat path has become reachable.
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'gh run list' },
+      tool_response: { stdout: 'STATUS\tTITLE\tWORKFLOW\n', stderr: '', interrupted: false, isImage: false, noOutputExpected: false },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: { ...process.env, CLAUDE_TOOL_NAME: 'Bash', CLAUDE_SESSION_ID: SESSION_ID, LEO_RETRY_STATE_DIR: tmpDir },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(true); // non-empty stdout is a usable signal, file IS written
+    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(written.exit_code).toBeNull(); // never fabricated, never observed as a real number
+  });
+
   it('TS-5 (SUCCEEDING-POLL-EXEMPTION-001, inverted contract): a SUCCESS payload with NO stdout/stderr content writes NO file and never records exit_code 0', () => {
     // Claude Code Bash tool_response carries NO exit_code and routes error text to stdout,
     // so the OLD Control-4 inference fabricated exit_code:0 for success AND hard failure

--- a/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
@@ -52,6 +52,113 @@ describe('Control 2 — isReadOnlyCommand (deny-by-default classifier)', () => {
     expect(isReadOnlyCommand(undefined)).toBe(false);
     expect(isReadOnlyCommand('')).toBe(false);
   });
+
+  // SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001 (FR-1): gh CLI read verbs. Legitimate CI polling
+  // (gh run list/view, gh pr checks/list/view/diff) previously classified non-read-only —
+  // READ_ONLY_LEADING_RE had zero gh verbs — and accumulated toward the 3-strike RCA block.
+  it('FR-1: gh read verbs classify as read-only', () => {
+    for (const c of [
+      'gh run list', 'gh run view 123', 'gh run watch 9',
+      'gh pr list', 'gh pr view 45', 'gh pr diff 45', 'gh pr checks 45', 'gh pr status',
+      'gh workflow list', 'gh workflow view x',
+      'gh issue list', 'gh issue view 1',
+      'gh api repos/x/y',
+      'GH PR LIST', // case-insensitive
+      'gh  pr   list', // tolerant of extra whitespace
+    ]) {
+      expect(isReadOnlyCommand(c)).toBe(true);
+    }
+  });
+
+  // FR-1 AC-3 + FR-2: near-miss gh verbs (real gh subcommands, confirmed via `gh <noun> --help`,
+  // that are NOT read-only) must not slip through a too-broad pattern. Most consequential:
+  // 'gh pr checkout' is one edit away from the allowlisted 'gh pr checks'.
+  it('FR-1 AC-3: near-miss gh verbs (real but mutating/targeted subcommands) are NOT read-only', () => {
+    for (const c of [
+      'gh pr merge 1', 'gh pr create', 'gh pr close 1', 'gh pr comment 1 --body x',
+      'gh pr checkout 1', 'gh pr edit 1', 'gh pr review 1', 'gh pr ready 1',
+      'gh run rerun 1', 'gh run cancel 1', 'gh run download 1',
+      'gh workflow run deploy.yml', 'gh workflow disable x',
+      'gh issue create', 'gh issue close 1',
+      'gh prune something', // near-miss to the bare-verb family, not a gh subcommand at all
+    ]) {
+      expect(isReadOnlyCommand(c)).toBe(false);
+    }
+  });
+
+  // FR-1 AC-2 + TR-1: gh api's mutating-method exclusion must be a FULL-STRING check, not a
+  // next-token check — adversarially probed (.artifacts/tst-regex-probe.cjs, 40 cases). A
+  // next-token-only implementation passes the obvious cases but false-positives on all of these,
+  // including a real mutation with the flag placed after the path.
+  it('FR-1 AC-2 + TR-1: gh api mutating-method shapes are NOT read-only, including adversarial flag placement', () => {
+    for (const c of [
+      'gh api -X POST /x', 'gh api -XPOST /x',
+      'gh api --method DELETE /x', 'gh api --method delete /x',
+      'gh api -X post /x',
+      'gh api /repos/x/y -X POST', // flag AFTER the path (ordering)
+      'gh api repos/x --method PATCH',
+      'gh api graphql -f query=abc',
+      'gh api repos/x -F body=@f',
+      'gh api repos/x --field a=b', // long form of -f
+      'gh api repos/x --raw-field a=b', // long form of -F
+      'gh api repos/x --input f.json',
+    ]) {
+      expect(isReadOnlyCommand(c)).toBe(false);
+    }
+  });
+
+  // FR-2 AC-2: gh read verbs combined with chaining/redirection remain non-read-only — the
+  // pre-existing MUTATION_OPERATOR_RE guard applies identically to the new gh patterns.
+  it('FR-2 AC-2: gh read verbs combined with chaining/redirection remain non-read-only', () => {
+    for (const c of [
+      'gh run list && git push', 'gh pr view 1 > out.txt', 'gh pr list; echo done',
+      'gh run list | grep foo', 'gh pr view $(echo 1)',
+    ]) {
+      expect(isReadOnlyCommand(c)).toBe(false);
+    }
+  });
+
+  // FR-2 AC-3: every gh verb pattern added in FR-1 must correspond to a real, documented gh
+  // read-only subcommand — not a wildcard over-match. Reference list verified directly against
+  // `gh <noun> --help` output (gh CLI, 2026-08-16) — hardcoded here (not shelled out at test
+  // time) so the test stays deterministic and does not depend on `gh` being installed in CI.
+  it('FR-2 AC-3: parity — every added gh verb is a real, documented read-only subcommand', () => {
+    const REAL_GH_READONLY_SUBCOMMANDS = {
+      run: ['list', 'view', 'watch'],
+      pr: ['list', 'view', 'diff', 'checks', 'status'],
+      workflow: ['list', 'view'],
+      issue: ['list', 'view'],
+    };
+    // Real gh subcommands that exist but are deliberately NOT in the read-only set (mutating or
+    // targeted-write) — asserts the classifier does not accidentally cover them.
+    const REAL_GH_NON_READONLY_SUBCOMMANDS = {
+      run: ['cancel', 'delete', 'download', 'rerun'],
+      pr: ['checkout', 'close', 'comment', 'create', 'edit', 'lock', 'merge', 'ready', 'reopen', 'review', 'unlock', 'update-branch'],
+      workflow: ['disable', 'enable', 'run'],
+      issue: ['close', 'comment', 'create', 'delete', 'develop', 'edit', 'lock', 'pin', 'reopen', 'transfer', 'unlock', 'unpin'],
+    };
+    for (const [noun, verbs] of Object.entries(REAL_GH_READONLY_SUBCOMMANDS)) {
+      for (const verb of verbs) {
+        expect(isReadOnlyCommand(`gh ${noun} ${verb}`)).toBe(true);
+      }
+    }
+    for (const [noun, verbs] of Object.entries(REAL_GH_NON_READONLY_SUBCOMMANDS)) {
+      for (const verb of verbs) {
+        expect(isReadOnlyCommand(`gh ${noun} ${verb} arg`)).toBe(false);
+      }
+    }
+  });
+
+  // FR-1 AC-4 (regression guard, C2/TS-3): the pre-existing EXEMPT_PATTERNS allowlist entry for
+  // 'gh pr checks' (QF-20260704-784) must remain untouched and still cover piped forms that
+  // isReadOnlyCommand structurally cannot (MUTATION_OPERATOR_RE rejects the pipe) — proving FR-1
+  // did not regress the 2026-07-05 3-worker incident that entry was created to fix.
+  it('FR-1 AC-4 / TS-3: gh-pr-checks EXEMPT_PATTERNS entry still covers piped forms isReadOnlyCommand cannot', () => {
+    const { isExempt } = loadFresh();
+    const piped = 'gh pr checks 1 --repo x/y | head -3';
+    expect(isReadOnlyCommand(piped)).toBe(false); // classifier correctly cannot prove this read-only
+    expect(isExempt(piped)).toBe(true); // allowlist backstop still covers it
+  });
 });
 
 describe('TS-1 — succeeding poll (prior SAME command exit 0) never accumulates', () => {

--- a/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
@@ -130,6 +130,17 @@ describe('Control 2 — isReadOnlyCommand (deny-by-default classifier)', () => {
     expect(isReadOnlyCommand('gh api \\\n  /repos/o/r/pulls/1')).toBe(true);
   });
 
+  // PLAN_VERIFY VALIDATION (EXEC-TO-PLAN review round 2): -X was the lone alternative among
+  // -X/--method/-f,-F that didn't tolerate an `=` separator -- `-X=PUT` (verified against the
+  // real gh CLI: behaves identically to `-X PUT`) slipped through. Confirmed newly introduced by
+  // this SD (main had zero gh coverage), not a pre-existing gap.
+  it('FR-1 AC-2 + TR-1 (VALIDATION hardening): -X=VERB equals-shorthand is NOT read-only; -X=GET stays read-only', () => {
+    expect(isReadOnlyCommand('gh api /repos/o/r/pulls/1/merge -X=PUT')).toBe(false);
+    expect(isReadOnlyCommand('gh api /repos/o/r -X=DELETE')).toBe(false);
+    expect(isReadOnlyCommand('gh api /repos/o/r -X=post')).toBe(false); // case-insensitive
+    expect(isReadOnlyCommand('gh api /repos/o/r -X=GET')).toBe(true); // GET is not mutating
+  });
+
   // FR-2 AC-2: gh read verbs combined with chaining/redirection remain non-read-only — the
   // pre-existing MUTATION_OPERATOR_RE guard applies identically to the new gh patterns.
   it('FR-2 AC-2: gh read verbs combined with chaining/redirection remain non-read-only', () => {

--- a/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
@@ -107,6 +107,29 @@ describe('Control 2 — isReadOnlyCommand (deny-by-default classifier)', () => {
     }
   });
 
+  // SECURITY (EXEC-TO-PLAN review): two additional leak classes in the gh-api mutating-method
+  // exclusion, found by independent adversarial re-probing of the SHIPPED module (not a
+  // re-derivation) -- both fixed in the same commit, asserted here so they cannot regress.
+  it('FR-1 AC-2 + TR-1 (SECURITY hardening): quoted method values and newline-continuation mutating flags are NOT read-only', () => {
+    for (const c of [
+      // Quoted method values -- a quote char between the flag and the verb previously broke
+      // the match, since the alternatives required the verb to follow immediately.
+      "gh api /repos/o/r -X 'PUT'",
+      'gh api /repos/o/r -X "POST"',
+      'gh api /repos/o/r --method="POST"',
+      "gh api /repos/o/r --method 'DELETE'",
+      "gh api /repos/o/r -X'POST'",
+      // Newline-continuation -- plain `.` in the lookahead does not match `\n` without /s;
+      // a mutating flag on an indented continuation line was invisible to the exclusion.
+      'gh api /repos/o/r/pulls/1/merge \\\n --method PUT \\\n -f merge_method=squash',
+    ]) {
+      expect(isReadOnlyCommand(c)).toBe(false);
+    }
+    // Sanity control: a genuinely read-only multi-line gh api call (no mutating flag anywhere)
+    // must still classify read-only -- the newline fix must not become an over-broad rejection.
+    expect(isReadOnlyCommand('gh api \\\n  /repos/o/r/pulls/1')).toBe(true);
+  });
+
   // FR-2 AC-2: gh read verbs combined with chaining/redirection remain non-read-only — the
   // pre-existing MUTATION_OPERATOR_RE guard applies identically to the new gh patterns.
   it('FR-2 AC-2: gh read verbs combined with chaining/redirection remain non-read-only', () => {

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1227,7 +1227,23 @@ async function main() {
           // fingerprint (claimed SD + phase + percent), already on disk so no extra I/O.
           // recordAndCount compares it across the repetition; a change means the session is
           // advancing → the auto-signal is suppressed (not a stuck loop).
-          progressFingerprint = `${claimedSdKey || ''}:${st.sd?.phase ?? ''}:${st.sd?.progress ?? ''}`;
+          // SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001: delegate to the extracted, unit-tested
+          // computeProgressFingerprint -- it returns undefined (not a degenerate '::' constant)
+          // when no SD is claimed or progress isn't a real number, so recordAndCount's
+          // typeof-string guard skips Control 3 entirely instead of writing a stale baseline
+          // that could later false-suppress a genuine stuck loop on an unclaimed→claimed
+          // transition. See its docblock in lib/hooks/auto-signal-threshold.cjs.
+          const { computeProgressFingerprint } = require('../../lib/hooks/auto-signal-threshold.cjs');
+          progressFingerprint = computeProgressFingerprint({
+            claimedSdKey,
+            phase: st.sd?.phase,
+            progress: st.sd?.progress,
+          });
+          if (progressFingerprint === undefined && process.env.LEO_TELEMETRY_DEBUG === '1') {
+            process.stderr.write(
+              `[pre-tool-enforce] no_progress_signal (claimedSdKey=${claimedSdKey || 'none'}, progress=${JSON.stringify(st.sd?.progress)})\n`
+            );
+          }
         }
       } catch {
         // Missing state file is not fatal — reset lookup simply no-ops.

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -179,8 +179,16 @@ const MUTATION_OPERATOR_RE = /[;&|`]|>>?|\$\(|<\(/;
 // above (git/ls/cat/etc) are NOT touched by this change -- their lack of \b word-boundary
 // anchoring (lsof/catx/findmnt/envsubst all currently misclassify read-only) is a separate,
 // confirmed, out-of-scope defect, logged for a future targeted fix.
+//
+// SECURITY review (EXEC-TO-PLAN) found the lookahead's plain `.*` does not match `\n` (no /s
+// flag), so a mutating flag placed on an indented continuation line (`gh api /x \` + newline +
+// `  --method PUT`) was invisible -- `[\s\S]*` fixes this. It also found the -X/--method value
+// match required the verb to follow the flag with no separating quote char, so `-X 'PUT'` /
+// `--method="POST"` slipped through -- `['"]?` tolerates an optional quote before the verb.
+// Both closed with zero regression to the 75+ pre-existing/adversarial cases (.artifacts/
+// verify-security-fix.cjs); linear-time confirmed (no ReDoS) on multi-megabyte inputs.
 const READ_ONLY_LEADING_RE =
-  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b|gh\s+(?:run\s+(?:list|view|watch)|pr\s+(?:list|view|diff|checks|status)|workflow\s+(?:list|view)|issue\s+(?:list|view))\b|gh\s+api\b(?!.*(?:(?:^|\s)-X\s*(?:POST|PUT|PATCH|DELETE)\b|--method[=\s]+(?:POST|PUT|PATCH|DELETE)\b|(?:^|\s)-[fF](?:\s|=)|--field\b|--raw-field\b|--input\b)))/i;
+  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b|gh\s+(?:run\s+(?:list|view|watch)|pr\s+(?:list|view|diff|checks|status)|workflow\s+(?:list|view)|issue\s+(?:list|view))\b|gh\s+api\b(?![\s\S]*(?:(?:^|\s)-X\s*['"]?(?:POST|PUT|PATCH|DELETE)\b|--method[=\s]+['"]?(?:POST|PUT|PATCH|DELETE)\b|(?:^|\s)-[fF](?:\s|=)|--field\b|--raw-field\b|--input\b)))/i;
 
 /**
  * Structurally classify a Bash command as provably read-only / non-mutating.

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -187,8 +187,12 @@ const MUTATION_OPERATOR_RE = /[;&|`]|>>?|\$\(|<\(/;
 // `--method="POST"` slipped through -- `['"]?` tolerates an optional quote before the verb.
 // Both closed with zero regression to the 75+ pre-existing/adversarial cases (.artifacts/
 // verify-security-fix.cjs); linear-time confirmed (no ReDoS) on multi-megabyte inputs.
+// PLAN_VERIFY VALIDATION review then found a third, internal-consistency leak: `-X` was the
+// lone alternative among the three (-X / --method / -f,-F) that didn't accept `=` — `gh api
+// ... -X=PUT` (verified against the real gh CLI: `-X=GET` behaves identically to `-X GET`)
+// slipped through. `-X[=\s]*` normalizes it to match its siblings' `=`-tolerance.
 const READ_ONLY_LEADING_RE =
-  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b|gh\s+(?:run\s+(?:list|view|watch)|pr\s+(?:list|view|diff|checks|status)|workflow\s+(?:list|view)|issue\s+(?:list|view))\b|gh\s+api\b(?![\s\S]*(?:(?:^|\s)-X\s*['"]?(?:POST|PUT|PATCH|DELETE)\b|--method[=\s]+['"]?(?:POST|PUT|PATCH|DELETE)\b|(?:^|\s)-[fF](?:\s|=)|--field\b|--raw-field\b|--input\b)))/i;
+  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b|gh\s+(?:run\s+(?:list|view|watch)|pr\s+(?:list|view|diff|checks|status)|workflow\s+(?:list|view)|issue\s+(?:list|view))\b|gh\s+api\b(?![\s\S]*(?:(?:^|\s)-X[=\s]*['"]?(?:POST|PUT|PATCH|DELETE)\b|--method[=\s]+['"]?(?:POST|PUT|PATCH|DELETE)\b|(?:^|\s)-[fF](?:\s|=)|--field\b|--raw-field\b|--input\b)))/i;
 
 /**
  * Structurally classify a Bash command as provably read-only / non-mutating.

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -170,8 +170,17 @@ function isExempt(commandStr) {
 const MUTATION_OPERATOR_RE = /[;&|`]|>>?|\$\(|<\(/;
 
 // Provably read-only leading verbs (anchored at the start of the trimmed command).
+//
+// SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001: adds gh read verbs. The gh api exclusion is a
+// FULL-STRING negative lookahead, not a next-token check -- a next-token-only implementation
+// was adversarially probed (40 cases, .artifacts/tst-regex-probe.cjs) and produces false
+// positives whenever a mutating flag appears after the path (e.g. 'gh api /repos/x/y -X POST'),
+// or via the --field/--raw-field long forms. TR-3 (PRD): the pre-existing bare-verb alternations
+// above (git/ls/cat/etc) are NOT touched by this change -- their lack of \b word-boundary
+// anchoring (lsof/catx/findmnt/envsubst all currently misclassify read-only) is a separate,
+// confirmed, out-of-scope defect, logged for a future targeted fix.
 const READ_ONLY_LEADING_RE =
-  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b)/i;
+  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b|gh\s+(?:run\s+(?:list|view|watch)|pr\s+(?:list|view|diff|checks|status)|workflow\s+(?:list|view)|issue\s+(?:list|view))\b|gh\s+api\b(?!.*(?:(?:^|\s)-X\s*(?:POST|PUT|PATCH|DELETE)\b|--method[=\s]+(?:POST|PUT|PATCH|DELETE)\b|(?:^|\s)-[fF](?:\s|=)|--field\b|--raw-field\b|--input\b)))/i;
 
 /**
  * Structurally classify a Bash command as provably read-only / non-mutating.

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -202,7 +202,8 @@
       "code_quality_pre_commit",
       "exec_atomic_insert_writer_consumer_pattern",
       "fleet_worker_loop_continuity",
-      "worktree_freshness_precheck"
+      "worktree_freshness_precheck",
+      "sanctioned_ci_wait_pattern"
     ],
     "_removed_sections_note": "mandatory_phase_transitions_exec (duplicate of CORE mandatory_phase_transitions), migration_execution_delegation (duplicate of CORE migration_execution_protocol), workflow (was listed twice — removed duplicate). RCA mandate removed from generator — already in router."
   },

--- a/tests/unit/auto-signal-threshold.test.js
+++ b/tests/unit/auto-signal-threshold.test.js
@@ -7,10 +7,13 @@
  * (on the ===2 crossing, not the 3rd hard-block), respects the LEO_AUTO_SIGNAL=off kill-switch, and
  * never fires without a real session identity.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createRequire } from 'node:module';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
 const require = createRequire(import.meta.url);
-const { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs, shouldHardBlock } = require('../../lib/hooks/auto-signal-threshold.cjs');
+const { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs, shouldHardBlock, computeProgressFingerprint } = require('../../lib/hooks/auto-signal-threshold.cjs');
 
 const SID = '11111111-2222-4333-8444-555555555555';
 
@@ -137,6 +140,73 @@ describe('shouldHardBlock (SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPET
   it('ignores non-integer attempts (fail-safe — never blocks on a malformed count)', () => {
     expect(shouldHardBlock({ attempts: NaN })).toBe(false);
     expect(shouldHardBlock({ attempts: undefined })).toBe(false);
+  });
+});
+
+// SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001 (FR-4): extracted from pre-tool-enforce.cjs so the
+// fingerprint computation is unit-testable at its own producer boundary, not just via the
+// consumer (recordAndCount). See the function's own docblock for the full defect history.
+describe('computeProgressFingerprint (SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001, FR-4)', () => {
+  it('returns undefined (never the degenerate constant "::") when no SD is claimed or progress is not a real number', () => {
+    expect(computeProgressFingerprint({ claimedSdKey: null, phase: undefined, progress: undefined })).toBeUndefined();
+    expect(computeProgressFingerprint({})).toBeUndefined();
+    expect(computeProgressFingerprint({ claimedSdKey: 'SD-X', phase: 'LEAD', progress: undefined })).toBeUndefined(); // claimed but no real progress yet
+    expect(computeProgressFingerprint({ claimedSdKey: '', phase: 'LEAD', progress: 10 })).toBeUndefined(); // falsy claimedSdKey
+    expect(computeProgressFingerprint({ claimedSdKey: 'SD-X', phase: 'LEAD', progress: NaN })).toBeUndefined();
+    expect(computeProgressFingerprint({ claimedSdKey: 'SD-X', phase: 'LEAD', progress: 'not-a-number' })).toBeUndefined();
+  });
+
+  it('returns a real, changing string when claimedSdKey and a genuine numeric progress are present', () => {
+    const a = computeProgressFingerprint({ claimedSdKey: 'SD-X', phase: 'EXEC', progress: 40 });
+    const b = computeProgressFingerprint({ claimedSdKey: 'SD-X', phase: 'EXEC', progress: 55 });
+    expect(typeof a).toBe('string');
+    expect(typeof b).toBe('string');
+    expect(a).not.toBe(b);
+  });
+
+  it('progress: 0 is a genuine number, not falsy-treated-as-absent', () => {
+    expect(typeof computeProgressFingerprint({ claimedSdKey: 'SD-X', phase: 'LEAD', progress: 0 })).toBe('string');
+  });
+});
+
+// SD-LEO-INFRA-RCA-READONLY-GH-VERBS-001 (FR-4, TS-5): integration-shaped test reproducing the
+// EXACT defect testing-agent found — a stale baseline written while unclaimed silently
+// suppressing a genuinely-repeating command once the session claims an SD. The pre-fix code
+// would write the constant '::' as the baseline during the unclaimed phase, causing the first
+// real (post-claim) fingerprint to read as "progress" (progressStalled=false) purely because it
+// differed from '::' — not because the command actually stopped repeating.
+describe('TS-5: a stale unclaimed-phase baseline cannot false-suppress a genuine stuck loop after claiming an SD', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'progress-fp-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+  });
+  afterEach(() => {
+    delete process.env.LEO_RETRY_STATE_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('progressStalled reads true (fresh baseline) on the first post-claim sighting, not false via a stale mismatch', async () => {
+    const { recordAndCount } = require('../../scripts/hooks/retry-state-manager.cjs');
+    const session = 'sess-transition';
+    const cmd = 'node scripts/some-repeating-check.js';
+    const rcaCheck = async () => null;
+
+    // Phase 1 (unclaimed): computeProgressFingerprint({claimedSdKey:null}) is undefined (the
+    // fix) -- recordAndCount's typeof-string guard skips Control 3 entirely, so NO baseline is
+    // written for this signature.
+    const unclaimedFp = computeProgressFingerprint({ claimedSdKey: null });
+    const r1 = await recordAndCount(session, null, 'Bash', { command: cmd }, { rcaCheck, progressFingerprint: unclaimedFp });
+    expect(r1.progressStalled).toBeUndefined(); // no fingerprint was tracked at all
+
+    // Phase 2: the SAME session claims an SD, and the SAME signature repeats again -- this is
+    // the FIRST time recordAndCount has ever seen a real progressFingerprint for it.
+    const claimedFp = computeProgressFingerprint({ claimedSdKey: 'SD-X-001', phase: 'LEAD', progress: 0 });
+    const r2 = await recordAndCount(session, 'SD-X-001', 'Bash', { command: cmd }, { rcaCheck, progressFingerprint: claimedFp });
+
+    // Correctly treated as a FRESH baseline, not a stale-'::' mismatch misread as progress.
+    expect(r2.progressStalled).toBe(true);
+    expect(r2.attempts).toBe(2); // the repeat counter itself still accrues normally across both calls
   });
 });
 


### PR DESCRIPTION
## Summary
- `READ_ONLY_LEADING_RE` (the RCA 3-strike retry-guard's read-only classifier) had zero `gh` CLI verbs, so legitimate CI polling (`gh run list`, `gh pr checks`, etc.) accumulated toward a false-positive block -- 13 narrow one-off allow-list patches had landed in 8 weeks instead of a classifier-level fix.
- Adds `gh run/pr/workflow/issue` read verbs + a non-mutating `gh api` pattern, using an adversarially-verified regex (three independent hardening rounds -- see commits).
- Fixes a real bug in the progress-stall escape hatch: a degenerate `'::'` fingerprint written while no SD was claimed could later false-suppress a genuinely stuck loop's hard-block once the same session claimed an SD. Extracted `computeProgressFingerprint` into `lib/hooks/auto-signal-threshold.cjs` so the fix is actually unit-testable.
- Documents the sanctioned `gh pr checks --watch` / `gh run watch` CI-wait pattern in `CLAUDE_EXEC.md`.
- Leaves the pre-existing `EXEMPT_PATTERNS` `gh pr checks` allowlist entry untouched (covers piped forms the new structural classifier cannot).

## Review history (why 3 commits)
- Commit 1: main implementation, all 6 PRD functional requirements.
- Commit 2: EXEC-TO-PLAN SECURITY sub-agent found 2 real leak classes in the `gh api` mutating-flag exclusion (quoted method values, newline-continuation) -- fixed same-session.
- Commit 3: PLAN_VERIFY VALIDATION sub-agent found a 3rd leak class (`-X=VERB` equals-shorthand asymmetry) -- fixed same-session.

Each fix independently verified against the real `gh` CLI and re-tested against the full adversarial case set (91/91 passing, zero regressions) before landing.

## Test plan
- [x] `npx vitest run` on all touched/adjacent test files (7 files, 120+ cases) -- 0 failures
- [x] Full `npm run test:unit`: 3189/3207 files, 39254+/39462+ tests passed (only 3 pre-existing, environment-load-related flaky files, unrelated to this diff, confirmed via isolated re-run)
- [x] TESTING sub-agent: mutation testing (reverted each fix, confirmed tests fail) + independent adversarial probes -- PASS
- [x] SECURITY sub-agent: ReDoS-checked (linear time, multi-megabyte inputs), anchoring confirmed, credential-exposure checked -- CONDITIONAL_PASS, findings folded in
- [x] REGRESSION sub-agent: confirmed pre-existing regex alternations are a byte-for-byte prefix of the final regex (zero chars changed), both production consumers (`pre-tool-enforce.cjs`, `BaseExecutor.js`) unbroken -- PASS
- [x] `node scripts/check-claude-md-drift.cjs` -- passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)