### PR TITLE
fix(QF-20260712-716): graduate 2 enabled-never-rolled-out flags

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2951,10 +2951,15 @@ export class StageExecutionWorker {
     // S19 backstop's "short-circuit with zero extra queries" contract: the
     // (cached) governance classification is checked FIRST, so the overwhelming
     // majority of stages (not chairman-designated high-consequence) never touch
-    // chairman_decisions or leo_feature_flags at all. A DB-level kill-switch
-    // (leo_feature_flags.LEO_HIGH_CONSEQUENCE_GATES_ENABLED, default ON) allows
-    // disabling the check fleet-wide without a code deploy if a bug is ever found
-    // here (security-agent finding, evidence 7b374eff). Scoped by
+    // chairman_decisions at all.
+    //
+    // QF-20260712-716 (Adam flag-gov ruling 8118abe7, 2026-08-16): GRADUATED. The
+    // leo_feature_flags.LEO_HIGH_CONSEQUENCE_GATES_ENABLED kill-switch read was
+    // removed — it was enabled-never-rolled-out (live is_enabled=true throughout),
+    // so this now permanently enforces the check rather than reading a flag that
+    // has never been flipped off. The DB-side fn_advance_venture_stage read of
+    // this same flag_key is a SEPARATE, out-of-scope surface (not touched by this
+    // QF) and continues reading the flag row unchanged. Scoped by
     // lifecycle_stage = fromStage so a blocking decision at one stage never holds
     // advancement from a different stage. This mirrors the equivalent additive
     // check in fn_advance_venture_stage (same PR) — BOTH chokepoints must carry
@@ -2967,33 +2972,23 @@ export class StageExecutionWorker {
       if (!gov.isHighConsequence(fromStage)) {
         highConsequenceBlocked = false; // short-circuit — not a chairman-designated stage
       } else {
-        // Both reads below MUST surface `error` explicitly and throw on it -- supabase-js
-        // returns DB/PostgREST errors via `{data:null, error}` WITHOUT throwing, so a
-        // data-only destructure would silently read `data` as null and compute a false
-        // "not blocked" result, defeating the fail-closed contract this backstop exists
-        // for (adversarial-review finding, PR #6104: this exact gap was live prior to fix).
-        const { data: flagRow, error: flagErr } = await this._supabase
-          .from('leo_feature_flags')
-          .select('is_enabled')
-          .eq('flag_key', 'LEO_HIGH_CONSEQUENCE_GATES_ENABLED')
+        // MUST surface `error` explicitly and throw on it -- supabase-js returns
+        // DB/PostgREST errors via `{data:null, error}` WITHOUT throwing, so a
+        // data-only destructure would silently read `data` as null and compute a
+        // false "not blocked" result, defeating the fail-closed contract this
+        // backstop exists for (adversarial-review finding, PR #6104: this exact
+        // gap was live prior to fix).
+        const { data: pendingBlockingDecision, error: decisionErr } = await this._supabase
+          .from('chairman_decisions')
+          .select('id')
+          .eq('venture_id', ventureId)
+          .eq('lifecycle_stage', fromStage)
+          .eq('status', 'pending')
+          .eq('blocking', true)
+          .limit(1)
           .maybeSingle();
-        if (flagErr) throw flagErr;
-        const flagEnabled = flagRow ? flagRow.is_enabled : true; // default ON when flag row absent
-        if (!flagEnabled) {
-          highConsequenceBlocked = false;
-        } else {
-          const { data: pendingBlockingDecision, error: decisionErr } = await this._supabase
-            .from('chairman_decisions')
-            .select('id')
-            .eq('venture_id', ventureId)
-            .eq('lifecycle_stage', fromStage)
-            .eq('status', 'pending')
-            .eq('blocking', true)
-            .limit(1)
-            .maybeSingle();
-          if (decisionErr) throw decisionErr;
-          highConsequenceBlocked = !!pendingBlockingDecision;
-        }
+        if (decisionErr) throw decisionErr;
+        highConsequenceBlocked = !!pendingBlockingDecision;
       }
     } catch (e) {
       this._logger.error(`[Worker] High-consequence choke-point eval error (FAIL-CLOSED): ${e.message}`);

--- a/lib/eva/stage-governance.js
+++ b/lib/eva/stage-governance.js
@@ -59,25 +59,18 @@ async function _readFresh(supabase) {
   if (error) throw error;
 
   // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A (FR-1): venture_stages.is_high_consequence
-  // has no per-row flag-gating, so the cutover kill-switch is applied HERE, at the single
-  // shared read both JS chokepoints (stage-execution-worker.js's per-tick review-mode
-  // block and its _advanceStage 4th backstop) consume via isHighConsequence/
-  // highConsequenceStages. Default OFF (row absent, or is_enabled=false) — treats every
-  // stage as NOT high-consequence regardless of the DB column, preserving pre-cutover
-  // behavior until the flag is deliberately flipped on (TR-1 reversibility). Cached
-  // alongside the venture_stages read (same 60s TTL) — a flag flip may take up to that
-  // long to take effect, an accepted latency for a one-time, deliberately-flipped cutover
-  // (not a per-request emergency kill-switch, which the RPC/callers already read fresh —
-  // see LEO_HIGH_CONSEQUENCE_GATES_ENABLED reads in stage-execution-worker.js and
-  // fn_advance_venture_stage).
-  const { data: cutoverFlagRow, error: cutoverFlagErr } = await supabase
-    .from('leo_feature_flags')
-    .select('is_enabled')
-    .eq('flag_key', 'HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED')
-    .maybeSingle();
-  if (cutoverFlagErr) throw cutoverFlagErr;
-  const cutoverEnabled = cutoverFlagRow ? cutoverFlagRow.is_enabled === true : false; // default OFF
-
+  // classification, consumed by both JS chokepoints (stage-execution-worker.js's
+  // per-tick review-mode block and its _advanceStage 4th backstop) via
+  // isHighConsequence/highConsequenceStages.
+  //
+  // QF-20260712-716 (Adam flag-gov ruling 8118abe7, 2026-08-16): GRADUATED. The
+  // leo_feature_flags.HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED cutover read was
+  // removed — it was enabled-never-rolled-out (live is_enabled=true throughout,
+  // seeded ON at deploy because stage 24 was already live-enforced), so this now
+  // permanently classifies is_high_consequence=true rows rather than reading a
+  // flag that has never been flipped off. The DB-side fn_advance_venture_stage
+  // read of this same flag_key is a SEPARATE, out-of-scope surface (not touched
+  // by this QF) and continues reading the flag row unchanged.
   const killStages = new Set();
   const promotionStages = new Set();
   const reviewStages = new Set();
@@ -103,8 +96,7 @@ async function _readFresh(supabase) {
     if (row.review_mode === 'review') reviewStages.add(row.stage_number);
     // is_high_consequence is independent of gate_type/review_mode/work_type —
     // a stage with gate_type='none' can still be chairman-designated high-consequence.
-    // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A: gated by cutoverEnabled — see comment above.
-    if (cutoverEnabled && row.is_high_consequence === true) highConsequenceStages.add(row.stage_number);
+    if (row.is_high_consequence === true) highConsequenceStages.add(row.stage_number);
   }
   const blockingStages = new Set([...killStages, ...promotionStages]);
 

--- a/tests/unit/eva/stage-execution-worker-high-consequence-gate.test.js
+++ b/tests/unit/eva/stage-execution-worker-high-consequence-gate.test.js
@@ -4,11 +4,17 @@
  * Mirrors stage-execution-worker-product-review-gate.test.js's pattern: drives the
  * REAL _advanceStage() method against a mocked, chainable supabase fake.
  *
+ * QF-20260712-716 (Adam flag-gov ruling 8118abe7, 2026-08-16): the
+ * LEO_HIGH_CONSEQUENCE_GATES_ENABLED kill-switch read was GRADUATED (removed from
+ * the code — the check is now permanently enforced). The three tests that
+ * exercised the flag's OFF/absent/throw behavior (formerly TS-11, the
+ * "row absent defaults to ENABLED" test, and TS-8b) are removed along with it —
+ * there is no longer a flag read to disable or throw on.
+ *
  * Complements tests/integration/eva/high-consequence-blocking-gate-realdb.test.js
- * (real DB, covers TS-1/2/4/6/9/10) with the two scenarios that are unsafe or
+ * (real DB, covers TS-1/2/4/6/9/10) with the one scenario that is unsafe or
  * impractical to force against shared live infrastructure:
  *   - TS-8: fail-CLOSED when the evaluator itself throws
- *   - TS-11: the kill-switch flag disables the check entirely
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -44,27 +50,23 @@ import { getStageGovernance } from '../../../lib/eva/stage-governance.js';
 const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
 
 /**
- * Thenable chainable supabase fake. Distinguishes by TABLE + the actual .eq() filter
- * values applied, not just table name -- the pre-existing artifact-precondition
- * backstop (checkStageArtifactPrecondition, lib/eva/stage-artifact-precondition.js)
- * ALSO unconditionally reads leo_feature_flags (flag_key='LEO_S22_GATES_ENABLED') on
- * every call, so a table-name-only mock cannot tell that read apart from THIS new
- * check's flag_key='LEO_HIGH_CONSEQUENCE_GATES_ENABLED' read. Defaults every OTHER
+ * Thenable chainable supabase fake. leo_feature_flags is still legitimately read by
+ * the pre-existing artifact-precondition backstop (checkStageArtifactPrecondition,
+ * lib/eva/stage-artifact-precondition.js, flag_key='LEO_S22_GATES_ENABLED') on every
+ * call — this fake resolves that read to absent (null) and defaults every OTHER
  * table (ventures, venture_stages, stage_artifact_requirements) to a response that
  * makes the artifact-precondition check resolve to blocked:false with zero required
  * artifacts, so the high-consequence check is the only blocker these tests exercise.
  *
- * `leoFeatureFlagRow` / `throwOnHcFlagRead` apply ONLY to the
- * LEO_HIGH_CONSEQUENCE_GATES_ENABLED read; `pendingBlockingDecision` /
- * `throwOnChairmanDecisionsRead` apply to the chairman_decisions read.
+ * `pendingBlockingDecision` / `throwOnChairmanDecisionsRead` apply to the
+ * chairman_decisions read (the only DB read this choke-point makes post-graduation).
  */
-function makeSupabase({ leoFeatureFlagRow = null, pendingBlockingDecision = null, throwOnHcFlagRead = false, throwOnChairmanDecisionsRead = false } = {}) {
+function makeSupabase({ pendingBlockingDecision = null, throwOnChairmanDecisionsRead = false } = {}) {
   const calls = { venturesUpdate: 0 };
   const from = (table) => {
-    const eqFilters = [];
     const chain = {
       select: () => chain,
-      eq: (col, val) => { eqFilters.push([col, val]); return chain; },
+      eq: () => chain,
       neq: () => chain,
       in: () => chain,
       gt: () => chain,
@@ -72,12 +74,7 @@ function makeSupabase({ leoFeatureFlagRow = null, pendingBlockingDecision = null
       limit: () => chain,
       maybeSingle: async () => {
         if (table === 'leo_feature_flags') {
-          const isHcFlagQuery = eqFilters.some(([c, v]) => c === 'flag_key' && v === 'LEO_HIGH_CONSEQUENCE_GATES_ENABLED');
-          if (isHcFlagQuery) {
-            if (throwOnHcFlagRead) throw new Error('db down');
-            return { data: leoFeatureFlagRow, error: null };
-          }
-          return { data: null, error: null }; // e.g. LEO_S22_GATES_ENABLED -> absent
+          return { data: null, error: null }; // LEO_S22_GATES_ENABLED -> absent
         }
         if (table === 'chairman_decisions') {
           if (throwOnChairmanDecisionsRead) throw new Error('db down');
@@ -111,7 +108,7 @@ describe('_advanceStage high-consequence blocking-gate choke-point (FR-3) — re
     mockIsHighConsequence = () => false;
   });
 
-  it('short-circuits with ZERO chairman_decisions queries for a non-high-consequence stage (leo_feature_flags is still legitimately read by the pre-existing artifact-precondition backstop for a DIFFERENT flag_key)', async () => {
+  it('short-circuits with ZERO chairman_decisions queries for a non-high-consequence stage', async () => {
     mockIsHighConsequence = () => false;
     let touchedChairmanDecisions = false;
     const supabase = makeSupabase();
@@ -149,24 +146,12 @@ describe('_advanceStage high-consequence blocking-gate choke-point (FR-3) — re
     expect(supabase.calls.venturesUpdate).toBe(1);
   });
 
-  // TS-11
-  it('TS-11: the kill-switch flag (is_enabled=false) disables the check entirely, even with a pending blocking decision', async () => {
+  // QF-20260712-716: the check is now permanently enforced (no kill-switch to test) —
+  // this replaces the removed "row absent defaults to ENABLED" test with the same
+  // assertion, minus the now-nonexistent flag mock.
+  it('holds on a pending blocking decision for a high-consequence stage (graduated: unconditional, no flag)', async () => {
     mockIsHighConsequence = () => true;
-    const supabase = makeSupabase({
-      leoFeatureFlagRow: { is_enabled: false },
-      pendingBlockingDecision: { id: 'decision-1' }, // would normally hold
-    });
-    const worker = makeWorker(supabase);
-
-    const result = await worker._advanceStage('v-1', 10, 11, {});
-
-    expect(result?.blocked).not.toBe(true);
-    expect(supabase.calls.venturesUpdate).toBe(1);
-  });
-
-  it('kill-switch flag row absent defaults to ENABLED — still holds on a pending blocking decision', async () => {
-    mockIsHighConsequence = () => true;
-    const supabase = makeSupabase({ leoFeatureFlagRow: null, pendingBlockingDecision: { id: 'decision-1' } });
+    const supabase = makeSupabase({ pendingBlockingDecision: { id: 'decision-1' } });
     const worker = makeWorker(supabase);
 
     const result = await worker._advanceStage('v-1', 10, 11, {});
@@ -178,17 +163,6 @@ describe('_advanceStage high-consequence blocking-gate choke-point (FR-3) — re
   it('TS-8: fails CLOSED (holds) when the chairman_decisions evaluator query throws', async () => {
     mockIsHighConsequence = () => true;
     const supabase = makeSupabase({ throwOnChairmanDecisionsRead: true });
-    const worker = makeWorker(supabase);
-
-    const result = await worker._advanceStage('v-1', 10, 11, {});
-
-    expect(result).toEqual({ advanced: false, blocked: true, reason: 'high_consequence_gate_blocked' });
-    expect(supabase.calls.venturesUpdate).toBe(0);
-  });
-
-  it('TS-8b: fails CLOSED when the leo_feature_flags kill-switch read itself throws', async () => {
-    mockIsHighConsequence = () => true;
-    const supabase = makeSupabase({ throwOnHcFlagRead: true });
     const worker = makeWorker(supabase);
 
     const result = await worker._advanceStage('v-1', 10, 11, {});

--- a/tests/unit/eva/stage-governance.test.js
+++ b/tests/unit/eva/stage-governance.test.js
@@ -44,35 +44,22 @@ const VENTURE_STAGES_FIXTURE = [
 
 // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single venture_stages table read.
 // One refresh == exactly one .from('venture_stages') call.
-// SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A: _readFresh now ALSO reads
-// leo_feature_flags (flag_key=HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED) every refresh —
-// one refresh is now 2 .from() calls. Defaults the flag to ENABLED so every
-// pre-existing assertion in this file (all written before the cutover flag existed,
-// against a fixture that marks stages 4/24 is_high_consequence=true directly) keeps
-// its original meaning; the dedicated cutover-flag test below overrides this default
-// to prove the OFF-by-default gating behavior.
-function mockSupabase(rows, { failChannel = false, cutoverFlagRow = { is_enabled: true } } = {}) {
+// QF-20260712-716 (Adam flag-gov ruling 8118abe7, 2026-08-16): GRADUATED. _readFresh
+// no longer reads leo_feature_flags at all — the former
+// HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED cutover read was removed, so
+// is_high_consequence classification is now unconditional and one refresh is back to
+// exactly one .from() call.
+function mockSupabase(rows, { failChannel = false } = {}) {
   // SD-LEO-FEAT-MAKE-HIGH-CONSEQUENCE-001: default is_high_consequence=false on any row
   // that doesn't explicitly set it, mirroring the DB's NOT NULL DEFAULT false — existing
   // fixture rows above don't need updating individually.
   const filledRows = rows === null ? rows : rows.map((r) => ({ is_high_consequence: false, ...r }));
   return {
-    from: vi.fn((table) => {
-      if (table === 'leo_feature_flags') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: vi.fn(async () => ({ data: cutoverFlagRow, error: null })),
-            })),
-          })),
-        };
-      }
-      return {
-        select: vi.fn(() => ({
-          order: vi.fn(async () => ({ data: filledRows, error: null })),
-        })),
-      };
-    }),
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        order: vi.fn(async () => ({ data: filledRows, error: null })),
+      })),
+    })),
     channel: failChannel
       ? () => { throw new Error('channel not available'); }
       : vi.fn(() => ({
@@ -152,49 +139,31 @@ describe('stage-governance', () => {
     expect(gov.isHighConsequence(1)).toBe(false);
   });
 
-  test('cache: second call within TTL does not re-fetch (one refresh = 2 .from() calls: venture_stages + cutover flag)', async () => {
-    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single-table read → 1 .from() per refresh
-    // (was 2 when stage_config + lifecycle_stage_config were read separately).
-    // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A: +1 .from() per refresh for the
-    // HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED read, so one refresh is now 2 calls.
+  test('cache: second call within TTL does not re-fetch (one refresh = 1 .from() call)', async () => {
+    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: single-table read → 1 .from() per refresh.
+    // QF-20260712-716: the cutover-flag read was graduated away, so this stays at 1
+    // (the interim 2-calls-per-refresh state from SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A
+    // no longer applies).
     const supabase = mockSupabase(VENTURE_STAGES_FIXTURE);
     await getStageGovernance(supabase);
     await getStageGovernance(supabase);
-    expect(supabase.from).toHaveBeenCalledTimes(2);
+    expect(supabase.from).toHaveBeenCalledTimes(1);
   });
 
   test('_resetCacheForTest forces a re-fetch', async () => {
-    // SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: 2 refreshes × 1 table = 2 .from() calls.
-    // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A: now 2 tables/refresh → 2 refreshes × 2 = 4.
+    // 2 refreshes × 1 table = 2 .from() calls.
     const supabase = mockSupabase(VENTURE_STAGES_FIXTURE);
     await getStageGovernance(supabase);
     _resetCacheForTest();
     await getStageGovernance(supabase);
-    expect(supabase.from).toHaveBeenCalledTimes(4);
+    expect(supabase.from).toHaveBeenCalledTimes(2);
   });
 
-  // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A (FR-1, TR-1)
-  test('cutover flag OFF (default, row absent) treats every stage as NOT high-consequence regardless of the DB column', async () => {
-    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE, { cutoverFlagRow: null }));
-    expect(gov.highConsequenceStages.size).toBe(0);
-    expect(gov.isHighConsequence(4)).toBe(false);
-    expect(gov.isHighConsequence(24)).toBe(false);
-    // Composed classifications (kill/promotion/review) are untouched by the cutover gate.
-    expect(gov.isPromotion(24)).toBe(true);
-  });
-
-  test('cutover flag explicitly OFF (is_enabled=false) behaves identically to an absent row', async () => {
-    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE, { cutoverFlagRow: { is_enabled: false } }));
-    expect(gov.highConsequenceStages.size).toBe(0);
-    expect(gov.isHighConsequence(24)).toBe(false);
-  });
-
-  test('cutover flag ON restores is_high_consequence classification from the DB column', async () => {
-    const gov = await getStageGovernance(mockSupabase(VENTURE_STAGES_FIXTURE, { cutoverFlagRow: { is_enabled: true } }));
-    expect([...gov.highConsequenceStages].sort((a, b) => a - b)).toEqual([4, 24]);
-    expect(gov.isHighConsequence(4)).toBe(true);
-    expect(gov.isHighConsequence(24)).toBe(true);
-  });
+  // QF-20260712-716: the three dedicated cutover-flag ON/OFF tests that lived here
+  // are removed along with the flag read they exercised — is_high_consequence
+  // classification is unconditional now, already covered by the
+  // 'isHighConsequence / highConsequenceStages derive from is_high_consequence' test
+  // above (line 137), which continues to pass unchanged.
 
   test('falls back gracefully when realtime channel API is unavailable', async () => {
     const supabase = mockSupabase(VENTURE_STAGES_FIXTURE, { failChannel: true });
@@ -213,20 +182,12 @@ describe('stage-governance', () => {
   test('Realtime channel teardown safety: CHANNEL_ERROR/CLOSED/TIMED_OUT drops the reference without calling unsubscribe()/removeChannel() (both would recurse)', async () => {
     const { channelMock, removeChannel, getStatusCallback, getUnsubscribeCallCount, getRemoveChannelCallCount } =
       createFaithfulRealtimeChannelMock();
-    // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-A: table-aware branch so the new
-    // leo_feature_flags read (HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED) resolves instead
-    // of throwing on a table-name-blind mock; value is irrelevant to this test.
     const supabase = {
-      from: vi.fn((table) => {
-        if (table === 'leo_feature_flags') {
-          return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: { is_enabled: true }, error: null })) })) })) };
-        }
-        return {
-          select: vi.fn(() => ({
-            order: vi.fn(async () => ({ data: VENTURE_STAGES_FIXTURE, error: null })),
-          })),
-        };
-      }),
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(async () => ({ data: VENTURE_STAGES_FIXTURE, error: null })),
+        })),
+      })),
       channel: vi.fn(() => channelMock),
       removeChannel,
     };
