### PR TITLE
fix(QF-20260816-049): route complete-quick-fix merge through gh-merge-safe.mjs

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -11,8 +11,16 @@
 import { execSync, execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { EXTERNAL_STEP_TIMEOUT_MS } from './constants.js';
 import { observeMergeWorkLadder } from '../../../lib/ship/auto-merge.mjs';
+
+// QF-20260816-049: bare `gh pr merge --delete-branch` fails locally (post-merge)
+// when a sibling worktree already holds `main` -- the merge itself lands fine.
+// scripts/gh-merge-safe.mjs avoids the local checkout entirely (merges via `gh
+// api`). Resolved as an absolute path since this function runs with cwd=testDir,
+// not the repo root.
+const GH_MERGE_SAFE_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../scripts/gh-merge-safe.mjs');
 
 // SD-LEO-INFRA-SHIP-WITNESS-TRIO-001 (FR-1): best-effort, never-throws observation
 // of a merge that just landed via `gh pr merge` in this lane. Mirrors
@@ -1102,7 +1110,7 @@ export async function mergeToMain(testDir, qf, prUrl, prompt, flags = {}) {
           const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
           // SD-SEC-DATA-VALIDATION-001: Validate PR number is numeric
           if (prNumber && /^\d+$/.test(prNumber)) {
-            execSync(`gh pr merge ${prNumber} --merge --delete-branch`, { stdio: 'inherit', cwd: testDir });
+            execFileSync(process.execPath, [GH_MERGE_SAFE_PATH, prNumber, '--merge', '--delete-branch'], { stdio: 'inherit', cwd: testDir });
             console.log('   ✅ PR merged and branch deleted via GitHub\n');
             const [, repoOwner, repoName] = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\//) || [];
             await observeQuickFixMerge({ prNumber, repoOwner, repoName, qfId: qf.id });

--- a/tests/unit/complete-quick-fix/skip-ci-wait-gate.test.js
+++ b/tests/unit/complete-quick-fix/skip-ci-wait-gate.test.js
@@ -9,8 +9,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const execSyncMock = vi.fn();
+// QF-20260816-049: mergeToMain's primary merge path now calls execFileSync (gh-merge-safe.mjs
+// via process.execPath), not execSync with a literal 'gh pr merge' string -- both must be
+// mocked or the primary path throws (execFileSync undefined), gets caught by mergeToMain's own
+// try/catch, and silently falls through to the local-merge fallback (which DOES use execSync),
+// masking what these tests actually exist to assert.
+const execFileSyncMock = vi.fn();
 vi.mock('child_process', () => ({
-  execSync: (...args) => execSyncMock(...args)
+  execSync: (...args) => execSyncMock(...args),
+  execFileSync: (...args) => execFileSyncMock(...args)
 }));
 
 const {
@@ -23,7 +30,14 @@ const {
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {});
   execSyncMock.mockReset();
+  execFileSyncMock.mockReset();
 });
+
+/** True when execFileSyncMock was called with the gh-merge-safe.mjs invocation shape. */
+function calledGhMergeSafe() {
+  return execFileSyncMock.mock.calls.some(([, args]) =>
+    Array.isArray(args) && args.some((a) => String(a).includes('gh-merge-safe')) && args.includes('--merge') && args.includes('--delete-branch'));
+}
 
 // ─── Pure decision functions — no IO, no mocking needed ───────────────────
 
@@ -112,7 +126,7 @@ describe('mergeToMain — CI-wait gate (QF-20260702-515)', () => {
       forceComplete: true, reason: 'audited'
     });
     expect(prompt).not.toHaveBeenCalled();
-    expect(execSyncMock.mock.calls.some(([cmd]) => cmd.startsWith('gh pr merge'))).toBe(true);
+    expect(calledGhMergeSafe()).toBe(true);
   });
 
   it('force-complete refuses to merge when a required check has failed', async () => {
@@ -124,7 +138,7 @@ describe('mergeToMain — CI-wait gate (QF-20260702-515)', () => {
       forceComplete: true, reason: 'audited'
     }).catch(e => { thrown = e; });
     expect(thrown).toBeNull(); // mergeToMain swallows and logs, per its existing contract
-    expect(execSyncMock.mock.calls.some(([cmd]) => cmd.startsWith('gh pr merge'))).toBe(false);
+    expect(calledGhMergeSafe()).toBe(false);
   });
 
   it('force-complete + skip-ci-wait merges without checking CI status at all', async () => {
@@ -132,7 +146,7 @@ describe('mergeToMain — CI-wait gate (QF-20260702-515)', () => {
     await mergeToMain('/fake', { id: 'QF-TEST' }, 'https://github.com/x/y/pull/42', vi.fn(), {
       forceComplete: true, skipCiWait: true, reason: 'audited-skip'
     });
-    expect(execSyncMock.mock.calls.some(([cmd]) => cmd.startsWith('gh pr merge'))).toBe(true);
+    expect(calledGhMergeSafe()).toBe(true);
   });
 
   it('force-complete polls past a pending check and merges once it completes', async () => {
@@ -160,6 +174,6 @@ describe('mergeToMain — CI-wait gate (QF-20260702-515)', () => {
     await mergePromise;
 
     expect(call).toBeGreaterThanOrEqual(2);
-    expect(execSyncMock.mock.calls.some(([cmd]) => cmd.startsWith('gh pr merge'))).toBe(true);
+    expect(calledGhMergeSafe()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/modules/complete-quick-fix/git-operations.js`'s `mergeToMain()` was executing a bare `gh pr merge --delete-branch`, which fails locally (after the server-side merge already lands) whenever a sibling worktree holds `main` — the exact failure class SD-LEO-INFRA-GH-MERGE-SAFE-WIRING-001 is currently wiring fixes for elsewhere.
- Swapped for `execFileSync` calling the existing, tested `scripts/gh-merge-safe.mjs` (resolved as an absolute path since this function runs with `cwd=testDir`, not the repo root). Existing try/catch fallback (re-check merge state, then local-merge) is unchanged.
- The sibling bare-call site in `ShippingExecutor.js:228` is intentionally NOT touched here — deferred to harness_backlog (320d98f4) pending confirmation of whether that path already has its own post-merge completion handling (gh-merge-safe.mjs's post-merge orchestrator only self-skips for QF branches, not SD branches, so wiring it in blind risks a double-fire).

## Test plan
- [x] 12/12 in `tests/unit/complete-quick-fix/skip-ci-wait-gate.test.js` (updated to mock `execFileSync` alongside `execSync`, since the primary merge path no longer calls `execSync` with a literal `gh pr merge` string)
- [x] 333/333 across the full `complete-quick-fix` + related test suites (25 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)