### PR TITLE
fix(QF-20260807-698): apply the one gate-threshold INCREASE without collateral

### DIFF
--- a/scripts/modules/ai-quality-evaluator/config.js
+++ b/scripts/modules/ai-quality-evaluator/config.js
@@ -25,8 +25,22 @@ export const SD_TYPE_PASS_THRESHOLDS = {
   // Database SDs: Slightly stricter (data integrity)
   database: 65,
 
-  // Security SDs: Stricter (but not blocking)
-  security: 65,
+  // Security SDs: raised 65 -> 70 by QF-20260807-698 (re-measured at claim per Adam addendum
+  // 2026-08-16, superseding the 3-set recorded at filing).
+  // BEFORE VALUE FOR ROLLBACK: 65 (the value SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002 shipped).
+  // Restoring 65 is the whole rollback.
+  //
+  // SAME GRANULARITY TRAP AS refactor's OWN COMMENT BELOW: the tuning view recommends per
+  // (sd_type x content_type), but this table is keyed by sd_type ALONE, so a per-cell
+  // recommendation can only be applied when EVERY content_type cell under that sd_type clears
+  // the new bar. Re-measured live 2026-08-16: security's actionable cell (user_story, n=17,
+  // avg=81.5, 100% pass) supports 70, and its two low-n siblings (prd n=5 avg=84.4;
+  // retrospective n=9 avg=83.4 — both INSUFFICIENT_DATA on their own) already sit comfortably
+  // above 70, so raising the shared key has no collateral. This is the ONLY one of six
+  // live-2026-08-16 INCREASE recommendations that clears this test; see
+  // scripts/quality/tuning-003-disposition.mjs for the full snapshot and the collateral
+  // measurement that refused the other five (bugfix, feature, infrastructure x2, orchestrator).
+  security: 70,
 
   // Refactor SDs: raised 60 -> 65 by SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002.
   // BEFORE VALUE FOR ROLLBACK: no key at all — refactor fell through to DEFAULT_THRESHOLD (60).

--- a/scripts/quality/tuning-003-disposition.mjs
+++ b/scripts/quality/tuning-003-disposition.mjs
@@ -1,0 +1,83 @@
+/**
+ * QF-20260807-698 — snapshot + disposition report, re-measured at claim per Adam addendum
+ * (2026-08-16T17:35:51.678Z, advisory 95a3c116: "v_ai_quality_tuning_recommendations now flags
+ * SIX INCREASE/DECREASE recommendations (was 3 surviving at filing). RE-MEASURE the view at claim
+ * time and apply per-type with review; the 6-set supersedes the 3-set").
+ *
+ * Mirrors scripts/quality/tuning-002-disposition.mjs's structure: THE REPORT IS THE DELIVERABLE
+ * FOR EVERYTHING NOT APPLIED — a run that printed only the applied change would be
+ * indistinguishable from one that never considered the rest, and silence about an adjudicated
+ * recommendation reads exactly like an oversight.
+ *
+ * THE GRANULARITY TRAP THIS DISPOSITION EXISTS TO CATCH: the tuning view recommends per
+ * (sd_type x content_type), but scripts/modules/ai-quality-evaluator/config.js's
+ * SD_TYPE_PASS_THRESHOLDS is keyed by sd_type ALONE (scoring.js never passes content_type when
+ * resolving it) — so a per-cell INCREASE can only be safely applied when EVERY OTHER content_type
+ * cell under that same sd_type already clears the new, higher bar. Applying blind to a single
+ * named cell silently raises the bar under every sibling cell too.
+ *
+ * Read-only. Run: node scripts/quality/tuning-003-disposition.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const { data: rows, error } = await sb.from('v_ai_quality_tuning_recommendations').select('*');
+if (error) { console.error('view read failed: ' + error.message); process.exit(2); }
+
+const kind = (r) => String(r.recommendation).split(':')[0].split(' ')[0];
+const cell = (r) => r.sd_type + ' x ' + r.content_type;
+const bySdType = (sdType) => rows.filter((r) => r.sd_type === sdType);
+
+// FR-1 — the frozen evidence base. The view MOVES while you measure it (same lesson as
+// tuning-002-disposition.mjs), so a diff against a live read later is not reviewable. Emitting the
+// snapshot is what makes the rest of this citable.
+console.log('=== FR-1 SNAPSHOT (' + rows.length + ' rows, live re-measurement at QF-20260807-698 claim) ===');
+for (const r of rows.filter((x) => ['DECREASE', 'INCREASE'].includes(kind(x)))) {
+  console.log('  ' + kind(r).padEnd(9) + cell(r).padEnd(34) + ' thr=' + String(r.current_threshold).padEnd(3)
+    + '-> ' + String(r.suggested_threshold).padEnd(3) + ' avg=' + String(r.avg_score).padEnd(5)
+    + ' pass=' + String(r.pass_rate).padEnd(5) + '% n=' + r.assessments_last_4_weeks);
+}
+
+// APPLIED. Only the sd_type whose EVERY content_type cell clears the new shared bar.
+console.log('\n=== APPLIED (1 change, no collateral) ===');
+const security = bySdType('security');
+console.log('  security 65 -> 70   [' + security.map((r) => r.content_type + ' avg=' + r.avg_score + ' n=' + r.assessments_last_4_weeks).join(', ') + ']');
+console.log('    rollback: restore security: 65 in scripts/modules/ai-quality-evaluator/config.js');
+console.log('    pre-apply baseline (for the 4-week-later measured-delta requirement):');
+for (const r of security) {
+  console.log('      ' + r.content_type.padEnd(14) + ' pass%=' + r.pass_rate + ' avg=' + r.avg_score + ' n=' + r.assessments_last_4_weeks + ' (measured ' + new Date().toISOString() + ')');
+}
+
+// REFUSED — not descoped. Each named cell's own recommendation is sound; the shared-key
+// granularity makes it unimplementable without moving a sibling cell that cannot bear it.
+console.log('\n=== REFUSED (5) — granularity mismatch, NOT a judgement on the named cell ===');
+const refused = [
+  { rec: 'bugfix x prd 60 -> 65', sdType: 'bugfix', collateral: 'bugfix x user_story' },
+  { rec: 'feature x prd 60 -> 65', sdType: 'feature', collateral: 'feature x user_story' },
+  { rec: 'infrastructure x prd 55 -> 60', sdType: 'infrastructure', collateral: 'infrastructure x user_story' },
+  { rec: 'infrastructure x retrospective 55 -> 60', sdType: 'infrastructure', collateral: 'infrastructure x user_story' },
+  { rec: 'orchestrator x retrospective 50 -> 55', sdType: 'orchestrator', collateral: 'orchestrator x user_story' },
+];
+for (const { rec, collateral } of refused) {
+  const c = rows.find((r) => cell(r) === collateral);
+  console.log('  ' + rec.padEnd(42) + ' would ALSO raise ' + collateral
+    + ' (avg ' + c.avg_score + ', ' + c.pass_rate + '% pass, n=' + c.assessments_last_4_weeks + ') — cannot clear the new bar');
+}
+
+// HELD — a DECREASE requires the fuller two-sided review QF-20260807-145 established for the
+// whole DECREASE arm (does the SAME sd_type's other content_type cells score far higher, meaning
+// the low cell is a CONTENT signal rather than a THRESHOLD signal). That review is not a bar-vs-
+// mean check alone and was not performed here; this disposition does not resolve it.
+console.log('\n=== HELD (1) — DECREASE requires the QF-20260807-145 two-sided review, not performed here ===');
+const orchUserStory = rows.find((r) => cell(r) === 'orchestrator x user_story');
+const orchPrd = rows.find((r) => cell(r) === 'orchestrator x prd');
+const orchRetro = rows.find((r) => cell(r) === 'orchestrator x retrospective');
+if (orchUserStory) {
+  console.log('  orchestrator x user_story 50 -> 45   avg=' + orchUserStory.avg_score + ' pass%=' + orchUserStory.pass_rate + ' n=' + orchUserStory.assessments_last_4_weeks);
+  console.log('    same sd_type\'s other cells: prd avg=' + (orchPrd?.avg_score ?? 'n/a') + ', retrospective avg=' + (orchRetro?.avg_score ?? 'n/a')
+    + ' — both in the 76-91 range QF-20260807-145 identified as the UNMASKABLE SIGNAL fingerprint');
+  console.log('    NOT applied. Needs the same holistic content-signal review the original 6 refused DECREASEs received.');
+}
+
+console.log('\nOK: 1 applied (security), 5 refused (granularity collateral), 1 held (needs DECREASE review).');

--- a/tests/unit/quality/ai-quality-evaluator-config.test.js
+++ b/tests/unit/quality/ai-quality-evaluator-config.test.js
@@ -1,0 +1,41 @@
+/**
+ * QF-20260807-698 — pins scripts/modules/ai-quality-evaluator/config.js's SD_TYPE_PASS_THRESHOLDS
+ * against the disposition in scripts/quality/tuning-003-disposition.mjs: exactly ONE change
+ * (security 65 -> 70) was applied; five sibling INCREASE recommendations and one DECREASE were
+ * refused/held because SD_TYPE_PASS_THRESHOLDS is keyed by sd_type alone (no content_type axis),
+ * so applying any of them would collaterally raise the bar on a sibling content_type cell that
+ * cannot bear it (see the disposition script for the measured evidence).
+ */
+import { describe, it, expect } from 'vitest';
+import { SD_TYPE_PASS_THRESHOLDS, ORCHESTRATOR_THRESHOLD, DEFAULT_THRESHOLD } from '../../../scripts/modules/ai-quality-evaluator/config.js';
+
+describe('SD_TYPE_PASS_THRESHOLDS — QF-20260807-698 disposition', () => {
+  it('APPLIED: security raised 65 -> 70 (the only cell whose siblings all cleared the new bar)', () => {
+    expect(SD_TYPE_PASS_THRESHOLDS.security).toBe(70);
+  });
+
+  it('REFUSED: bugfix, infrastructure, and orchestrator INCREASE recommendations were NOT applied', () => {
+    // bugfix has no dedicated key at all -- it must keep falling through to DEFAULT_THRESHOLD,
+    // exactly like refactor did before TUNING-002 gave it one.
+    expect(SD_TYPE_PASS_THRESHOLDS.bugfix).toBeUndefined();
+    // infrastructure's prd/retrospective cells both recommended 55 -> 60, refused because
+    // infrastructure x user_story (avg ~53, the largest cell in the view) cannot clear 60.
+    expect(SD_TYPE_PASS_THRESHOLDS.infrastructure).toBe(55);
+    // orchestrator has no dedicated key -- ORCHESTRATOR_THRESHOLD governs it separately, and its
+    // retrospective cell's 50 -> 55 recommendation was refused because orchestrator x user_story
+    // cannot clear 55 (and the SAME view recommends DECREASING that cell, not raising the shared bar).
+    expect(SD_TYPE_PASS_THRESHOLDS.orchestrator).toBeUndefined();
+    expect(ORCHESTRATOR_THRESHOLD).toBe(50);
+  });
+
+  it('REFUSED: feature was NOT raised (feature x user_story cannot clear a higher bar)', () => {
+    expect(SD_TYPE_PASS_THRESHOLDS.feature).toBe(60);
+  });
+
+  it('unrelated thresholds are untouched by this QF', () => {
+    expect(SD_TYPE_PASS_THRESHOLDS.documentation).toBe(50);
+    expect(SD_TYPE_PASS_THRESHOLDS.database).toBe(65);
+    expect(SD_TYPE_PASS_THRESHOLDS.refactor).toBe(65);
+    expect(DEFAULT_THRESHOLD).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- QF-20260807-145 dispositioned 9 tuning recommendations: 6 DECREASEs refused on evidence, 3 INCREASEs "approved-in-principle but unapplied" pending a post-apply delta measurement. Per Adam addendum (2026-08-16T17:35:51Z, advisory `95a3c116`), the live view now flags a different set — this QF re-measures `v_ai_quality_tuning_recommendations` at claim per the addendum's instruction rather than trusting the stale 3-set.
- Live re-measurement (2026-08-16) found **6 INCREASE + 1 DECREASE**. Applying blindly runs into a granularity trap already documented in `config.js`'s own `refactor` comment: `SD_TYPE_PASS_THRESHOLDS` is keyed by `sd_type` ALONE (no `content_type` axis) — raising one content_type's cell collaterally raises every sibling content_type under that sd_type.
- Checked each of the 6 INCREASEs against its siblings: **only `security` (65→70) has zero collateral** — its siblings (`prd` avg=84.4, `retrospective` avg=83.4) already clear 70 comfortably. The other 5 (`bugfix`, `feature`, `infrastructure` x2, `orchestrator`) each collide with a `user_story` sibling well below the proposed bar, mirroring exactly why `refactor` was the sole applicable cell from the original 3-set.
- The 1 DECREASE (`orchestrator/user_story` 50→45) is **NOT applied**: its sibling cells (`prd` avg=79.1, `retrospective` avg=86.9) sit in the same 76–91 range QF-20260807-145 identified as the "unmaskable signal" fingerprint across the whole refused DECREASE arm — it needs that same holistic review, which this QF does not perform.

## Changes
- `scripts/modules/ai-quality-evaluator/config.js`: `security: 65 → 70`, with a comment matching the `refactor` precedent's documentation style (rollback value, collateral-check rationale).
- New `scripts/quality/tuning-003-disposition.mjs` (read-only, mirrors the prior `tuning-002-disposition.mjs`): the auditable record — FR-1 snapshot, the applied change with its pre-apply baseline (for the 4-week-later measured-delta requirement the acceptance still needs), the 5 refused INCREASEs with their blocking measurement, and the 1 held DECREASE with its review requirement.

## Test plan
- [x] New `tests/unit/quality/ai-quality-evaluator-config.test.js` pins the disposition: `security=70` applied; `bugfix`/`orchestrator` absent (no key), `infrastructure=55`, `feature=60` unchanged (all refused); `database`, `documentation`, `refactor` untouched.
- [x] Verified non-vacuous: reverted `security` to 65, confirmed the pinning test fails, restored it.
- [x] `tests/unit/quality/`, `tuning-rules.test.js`, `threshold-acceptance.test.js`: 6 files, 110 tests, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)