@@ -257,12 +218,7 @@ describe('stage-governance', () => {
 
   test('null data with no error yields empty sets (defensive — empty table or minimal mock)', async () => {
     const supabase = {
-      from: (table) => {
-        if (table === 'leo_feature_flags') {
-          return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { is_enabled: true }, error: null }) }) }) };
-        }
-        return { select: () => ({ order: async () => ({ data: null, error: null }) }) };
-      },
+      from: () => ({ select: () => ({ order: async () => ({ data: null, error: null }) }) }),
       channel: () => ({ on: () => ({ subscribe: () => ({}) }), subscribe: () => ({}) }),
     };
     const gov = await getStageGovernance(supabase);


### PR DESCRIPTION
## Summary
- Per Adam flag-gov ruling `8118abe7` (2026-08-16 13:48Z, rescoping the original 07-12 kill-list ticket to **GRADUATE ONLY**): both `LEO_HIGH_CONSEQUENCE_GATES_ENABLED` and `HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED` are enabled-never-rolled-out — verified live (`is_enabled=true` on both rows) before touching any code, since `stage-governance.js`'s own comment documented a DEFAULT-OFF behavior for the cutover flag when its row is absent, which would have made graduation a real behavior change had the row not existed. Both rows exist and are ON.
- Removed the flag reads from the 2 measured JS chokepoints, tightening permanently (behavior stays ON unconditionally):
  - `lib/eva/stage-execution-worker.js`'s `_advanceStage` 4th backstop no longer reads `LEO_HIGH_CONSEQUENCE_GATES_ENABLED`.
  - `lib/eva/stage-governance.js`'s `_readFresh` no longer reads `HIGH_CONSEQUENCE_STAGE_CUTOVER_ENABLED`.
