### PR TITLE
fix(SD-LEO-INFRA-STORY-CASCADE-ADDITIVE-ONLY-001): stamp provenance on machine-forced user_stories completions

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/atomic-transitions.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/atomic-transitions.js
@@ -22,6 +22,11 @@ export function generateRequestId(sdId, sessionId) {
   return `${sdId}-${sessionId || 'unknown'}-${timestampBucket}`;
 }
 
+// Same format gate scripts/lib/sd-id-resolver.js's resolveSdInput() applies before
+// building an identical .or() filter string -- rejects commas/parens/periods that
+// could otherwise alter the intended PostgREST OR-clause.
+const SD_ID_OR_KEY_FORMAT = /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|SD-[A-Z0-9-]+)$/i;
+
 /**
  * Resolve a Strategic Directive identifier (id or sd_key) to its uuid_id column
  * value -- the SAME column fn_atomic_exec_to_plan_transition resolves p_sd_id to
@@ -36,13 +41,18 @@ export function generateRequestId(sdId, sessionId) {
  * @returns {Promise<string|null>}
  */
 export async function resolveSdUuidId(supabase, sdId) {
+  if (typeof sdId !== 'string' || !SD_ID_OR_KEY_FORMAT.test(sdId)) return null;
   try {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('strategic_directives_v2')
       .select('uuid_id')
       .or(`id.eq.${sdId},sd_key.eq.${sdId}`)
       .limit(1)
       .maybeSingle();
+    if (error) {
+      console.log(`   ⚠️  Provenance stamp: could not resolve SD uuid_id (non-fatal): ${error.message}`);
+      return null;
+    }
     return data?.uuid_id || null;
   } catch {
     return null;
@@ -60,11 +70,15 @@ export async function resolveSdUuidId(supabase, sdId) {
 export async function captureInProgressStories(supabase, sdUuidId) {
   if (!sdUuidId) return [];
   try {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('user_stories')
       .select('id, completed_by')
       .eq('sd_id', sdUuidId)
       .eq('status', 'in_progress');
+    if (error) {
+      console.log(`   ⚠️  Provenance stamp: could not capture in_progress stories (non-fatal): ${error.message}`);
+      return [];
+    }
     return data || [];
   } catch {
     return [];
@@ -87,18 +101,26 @@ export async function stampRpcPromotedStories(supabase, beforeInProgress) {
   if (!beforeInProgress || beforeInProgress.length === 0) return;
   try {
     const ids = beforeInProgress.map((s) => s.id);
-    const { data: after } = await supabase
+    const { data: after, error: fetchError } = await supabase
       .from('user_stories')
       .select('id, status, completed_by')
       .in('id', ids);
 
+    if (fetchError) {
+      console.log(`   ⚠️  Provenance stamp: could not re-fetch promoted stories (non-fatal): ${fetchError.message}`);
+      return;
+    }
+
     const now = new Date().toISOString();
     for (const story of after || []) {
       if (story.status === 'completed' && !story.completed_by) {
-        await supabase
+        const { error: updateError } = await supabase
           .from('user_stories')
           .update({ completed_by: 'system:fn_atomic_exec_to_plan_transition', completed_at: now })
           .eq('id', story.id);
+        if (updateError) {
+          console.log(`   ⚠️  Provenance stamp: failed to stamp story ${story.id} (non-fatal): ${updateError.message}`);
+        }
       }
     }
   } catch (err) {

--- a/scripts/modules/handoff/executors/exec-to-plan/atomic-transitions.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/atomic-transitions.js
@@ -23,6 +23,90 @@ export function generateRequestId(sdId, sessionId) {
 }
 
 /**
+ * Resolve a Strategic Directive identifier (id or sd_key) to its uuid_id column
+ * value -- the SAME column fn_atomic_exec_to_plan_transition resolves p_sd_id to
+ * internally (database/migrations/20260406_fix_exec_to_plan_sd_status.sql:39-43,
+ * `SELECT uuid_id INTO v_sd_uuid ... WHERE id = p_sd_id OR sd_key = p_sd_id`) and
+ * then matches against user_stories.sd_id. uuid_id is a separate column from the
+ * primary key id (kept in sync with uuid_internal_pk via its own trigger), so this
+ * must NOT be conflated with resolveSdInput()'s id field.
+ * Fails soft (returns null) so a resolution error never aborts the RPC transition.
+ * @param {Object} supabase
+ * @param {string} sdId
+ * @returns {Promise<string|null>}
+ */
+export async function resolveSdUuidId(supabase, sdId) {
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('uuid_id')
+      .or(`id.eq.${sdId},sd_key.eq.${sdId}`)
+      .limit(1)
+      .maybeSingle();
+    return data?.uuid_id || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Capture the SD's in_progress stories before the RPC call -- the only status
+ * value fn_atomic_exec_to_plan_transition's own CASE actually promotes to
+ * completed. Fails soft (returns []) so a read error never aborts the transition.
+ * @param {Object} supabase
+ * @param {string|null} sdUuidId
+ * @returns {Promise<Array<{id: string, completed_by: string|null}>>}
+ */
+export async function captureInProgressStories(supabase, sdUuidId) {
+  if (!sdUuidId) return [];
+  try {
+    const { data } = await supabase
+      .from('user_stories')
+      .select('id, completed_by')
+      .eq('sd_id', sdUuidId)
+      .eq('status', 'in_progress');
+    return data || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Stamp provenance on exactly the stories the RPC actually promoted to
+ * completed, matching the same guard discipline as finalizeUserStories()/
+ * transitionUserStoriesToValidated(): only a genuine first-time completion is
+ * stamped, an existing completed_by is never overwritten. Pure no-op when
+ * beforeInProgress is empty (covers both "nothing to promote" and an
+ * idempotent-hit retry, where the original call already promoted everything).
+ * Fails soft -- a stamp failure never reverses or fails the already-successful
+ * RPC transition.
+ * @param {Object} supabase
+ * @param {Array<{id: string, completed_by: string|null}>} beforeInProgress
+ */
+export async function stampRpcPromotedStories(supabase, beforeInProgress) {
+  if (!beforeInProgress || beforeInProgress.length === 0) return;
+  try {
+    const ids = beforeInProgress.map((s) => s.id);
+    const { data: after } = await supabase
+      .from('user_stories')
+      .select('id, status, completed_by')
+      .in('id', ids);
+
+    const now = new Date().toISOString();
+    for (const story of after || []) {
+      if (story.status === 'completed' && !story.completed_by) {
+        await supabase
+          .from('user_stories')
+          .update({ completed_by: 'system:fn_atomic_exec_to_plan_transition', completed_at: now })
+          .eq('id', story.id);
+      }
+    }
+  } catch (err) {
+    console.log(`   ⚠️  Provenance stamp diff failed (non-fatal, transition already succeeded): ${err.message}`);
+  }
+}
+
+/**
  * Execute atomic EXEC-TO-PLAN state transition
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase - Supabase client
@@ -42,6 +126,13 @@ export async function executeAtomicExecToPlanTransition(supabase, sdId, prdId, o
   console.log(`   SD: ${sdId}`);
   console.log(`   PRD: ${prdId || '(none)'}`);
   console.log(`   Request ID: ${requestId}`);
+
+  // Provenance-stamp diff: capture in_progress stories before the RPC call so
+  // we can stamp exactly the rows it promotes afterward, without touching its
+  // SQL body. Resolved/captured before the try block's RPC call so a failure
+  // here (soft-failed to null/[] above) never affects the transition itself.
+  const sdUuidId = await resolveSdUuidId(supabase, sdId);
+  const beforeInProgress = await captureInProgressStories(supabase, sdUuidId);
 
   try {
     const { data, error } = await supabase.rpc('fn_atomic_exec_to_plan_transition', {
@@ -68,6 +159,13 @@ export async function executeAtomicExecToPlanTransition(supabase, sdId, prdId, o
         code: data.code
       };
     }
+
+    // Stamp provenance on whichever previously-in_progress stories the RPC
+    // just promoted to completed. Covers both the fresh-success path below and
+    // an idempotent-hit retry (beforeInProgress is naturally empty on a retry,
+    // since the original call already promoted everything -- this is then a
+    // pure no-op, requiring no special-casing of data.idempotent_hit).
+    await stampRpcPromotedStories(supabase, beforeInProgress);
 
     // Check for idempotent hit
     if (data.idempotent_hit) {
@@ -190,5 +288,8 @@ export default {
   executeAtomicExecToPlanTransition,
   isAtomicTransitionAvailable,
   executeLegacyTransitions,
-  generateRequestId
+  generateRequestId,
+  resolveSdUuidId,
+  captureInProgressStories,
+  stampRpcPromotedStories
 };

--- a/scripts/modules/handoff/executors/exec-to-plan/state-transitions.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/state-transitions.js
@@ -23,7 +23,7 @@ export async function transitionUserStoriesToValidated(supabase, sdId) {
     // Get all user stories for this SD
     const { data: stories, error: fetchError } = await supabase
       .from('user_stories')
-      .select('id, title, e2e_test_path, status, validation_status')
+      .select('id, title, e2e_test_path, status, validation_status, completed_by')
       .eq('sd_id', sdId);
 
     if (fetchError) {
@@ -39,15 +39,29 @@ export async function transitionUserStoriesToValidated(supabase, sdId) {
     // Update each story
     let updatedCount = 0;
     for (const story of stories) {
+      // Idempotency guard (mirrors finalizeUserStories' sibling condition): skip a
+      // story that is already fully complete instead of needlessly rewriting it.
+      if (story.status === 'completed' && story.validation_status === 'validated') {
+        continue;
+      }
+
+      const now = new Date().toISOString();
       const updates = {
         status: 'completed',
         validation_status: 'validated',
-        updated_at: new Date().toISOString()
+        updated_at: now
       };
 
       // Only set e2e_test_status if test path exists
       if (story.e2e_test_path) {
         updates.e2e_test_status = 'passing';
+      }
+
+      // Provenance stamp: only on this story's first-ever completion, never
+      // overwriting an existing completed_by value.
+      if (story.status !== 'completed' && !story.completed_by) {
+        updates.completed_by = 'system:transitionUserStoriesToValidated';
+        updates.completed_at = now;
       }
 
       const { error: updateError } = await supabase

--- a/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
@@ -84,7 +84,7 @@ export async function finalizeUserStories(supabase, prdId, sdId) {
   try {
     let query = supabase
       .from('user_stories')
-      .select('id, title, status, validation_status, e2e_test_path, e2e_test_status');
+      .select('id, title, status, validation_status, e2e_test_path, e2e_test_status, completed_by');
 
     if (prdId) {
       query = query.eq('prd_id', prdId);
@@ -110,14 +110,24 @@ export async function finalizeUserStories(supabase, prdId, sdId) {
     let updatedCount = 0;
     for (const story of stories) {
       if (story.status !== 'completed' || story.validation_status !== 'validated') {
+        const now = new Date().toISOString();
         const updates = {
           status: 'completed',
           validation_status: 'validated',
-          updated_at: new Date().toISOString()
+          updated_at: now
         };
 
         if (story.e2e_test_path && story.e2e_test_status !== 'passing') {
           updates.e2e_test_status = 'passing';
+        }
+
+        // Provenance stamp: only when this call is the one flipping status to
+        // completed for the first time -- never on a validation-only repair of an
+        // already-completed story (which would mislabel a genuine completion as
+        // machine-forced), and never overwriting an existing completed_by value.
+        if (story.status !== 'completed' && !story.completed_by) {
+          updates.completed_by = 'system:finalizeUserStories';
+          updates.completed_at = now;
         }
 
         const { error: updateError } = await supabase

--- a/tests/unit/handoff/executors/exec-to-plan/atomic-transitions-provenance-stamp.test.js
+++ b/tests/unit/handoff/executors/exec-to-plan/atomic-transitions-provenance-stamp.test.js
@@ -73,6 +73,28 @@ describe('resolveSdUuidId', () => {
     const db = { from: vi.fn().mockImplementation(() => { throw new Error('boom'); }) };
     await expect(resolveSdUuidId(db, 'SD-FOO-001')).resolves.toBeNull();
   });
+
+  it('ship-review hardening: rejects a malformed sdId before ever building the .or() filter string', async () => {
+    const db = { from: vi.fn() };
+    const result = await resolveSdUuidId(db, 'not,a,valid;id(with)special.chars');
+    expect(result).toBeNull();
+    expect(db.from).not.toHaveBeenCalled();
+  });
+
+  it('ship-review hardening: a Postgrest-level error (resolved, not thrown) is treated as not-found, not propagated', async () => {
+    const db = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          or: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection reset' } }),
+            }),
+          }),
+        }),
+      }),
+    };
+    await expect(resolveSdUuidId(db, 'SD-FOO-001')).resolves.toBeNull();
+  });
 });
 
 describe('captureInProgressStories', () => {
@@ -246,6 +268,75 @@ describe('executeAtomicExecToPlanTransition provenance stamp', () => {
     await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
 
     expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('regression-lock: the before-capture genuinely runs before the RPC call, not after', async () => {
+    // Ship-review finding: prior tests here used STATIC fixtures for
+    // beforeStories/afterStories, which would pass unchanged even if a future
+    // refactor accidentally moved resolveSdUuidId/captureInProgressStories to
+    // run AFTER the RPC call -- silently defeating the entire diff design
+    // (before would equal after, nothing would ever get stamped in
+    // production). This test uses a shared mutable fake table that the mocked
+    // rpc() call itself mutates, so the before-query only finds the
+    // in_progress row if it genuinely runs first.
+    const table = { s1: { id: 's1', status: 'in_progress', completed_by: null } };
+    const callOrder = [];
+    const updateCalls = [];
+
+    const db = {
+      rpc: vi.fn().mockImplementation(() => {
+        callOrder.push('rpc');
+        table.s1.status = 'completed'; // simulates the real RPC's effect
+        return Promise.resolve({
+          data: { success: true, audit_id: 'a1', stories_updated: 1 },
+          error: null,
+        });
+      }),
+      from: vi.fn((table_) => {
+        if (table_ === 'strategic_directives_v2') {
+          return {
+            select: vi.fn().mockReturnValue({
+              or: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: { uuid_id: 'uuid-sd-1' }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table_ === 'user_stories') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockImplementation(() => {
+                  callOrder.push('before-query');
+                  return Promise.resolve({
+                    data: Object.values(table).filter((s) => s.status === 'in_progress'),
+                    error: null,
+                  });
+                }),
+              }),
+              in: vi.fn().mockImplementation(() => {
+                callOrder.push('after-query');
+                return Promise.resolve({ data: Object.values(table), error: null });
+              }),
+            }),
+            update: vi.fn((updates) => {
+              updateCalls.push(updates);
+              return { eq: vi.fn().mockResolvedValue({ error: null }) };
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(true);
+    expect(callOrder).toEqual(['before-query', 'rpc', 'after-query']);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].completed_by).toBe('system:fn_atomic_exec_to_plan_transition');
   });
 
   it('a stamp-diff failure never reverses a successful RPC transition (fails soft)', async () => {

--- a/tests/unit/handoff/executors/exec-to-plan/atomic-transitions-provenance-stamp.test.js
+++ b/tests/unit/handoff/executors/exec-to-plan/atomic-transitions-provenance-stamp.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for the provenance-stamp diff wrapper added to
+ * executeAtomicExecToPlanTransition() by SD-LEO-INFRA-STORY-CASCADE-ADDITIVE-ONLY-001.
+ *
+ * Covers: resolveSdUuidId, captureInProgressStories, stampRpcPromotedStories, and
+ * their integration into executeAtomicExecToPlanTransition's success/idempotent-hit/
+ * error/exception paths. Live measurement (round-3 VALIDATION review) confirmed the
+ * atomic RPC is the DOMINANT EXEC-TO-PLAN path in production, and a round-5
+ * self-review (during EXEC) found the RPC resolves p_sd_id to
+ * strategic_directives_v2.uuid_id specifically -- a column genuinely distinct from
+ * the primary key id -- so resolveSdUuidId must never be confused with the
+ * codebase's separate resolveSdInput() helper (which returns id).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  executeAtomicExecToPlanTransition,
+  resolveSdUuidId,
+  captureInProgressStories,
+} from '../../../../../scripts/modules/handoff/executors/exec-to-plan/atomic-transitions.js';
+
+function makeAtomicMock({ sdRow, beforeStories, afterStories, rpcResponse, rpcError = null, rpcThrows = null }) {
+  const updateCalls = [];
+  const updateFn = vi.fn((updates) => {
+    updateCalls.push(updates);
+    return { eq: vi.fn().mockResolvedValue({ error: null }) };
+  });
+
+  const beforeEqInnerFn = vi.fn().mockResolvedValue({ data: beforeStories, error: null });
+  const beforeEqOuterFn = vi.fn().mockReturnValue({ eq: beforeEqInnerFn });
+  const afterInFn = vi.fn().mockResolvedValue({ data: afterStories, error: null });
+  const sdOrFn = vi.fn().mockReturnValue({
+    limit: vi.fn().mockReturnValue({
+      maybeSingle: vi.fn().mockResolvedValue({ data: sdRow, error: null }),
+    }),
+  });
+
+  const db = {
+    rpc: vi.fn().mockImplementation(() => {
+      if (rpcThrows) return Promise.reject(rpcThrows);
+      if (rpcError) return Promise.resolve({ data: null, error: rpcError });
+      return Promise.resolve({ data: rpcResponse, error: null });
+    }),
+    from: vi.fn((table) => {
+      if (table === 'strategic_directives_v2') {
+        return { select: vi.fn().mockReturnValue({ or: sdOrFn }) };
+      }
+      if (table === 'user_stories') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: beforeEqOuterFn,
+            in: afterInFn,
+          }),
+          update: updateFn,
+        };
+      }
+      return {};
+    }),
+  };
+
+  return { db, updateFn, updateCalls, beforeEqOuterFn, beforeEqInnerFn, afterInFn, sdOrFn };
+}
+
+describe('resolveSdUuidId', () => {
+  it('resolves sdId (id or sd_key form) to the uuid_id column, not the primary key id', async () => {
+    const { db, sdOrFn } = makeAtomicMock({ sdRow: { uuid_id: 'uuid-abc-123' } });
+    const result = await resolveSdUuidId(db, 'SD-FOO-001');
+    expect(result).toBe('uuid-abc-123');
+    expect(sdOrFn).toHaveBeenCalledWith('id.eq.SD-FOO-001,sd_key.eq.SD-FOO-001');
+  });
+
+  it('fails soft (returns null) on a query error, never throwing', async () => {
+    const db = { from: vi.fn().mockImplementation(() => { throw new Error('boom'); }) };
+    await expect(resolveSdUuidId(db, 'SD-FOO-001')).resolves.toBeNull();
+  });
+});
+
+describe('captureInProgressStories', () => {
+  it('returns [] immediately without querying when sdUuidId is null', async () => {
+    const db = { from: vi.fn() };
+    const result = await captureInProgressStories(db, null);
+    expect(result).toEqual([]);
+    expect(db.from).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeAtomicExecToPlanTransition provenance stamp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('TS-6: stamps exactly the stories the RPC promotes (in_progress -> completed), using the resolved uuid_id', async () => {
+    const beforeStories = [
+      { id: 's1', completed_by: null },
+      { id: 's2', completed_by: null },
+    ];
+    const afterStories = [
+      { id: 's1', status: 'completed', completed_by: null },
+      { id: 's2', status: 'completed', completed_by: null },
+    ];
+    const { db, updateCalls, beforeEqOuterFn, beforeEqInnerFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories,
+      afterStories,
+      rpcResponse: { success: true, audit_id: 'a1', stories_updated: 2 },
+    });
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', 'prd-1');
+
+    expect(result.success).toBe(true);
+    // before-query filtered by the resolved uuid_id and status='in_progress'
+    expect(beforeEqOuterFn).toHaveBeenCalledWith('sd_id', 'uuid-sd-1');
+    expect(beforeEqInnerFn).toHaveBeenCalledWith('status', 'in_progress');
+    // after-query targets exactly the captured in_progress ids
+    expect(afterInFn).toHaveBeenCalledWith('id', ['s1', 's2']);
+    expect(updateCalls).toHaveLength(2);
+    for (const call of updateCalls) {
+      expect(call.completed_by).toBe('system:fn_atomic_exec_to_plan_transition');
+      expect(call.completed_at).toBeTruthy();
+    }
+  });
+
+  it('TS-6b: a story the RPC does not promote (still ready/draft, never in_progress) is never stamped -- it never appears in the before-list at all', async () => {
+    // ready/draft stories are excluded by captureInProgressStories' own
+    // .eq('status','in_progress') filter -- the mock's beforeStories fixture
+    // simply never includes them, proving they cannot reach the after-diff.
+    const { db, updateFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories: [],
+      afterStories: [],
+      rpcResponse: { success: true, audit_id: 'a1', stories_updated: 0 },
+    });
+
+    await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(updateFn).not.toHaveBeenCalled();
+    expect(afterInFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-7: pure no-op fast path when there are zero in_progress stories', async () => {
+    const { db, updateFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories: [],
+      afterStories: [],
+      rpcResponse: { success: true, audit_id: 'a1', stories_updated: 0 },
+    });
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(true);
+    expect(afterInFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-8: skips the after-diff when the RPC call returns success:false', async () => {
+    const { db, updateFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories: [{ id: 's1', completed_by: null }],
+      afterStories: [],
+      rpcResponse: { success: false, error: 'SD not found', code: 'NOT_FOUND' },
+    });
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(false);
+    expect(afterInFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-10: correctly resolves an sd_key-form sdId to the canonical uuid_id before querying user_stories', async () => {
+    const { db, beforeEqOuterFn } = makeAtomicMock({
+      sdRow: { uuid_id: '4cd5c7ff-uuid-form' },
+      beforeStories: [{ id: 's1', completed_by: null }],
+      afterStories: [{ id: 's1', status: 'completed', completed_by: null }],
+      rpcResponse: { success: true, audit_id: 'a1', stories_updated: 1 },
+    });
+
+    await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    // A naive .eq('sd_id', 'SD-FOO-001') against UUID-keyed rows would never
+    // match -- the wrapper must use the resolved uuid_id instead.
+    expect(beforeEqOuterFn).toHaveBeenCalledWith('sd_id', '4cd5c7ff-uuid-form');
+    expect(beforeEqOuterFn).not.toHaveBeenCalledWith('sd_id', 'SD-FOO-001');
+  });
+
+  it('TS-11: an idempotent-hit retry correctly no-ops without special-casing', async () => {
+    const { db, updateFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      // The stories were already promoted by the ORIGINAL call, so a retry's
+      // before-query naturally finds zero in_progress rows.
+      beforeStories: [],
+      afterStories: [],
+      rpcResponse: { success: true, idempotent_hit: true, audit_id: 'a1' },
+    });
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(true);
+    expect(result.idempotent_hit).toBe(true);
+    expect(afterInFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-12: skips the after-diff when the RPC call itself returns an error (not just success:false)', async () => {
+    const { db, updateFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories: [{ id: 's1', completed_by: null }],
+      afterStories: [],
+      rpcResponse: null,
+      rpcError: { message: 'connection reset', code: '08006' },
+    });
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('connection reset');
+    expect(afterInFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-13: skips the after-diff when the RPC call throws (caught by the surrounding try/catch)', async () => {
+    const { db, updateFn, afterInFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories: [{ id: 's1', completed_by: null }],
+      afterStories: [],
+      rpcResponse: null,
+      rpcThrows: new Error('network unreachable'),
+    });
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('EXCEPTION');
+    expect(afterInFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('AC-4: an existing non-null completed_by on a promoted in_progress story is never overwritten', async () => {
+    const { db, updateFn } = makeAtomicMock({
+      sdRow: { uuid_id: 'uuid-sd-1' },
+      beforeStories: [{ id: 's1', completed_by: 'EXEC (manual)' }],
+      afterStories: [{ id: 's1', status: 'completed', completed_by: 'EXEC (manual)' }],
+      rpcResponse: { success: true, audit_id: 'a1', stories_updated: 1 },
+    });
+
+    await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('a stamp-diff failure never reverses a successful RPC transition (fails soft)', async () => {
+    const db = {
+      rpc: vi.fn().mockResolvedValue({
+        data: { success: true, audit_id: 'a1', stories_updated: 1 },
+        error: null,
+      }),
+      from: vi.fn((table) => {
+        if (table === 'strategic_directives_v2') {
+          return { select: vi.fn().mockImplementation(() => { throw new Error('sd lookup failed'); }) };
+        }
+        if (table === 'user_stories') {
+          return { select: vi.fn().mockImplementation(() => { throw new Error('should not be reached'); }) };
+        }
+        return {};
+      }),
+    };
+
+    const result = await executeAtomicExecToPlanTransition(db, 'SD-FOO-001', null);
+
+    expect(result.success).toBe(true);
+    expect(result.audit_id).toBe('a1');
+  });
+});

--- a/tests/unit/handoff/executors/exec-to-plan/state-transitions.test.js
+++ b/tests/unit/handoff/executors/exec-to-plan/state-transitions.test.js
@@ -1,0 +1,101 @@
+/**
+ * Tests for exec-to-plan/state-transitions.js transitionUserStoriesToValidated()
+ *
+ * SD-LEO-INFRA-STORY-CASCADE-ADDITIVE-ONLY-001: this function previously had zero
+ * precondition -- every story for an SD was unconditionally overwritten. It now
+ * (a) skips an already-complete story entirely (idempotency guard, mirroring its
+ * plan-to-lead sibling), and (b) stamps completed_by/completed_at only on a
+ * genuine first-time completion, never overwriting an existing marker.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { transitionUserStoriesToValidated } from '../../../../../scripts/modules/handoff/executors/exec-to-plan/state-transitions.js';
+
+function makeStoriesMock(stories) {
+  const updateCalls = [];
+  const updateFn = vi.fn((updates) => {
+    updateCalls.push(updates);
+    return { eq: vi.fn().mockResolvedValue({ error: null }) };
+  });
+  const db = {
+    from: vi.fn((table) => {
+      if (table === 'user_stories') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: stories, error: null }),
+          }),
+          update: updateFn,
+        };
+      }
+      return {};
+    }),
+  };
+  return { db, updateCalls, updateFn };
+}
+
+describe('transitionUserStoriesToValidated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('TS-4: is a true no-op on an already-complete story (idempotency guard)', async () => {
+    const story = {
+      id: 's1',
+      title: 'Already done',
+      e2e_test_path: null,
+      status: 'completed',
+      validation_status: 'validated',
+      completed_by: null,
+    };
+    const { db, updateFn } = makeStoriesMock([story]);
+
+    await transitionUserStoriesToValidated(db, 'sd-1');
+
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-5: stamps a fresh in_progress story on first completion', async () => {
+    const story = {
+      id: 's2',
+      title: 'In progress',
+      e2e_test_path: null,
+      status: 'in_progress',
+      validation_status: 'pending',
+      completed_by: null,
+    };
+    const { db, updateCalls } = makeStoriesMock([story]);
+
+    await transitionUserStoriesToValidated(db, 'sd-1');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].status).toBe('completed');
+    expect(updateCalls[0].validation_status).toBe('validated');
+    expect(updateCalls[0].completed_by).toBe('system:transitionUserStoriesToValidated');
+    expect(updateCalls[0].completed_at).toBeTruthy();
+  });
+
+  it('FR-2 AC-5: an existing non-null completed_by on an in_progress story survives the call', async () => {
+    const story = {
+      id: 's3',
+      title: 'Manually completed once, needs validation repair',
+      e2e_test_path: null,
+      status: 'in_progress',
+      validation_status: 'pending',
+      completed_by: 'EXEC (manual)',
+    };
+    const { db, updateCalls } = makeStoriesMock([story]);
+
+    await transitionUserStoriesToValidated(db, 'sd-1');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].completed_by).toBeUndefined();
+    expect(updateCalls[0].completed_at).toBeUndefined();
+  });
+
+  it('handles an empty story set without error', async () => {
+    const { db, updateFn } = makeStoriesMock([]);
+
+    await expect(transitionUserStoriesToValidated(db, 'sd-1')).resolves.toBeUndefined();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js
@@ -11,7 +11,10 @@ vi.mock('../../../../../scripts/modules/handoff/lib/retro-clobber-guard.js', () 
   isSafeToWriteRetro: vi.fn().mockResolvedValue({ safe: true, reason: 'no_retro', existingRetro: null }),
 }));
 
-import { satisfyOrchestratorTemplateRequirements } from '../../../../../scripts/modules/handoff/executors/plan-to-lead/state-transitions.js';
+import {
+  satisfyOrchestratorTemplateRequirements,
+  finalizeUserStories,
+} from '../../../../../scripts/modules/handoff/executors/plan-to-lead/state-transitions.js';
 
 describe('satisfyOrchestratorTemplateRequirements', () => {
   let mockDb;
@@ -370,5 +373,97 @@ describe('satisfyOrchestratorTemplateRequirements', () => {
     const result = await satisfyOrchestratorTemplateRequirements(mockDb, 'sd-123', 'Test SD');
     expect(result.satisfied).toBe(true);
     expect(result.created).toHaveLength(2);
+  });
+});
+
+// SD-LEO-INFRA-STORY-CASCADE-ADDITIVE-ONLY-001: finalizeUserStories() must stamp
+// completed_by/completed_at only on a genuine first-time completion, never on a
+// validation-only repair of an already-completed story, and never overwriting an
+// existing completed_by value.
+describe('finalizeUserStories', () => {
+  function makeStoriesMock(stories) {
+    const updateCalls = [];
+    const updateFn = vi.fn((updates) => {
+      updateCalls.push(updates);
+      return { eq: vi.fn().mockResolvedValue({ error: null }) };
+    });
+    const db = {
+      from: vi.fn((table) => {
+        if (table === 'user_stories') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: stories, error: null }),
+            }),
+            update: updateFn,
+          };
+        }
+        return {};
+      }),
+    };
+    return { db, updateCalls, updateFn };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('TS-1: stamps a fresh ready-status story on first completion', async () => {
+    const story = {
+      id: 's1',
+      title: 'Story 1',
+      status: 'ready',
+      validation_status: 'pending',
+      e2e_test_path: null,
+      e2e_test_status: null,
+      completed_by: null,
+    };
+    const { db, updateCalls } = makeStoriesMock([story]);
+
+    await finalizeUserStories(db, null, 'sd-1');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].status).toBe('completed');
+    expect(updateCalls[0].validation_status).toBe('validated');
+    expect(updateCalls[0].completed_by).toBe('system:finalizeUserStories');
+    expect(updateCalls[0].completed_at).toBeTruthy();
+  });
+
+  it('TS-2: does NOT stamp a story that is already completed and only needs validation_status repaired', async () => {
+    const story = {
+      id: 's2',
+      title: 'Story 2',
+      status: 'completed',
+      validation_status: 'pending',
+      e2e_test_path: null,
+      e2e_test_status: null,
+      completed_by: null,
+    };
+    const { db, updateCalls } = makeStoriesMock([story]);
+
+    await finalizeUserStories(db, null, 'sd-1');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].validation_status).toBe('validated');
+    expect(updateCalls[0].completed_by).toBeUndefined();
+    expect(updateCalls[0].completed_at).toBeUndefined();
+  });
+
+  it('TS-3: never overwrites an existing completed_by value', async () => {
+    const story = {
+      id: 's3',
+      title: 'Story 3',
+      status: 'ready',
+      validation_status: 'pending',
+      e2e_test_path: null,
+      e2e_test_status: null,
+      completed_by: 'Alpha (worker session e7c92ad8)',
+    };
+    const { db, updateCalls } = makeStoriesMock([story]);
+
+    await finalizeUserStories(db, null, 'sd-1');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].completed_by).toBeUndefined();
+    expect(updateCalls[0].completed_at).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- `finalizeUserStories()`, `transitionUserStoriesToValidated()`, and the atomic EXEC-TO-PLAN RPC path all force-complete `user_stories` rows with zero provenance -- a worker's evidence-based non-completion is indistinguishable from a machine-forced one after the fact.
- Stamps `completed_by`/`completed_at` only on a story's genuine first-time completion (never on a validation-only repair of an already-completed row, never overwriting an existing marker) at all 3 real write sites, including a new JS-only before/after diff around the dominant atomic-RPC path.
- No skip/gate guard was added: two independent adversarial reviews (prospective testing-agent, then independent validation-agent) found any "preserve worker intent by skipping" design would fail PLAN-TO-LEAD's `ACCEPTANCE_CRITERIA_VALIDATION` gate on ~42% of historical SDs, since `finalizeUserStories()`'s call site exists specifically to make that gate pass.
- LEAD-phase investigation found the SD's original premise (a bulk-flipping DB trigger, fixable via a chairman-gated migration) was false -- no such trigger exists; the real mechanism is plain application JS, so this ships as a normal code fix with no migration.

## PR size justification (600 LOC total, exceeds the 400 LOC tiered ceiling)
- **~135 LOC is the actual production fix**, spread symmetrically across 3 related write sites (each individually well under 150 LOC).
- **~465 LOC is exhaustive test coverage** (20 new test cases across 3 files) closing a pre-existing zero-coverage gap on all 3 functions, directly implementing the fixture requirements demanded by 3 rounds of adversarial pre-merge review.
- Splitting code from its tests would ship either unverified production code or orphaned tests -- neither is acceptable, so this ships as one PR.

## Test plan
- [x] `npx vitest run tests/unit/handoff/` -- 96 files, 907 passed, 1 pre-existing unrelated skip, 0 failed
- [x] Mutation-tested the critical FR-1 guard: reverted it to always-stamp, confirmed the 2 guarding tests correctly failed, restored the exact original (verified byte-identical via `git diff --stat`)
- [x] ESLint clean on all 3 source files + 3 test files
- [x] 3 adjacent, genuinely out-of-scope findings (e2e_test_status fabrication cascading through a real trigger; a separate RPC ready/draft-promotion bug; an inert-but-armed deliverable-linkage cascade) recorded as queryable `feedback` rows via `log-harness-bug.js`, not silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)