### PR TITLE
fix(QF-20260816-023): paginate past the server's 1000-row response clamp

### DIFF
--- a/lib/coordinator/worker-signal-starvation.cjs
+++ b/lib/coordinator/worker-signal-starvation.cjs
@@ -63,6 +63,11 @@ const LOOKBACK_MS = 30 * 24 * 3600 * 1000; // 30 days
 // binds again as traffic grows, instead of silently resuming the old behaviour.
 const MAX_SIGNALS = 5000;
 const MAX_SAMPLES_LOGGED = 5;
+// QF-20260816-023: PostgREST clamps a single response to this many rows regardless of a larger
+// .limit()/.range() request (measured live 2026-08-16: both fetches below returned exactly 1000
+// even when .limit(5000) was requested). fetchPaginated() below issues repeated .range() requests
+// of this size to actually reach MAX_SIGNALS instead of silently truncating at the server's cap.
+const PAGE_SIZE = 1000;
 // FR-4: row_timestamp is expires_at, not created_at, so the indexed bound must be widened by at
 // least one expiry interval or rows created inside the lookback but expiring just outside it would
 // be missed. One hour is the observed coordination expiry; 2h is deliberate slack.
@@ -105,10 +110,39 @@ function reviveArchivedSignal(archiveRow) {
  */
 function assertNonBinding(liveCount, archivedCount, cap) {
   const fetched = (liveCount || 0) + (archivedCount || 0);
-  if (fetched < cap) return null;
+  // QF-20260816-023: also fire when either source's TOTAL lands exactly on the server page size —
+  // a defensive second trigger in case some other server-side cap stops a source dead at PAGE_SIZE
+  // even though fetchPaginated() below requested more, which the original fetched>=cap check alone
+  // could never see (fetched maxed at PAGE_SIZE+PAGE_SIZE, far short of the 5000 cap).
+  const pageBound = liveCount === PAGE_SIZE || archivedCount === PAGE_SIZE;
+  if (fetched < cap && !pageBound) return null;
   return 'WORKER SIGNALS: TRUNCATED at MAX_SIGNALS=' + cap + ' (fetched ' + fetched
     + ') — the OLDEST signals in the window were discarded and cannot be reported as starved. '
     + 'Raise MAX_SIGNALS; this count is a FLOOR, not a measurement.';
+}
+
+/**
+ * QF-20260816-023: repeatedly .range()-page a query up to `cap` rows, since the server clamps any
+ * single response to PAGE_SIZE regardless of a larger request. Stops early once a page returns
+ * fewer than requested (the source is exhausted). Throws on a query error rather than silently
+ * returning a partial/empty result.
+ * @param {(from:number, to:number) => PromiseLike<{data, error}>} build
+ * @param {number} cap
+ * @returns {Promise<Array>}
+ */
+async function fetchPaginated(build, cap) {
+  const rows = [];
+  let offset = 0;
+  while (rows.length < cap) {
+    const pageEnd = Math.min(offset + PAGE_SIZE, cap) - 1;
+    const { data, error } = await build(offset, pageEnd);
+    if (error) throw new Error(error.message);
+    const page = data || [];
+    rows.push(...page);
+    if (page.length < pageEnd - offset + 1) break; // source exhausted
+    offset += page.length;
+  }
+  return rows;
 }
 
 /** Resolve the starvation threshold (ms) from env, mirroring coordination-events.resolveThresholds. */
@@ -134,12 +168,15 @@ async function reportWorkerSignalStarvation(supabase, opts = {}) {
     const detectors = opts.detectors || require('./detectors.cjs');
     const now = opts.now ?? Date.now();
     const sinceIso = new Date(now - LOOKBACK_MS).toISOString();
-    const { data: signals } = await supabase
-      .from('session_coordination')
-      .select('id, sender_session, sender_type, message_type, acknowledged_at, read_at, payload, created_at')
-      .gte('created_at', sinceIso)
-      .order('created_at', { ascending: false })
-      .limit(MAX_SIGNALS);
+    const signals = await fetchPaginated(
+      (from, to) => supabase
+        .from('session_coordination')
+        .select('id, sender_session, sender_type, message_type, acknowledged_at, read_at, payload, created_at')
+        .gte('created_at', sinceIso)
+        .order('created_at', { ascending: false })
+        .range(from, to),
+      MAX_SIGNALS
+    );
 
     // SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001 (FR-1): ALSO read the archive.
     //
@@ -166,14 +203,17 @@ async function reportWorkerSignalStarvation(supabase, opts = {}) {
     let archiveNote = null;
     try {
       const coarseIso = new Date(now - LOOKBACK_MS - ARCHIVE_COARSE_SLACK_MS).toISOString();
-      const { data: arch, error: archErr } = await supabase
-        .from('retention_archive')
-        .select('row_data')
-        .eq('source_table', 'session_coordination')
-        .gte('row_timestamp', coarseIso)
-        .limit(MAX_SIGNALS);
-      if (archErr) throw new Error(archErr.message);
-      archived = (arch || [])
+      const arch = await fetchPaginated(
+        (from, to) => supabase
+          .from('retention_archive')
+          .select('row_data')
+          .eq('source_table', 'session_coordination')
+          .gte('row_timestamp', coarseIso)
+          .order('row_timestamp', { ascending: false })
+          .range(from, to),
+        MAX_SIGNALS
+      );
+      archived = arch
         .map(reviveArchivedSignal)
         .filter((r) => r && r.created_at && r.created_at >= sinceIso);
     } catch (e) {
@@ -220,6 +260,8 @@ module.exports = {
   // discards the oldest signals. Neither is observable without asserting on it.
   reviveArchivedSignal,
   assertNonBinding,
+  fetchPaginated,
   MAX_SIGNALS,
   LOOKBACK_MS,
+  PAGE_SIZE,
 };

--- a/tests/unit/coordinator/worker-signal-starvation-archive.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation-archive.test.js
@@ -52,12 +52,15 @@ function makeDb({ live = [], archived = [], archiveThrows = false } = {}) {
         eq() { return chain; },
         gte() { return chain; },
         order() { return chain; },
-        limit(n) {
+        // QF-20260816-023: production code now pages via .range(from, to) instead of .limit(n).
+        // These fixtures are always tiny, so this resolves in a single page regardless.
+        range(from, to) {
+          const n = to - from + 1;
           if (chain._t === 'retention_archive') {
             if (archiveThrows) return Promise.resolve({ data: null, error: { message: 'archive boom' } });
-            return Promise.resolve({ data: archived.slice(0, n).map((r) => ({ row_data: r })), error: null });
+            return Promise.resolve({ data: archived.slice(from, from + n).map((r) => ({ row_data: r })), error: null });
           }
-          return Promise.resolve({ data: live.slice(0, n), error: null });
+          return Promise.resolve({ data: live.slice(from, from + n), error: null });
         },
       };
       return chain;

--- a/tests/unit/coordinator/worker-signal-starvation-lookback-window.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation-lookback-window.test.js
@@ -45,7 +45,8 @@ function makeCapturingDb() {
           return api;
         },
         order() { return api; },
-        limit() { return Promise.resolve({ data: [] }); },
+        // QF-20260816-023: production code now pages via .range(from, to) instead of .limit(n).
+        range() { return Promise.resolve({ data: [] }); },
       };
       return api;
     },

--- a/tests/unit/coordinator/worker-signal-starvation-pagination.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation-pagination.test.js
@@ -1,0 +1,128 @@
+/**
+ * QF-20260816-023 — the server clamps a single session_coordination/retention_archive response to
+ * 1000 rows regardless of a larger .limit()/.range() request (measured live 2026-08-16 16:33Z: both
+ * fetches returned exactly 1000 rows). The pre-fix code issued ONE request per source, so a window
+ * with more than 1000 matching rows silently lost everything past the clamp — and because the
+ * archive fetch had NO order() at all, the surviving 1000 were an ARBITRARY subset of the lookback
+ * window, so an answered signal's archived reply could be randomly present or absent from one tick
+ * to the next (witnessed: signals 51724a9c/32c80076 flickered 0->2->6 starved with no new
+ * starvation). assertNonBinding compared fetched>=MAX_SIGNALS(5000), which the 1000-row clamp could
+ * never reach, so the truncation note never fired despite real, silent data loss every tick.
+ *
+ * Under test: fetchPaginated() actually walks past a PAGE_SIZE-sized clamp via repeated .range()
+ * calls, the archive query is now ordered, and assertNonBinding() fires on a PAGE_SIZE-exact total
+ * as a defensive second trigger alongside the MAX_SIGNALS-reached case.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require_ = createRequire(import.meta.url);
+const mod = require_('../../../lib/coordinator/worker-signal-starvation.cjs');
+const { reportWorkerSignalStarvation, fetchPaginated, assertNonBinding, PAGE_SIZE, MAX_SIGNALS } = mod;
+
+const NOW = Date.parse('2026-08-16T16:33:00.000Z');
+const ago = (min) => new Date(NOW - min * 60000).toISOString();
+
+const signal = (id, minAgo = 120) => ({
+  id, sender_session: 'sess-worker', sender_type: 'worker', message_type: 'INFO',
+  acknowledged_at: null, read_at: null,
+  payload: { signal_type: 'stuck', body: 'blocked on x' },
+  created_at: ago(minAgo),
+});
+
+/**
+ * A server that clamps every response to PAGE_SIZE regardless of the requested range, exactly like
+ * the live PostgREST behavior this QF measured — proves fetchPaginated() makes repeated requests
+ * rather than accepting the first clamped page as the whole answer.
+ */
+function makeClampingDb(totalRows) {
+  const orderCalls = { live: 0, archive: 0 };
+  return {
+    orderCalls,
+    from(table) {
+      const isArchive = table === 'retention_archive';
+      const api = {
+        select() { return api; },
+        eq() { return api; },
+        gte() { return api; },
+        order() {
+          if (isArchive) orderCalls.archive++; else orderCalls.live++;
+          return api;
+        },
+        range(from, to) {
+          const requested = to - from + 1;
+          const clamped = Math.min(requested, PAGE_SIZE);
+          const remaining = Math.max(0, totalRows - from);
+          const n = Math.min(clamped, remaining);
+          // Fixed, well-past-threshold age for every row -- the point of this fake is coverage past
+          // the clamp, not age variety (a per-index age would run negative at high offsets and
+          // silently stop counting as starved, masking the exact defect under test).
+          const page = Array.from({ length: n }, (_, i) => signal('s-' + (from + i), 200));
+          return Promise.resolve({ data: page, error: null });
+        },
+      };
+      return api;
+    },
+  };
+}
+
+describe('fetchPaginated — walks past a server-side page clamp', () => {
+  it('retrieves more than one clamped page when more rows exist than PAGE_SIZE', async () => {
+    const totalRows = PAGE_SIZE + 250;
+    const build = (from, to) => Promise.resolve({
+      data: Array.from({ length: Math.min(to - from + 1, Math.max(0, totalRows - from)) }, (_, i) => ({ id: from + i })),
+      error: null,
+    });
+    const rows = await fetchPaginated(build, MAX_SIGNALS);
+    expect(rows.length).toBe(totalRows);
+  });
+
+  it('stops at the requested cap even when the source has more rows still', async () => {
+    const build = (from, to) => Promise.resolve({
+      data: Array.from({ length: to - from + 1 }, (_, i) => ({ id: from + i })), // bottomless source
+      error: null,
+    });
+    const rows = await fetchPaginated(build, 1500);
+    expect(rows.length).toBe(1500);
+  });
+
+  it('throws on a query error rather than returning a silent partial result', async () => {
+    const build = () => Promise.resolve({ data: null, error: { message: 'boom' } });
+    await expect(fetchPaginated(build, MAX_SIGNALS)).rejects.toThrow('boom');
+  });
+});
+
+describe('reportWorkerSignalStarvation — end-to-end past the clamp (QF-20260816-023)', () => {
+  it('finds a starved signal that lived entirely past the first clamped page', async () => {
+    const totalRows = PAGE_SIZE + 5; // the starved signal below is generated at offset PAGE_SIZE+4
+    const db = makeClampingDb(totalRows);
+    const r = await reportWorkerSignalStarvation(db, { now: NOW, log: () => {}, env: {} });
+    // Every row this fake generates is a worker signal older than the 30m default threshold, so the
+    // WHOLE population past the clamp must be visible, not just the first PAGE_SIZE.
+    expect(r.measured).toBe(true);
+    expect(r.starved).toBeGreaterThan(PAGE_SIZE);
+  });
+
+  it('orders the archive query (row_timestamp desc) — an unordered fetch returns an arbitrary subset on repeat calls', () => {
+    const db = makeClampingDb(5);
+    return reportWorkerSignalStarvation(db, { now: NOW, log: () => {}, env: {} }).then(() => {
+      expect(db.orderCalls.archive).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('assertNonBinding — fires on a PAGE_SIZE-exact total, not just MAX_SIGNALS', () => {
+  it('still fires when the true MAX_SIGNALS cap is reached', () => {
+    expect(assertNonBinding(4000, 1000, MAX_SIGNALS)).toMatch(/TRUNCATED/);
+  });
+
+  it('now ALSO fires when a single source lands exactly on PAGE_SIZE, well under MAX_SIGNALS', () => {
+    // This is the exact pre-fix blind spot: two sources each silently clamped at 1000 summed to
+    // 2000, nowhere near the 5000 cap, so the old fetched>=cap check never fired.
+    const note = assertNonBinding(PAGE_SIZE, 3, MAX_SIGNALS);
+    expect(note).toMatch(/TRUNCATED/);
+  });
+
+  it('does not false-positive on an ordinary count that is not a page-size coincidence', () => {
+    expect(assertNonBinding(10, 10, MAX_SIGNALS)).toBeNull();
+  });
+});

--- a/tests/unit/coordinator/worker-signal-starvation.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation.test.js
@@ -23,7 +23,8 @@ function fakeSupabase(rows, { throwOn = false } = {}) {
     select() { return api; },
     gte() { return api; },
     order() { return api; },
-    limit() {
+    // QF-20260816-023: production code now pages via .range(from, to) instead of .limit(n).
+    range() {
       if (throwOn) return Promise.reject(new Error('boom'));
       return Promise.resolve({ data: rows });
     },


### PR DESCRIPTION
## Summary
- Both the live `session_coordination` fetch and the `retention_archive` fetch in `lib/coordinator/worker-signal-starvation.cjs` requested `.limit(MAX_SIGNALS=5000)` but the server clamps a single response to 1000 rows regardless (measured live 2026-08-16 16:33Z: both returned exactly 1000).
- The archive query additionally had NO `order()` at all, so the revived set was an arbitrary 1000 of a 30-day window — a signal's archived reply was randomly present/absent from one tick to the next (witnessed: signals `51724a9c`/`32c80076` flickered 0→2→6 starved with no new starvation, flagging my own already-answered signals as phantoms).
- `assertNonBinding` compared `fetched >= MAX_SIGNALS(5000)`, which the 1000-row clamp could never reach (max 1000+1000=2000), so the truncation note never fired despite real, silent data loss every tick.

## Fix
- `fetchPaginated()` issues repeated `.range()` requests of `PAGE_SIZE` (1000) rows until a page returns short or the requested cap is reached, replacing the single `.limit()` call on both fetches.
- The archive query is now ordered (`row_timestamp desc`), matching the live query's existing `created_at desc` order.
- `assertNonBinding()` now ALSO fires when either source's total lands exactly on `PAGE_SIZE`, as a defensive second trigger alongside the `MAX_SIGNALS`-reached case.

## Test plan
- [x] Updated the 3 existing test fakes (`worker-signal-starvation.test.js`, `-archive.test.js`, `-lookback-window.test.js`) from `.limit()` to `.range()` terminal resolvers to match the new call shape.
- [x] 8 new tests in `worker-signal-starvation-pagination.test.js` covering: `fetchPaginated` walking past a clamped page, stopping at the requested cap, throwing on a query error, an end-to-end starved signal living entirely past the first clamped page, the archive `order()` call firing, and `assertNonBinding`'s new `PAGE_SIZE`-exact trigger.
- [x] Verified non-vacuous: reverted the `pageBound` check in `assertNonBinding` (1 test failed as expected), restored it; disabled the `fetchPaginated` loop entirely (5 of 8 new tests failed as expected), restored it.
- [x] Full `tests/unit/coordinator/` suite: 70 files, 819 tests, no regressions.
- [x] `tests/ci/sweep-legacy-twin-parity.test.js`: 9 tests, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)