- The DB-side `fn_advance_venture_stage` reads of these same flag_keys are a separate, out-of-scope surface (not touched by this QF) and continue reading the flag rows unchanged, per the QF's own measured surface (4 references in exactly these 2 files).
- `auto_exec_engine_v1` / `auto_exec_checkout_sync_v1` are NOT touched — their disposition sits in the chairman `flag_enablement` queue (rows `1315d76e`, `c08f4368`), unrelated to this QF's rescoped surface.

## Housekeeping note
A stale local+remote branch named `qf/QF-20260712-716` existed from the ORIGINAL (withdrawn) 07-12 kill-3-flags approach, never had a PR, and was 1+ month stale against current main. Deleted before creating this fresh branch, since the QF's own current text explicitly states "Original 07-12 kill-list WITHDRAWN."

## Test plan
- [x] `tests/unit/eva/stage-execution-worker-high-consequence-gate.test.js`: dropped the 3 tests exercising the removed kill-switch's OFF/absent/throw behavior; simplified the mock.
- [x] `tests/unit/eva/stage-governance.test.js`: dropped the 3 cutover-flag ON/OFF tests (superseded by the existing unconditional-classification test), corrected `.from()`-call-count assertions (2→1 per refresh, 4→2 for two refreshes), cleaned up two now-dead mock branches.
- [x] Verified non-vacuous: reverted the `stage-governance.js` unconditional check to a no-op, confirmed a test fails (`expected [4,24], got []`), restored it, confirmed it passes.
- [x] Confirmed via grep that no `.eq('flag_key', ...)` call to either flag_key remains in either production file.
- [x] Full `tests/unit/eva/` + `tests/lib/eva/` suite: 537 files (5 skipped), 7026 tests (31 skipped), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)