### PR TITLE
fix(SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001): repoint dead progress column to progress_percentage

### DIFF
--- a/lib/eva-support/sd-blocker-surface.js
+++ b/lib/eva-support/sd-blocker-surface.js
@@ -48,7 +48,7 @@ const ALLOWED_SD_COLUMNS = Object.freeze([
   'status',
   'current_phase',
   'priority',
-  'progress',
+  'progress_percentage',
   'parent_sd_id',
   'target_application',
 ]);
@@ -180,7 +180,7 @@ export async function getBlockedSDs(opts = {}) {
       sd_key: sd.sd_key,
       sd_title: sd.title,
       priority: sd.priority,
-      progress: sd.progress,
+      progress: sd.progress_percentage,
       target_application: sd.target_application,
       parent_sd_key: sd.parent_sd_id ? parentMap.get(sd.parent_sd_id)?.sd_key ?? null : null,
       latest_handoff_status: latestHandoffStatus,

--- a/lib/eva-support/sd-reader.js
+++ b/lib/eva-support/sd-reader.js
@@ -44,7 +44,7 @@ const ALLOWED_COLUMNS = Object.freeze([
   'current_phase',
   'target_application',
   'priority',
-  'progress',
+  'progress_percentage',
 ]);
 
 const SELECT_CLAUSE = ALLOWED_COLUMNS.join(',');
@@ -115,7 +115,7 @@ export async function getActiveSDs(opts = {}) {
   }
   query = query
     .order('priority', { ascending: false }) // critical first
-    .order('progress', { ascending: false })  // most-progressed first
+    .order('progress_percentage', { ascending: false })  // most-progressed first
     .limit(limit);
 
   const { data, error } = await query;

--- a/lib/sd/revert.js
+++ b/lib/sd/revert.js
@@ -73,6 +73,19 @@ export async function revertSD(sdId, reason, options = {}) {
     };
   }
 
+  // KNOWN LIMITATION (adversarial review, SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001): the
+  // auto_calculate_progress() BEFORE-UPDATE trigger (database/migrations/
+  // 20251211_fix_progress_trigger_rls_access.sql:315-329) recalculates progress_percentage via
+  // calculate_sd_progress() whenever an UPDATE's NEW value IS NOT DISTINCT FROM OLD -- which is
+  // PRE-EXISTING behavior, not introduced by this repoint: the prior `progress: 0` write never
+  // touched progress_percentage at all, so NEW trivially equaled OLD on every single call, and
+  // this trigger already fired unconditionally before this file was repointed. Explicitly
+  // writing progress_percentage: 0 here NARROWS that to only the case where the SD's progress_
+  // percentage was already 0 pre-revert -- for this function's actual target population (ghost-
+  // completed SDs, PAT-GHOST-COMPLETION-PARTIAL-REVERT-001), enforce_progress_on_completion()
+  // required progress_percentage=100 to reach 'completed' in the first place, so OLD is 100, not
+  // 0, in the common case. The "atomic reset to 0" guarantee below is therefore reliable for the
+  // primary use case but not unconditional for an already-0%-progress SD.
   const revertedAt = new Date().toISOString();
   const payload = {
     status: 'draft',

--- a/lib/sd/revert.js
+++ b/lib/sd/revert.js
@@ -4,9 +4,9 @@
  * SD: SD-FDBK-INFRA-ATOMIC-REVERT-HELPER-001
  * Pattern: PAT-GHOST-COMPLETION-PARTIAL-REVERT-001
  *
- * Performs a SINGLE supabase update writing status + current_phase + progress + metadata
- * atomically. Eliminates the partial-revert class where metadata.reverted_at is set but
- * the status/current_phase/progress column updates are forgotten in a separate write.
+ * Performs a SINGLE supabase update writing status + current_phase + progress_percentage +
+ * metadata atomically. Eliminates the partial-revert class where metadata.reverted_at is set
+ * but the status/current_phase/progress_percentage column updates are forgotten in a separate write.
  *
  * Idempotent: if metadata.reverted_at is already set, the second call returns the
  * existing payload unchanged with was_idempotent=true. Fail-loud: throws on
@@ -46,7 +46,7 @@ export async function revertSD(sdId, reason, options = {}) {
   // Read existing metadata for idempotency check and metadata preservation
   const { data: existing, error: fetchError } = await supabase
     .from('strategic_directives_v2')
-    .select('id, metadata, status, current_phase, progress')
+    .select('id, metadata, status, current_phase, progress_percentage')
     .eq('id', sdId)
     .maybeSingle();
 
@@ -66,7 +66,7 @@ export async function revertSD(sdId, reason, options = {}) {
       payload: {
         status: existing.status,
         current_phase: existing.current_phase,
-        progress: existing.progress,
+        progress_percentage: existing.progress_percentage,
         metadata: existingMetadata,
       },
       was_idempotent: true,
@@ -77,7 +77,7 @@ export async function revertSD(sdId, reason, options = {}) {
   const payload = {
     status: 'draft',
     current_phase: 'LEAD',
-    progress: 0,
+    progress_percentage: 0,
     metadata: {
       ...existingMetadata,
       ...preserve_metadata,
@@ -90,7 +90,7 @@ export async function revertSD(sdId, reason, options = {}) {
     return { updated: false, payload, was_idempotent: false };
   }
 
-  // Single atomic update: status, current_phase, progress, metadata in ONE call.
+  // Single atomic update: status, current_phase, progress_percentage, metadata in ONE call.
   // The static-pin test asserts this exact pattern. Do not split into multiple
   // .update() calls — that re-introduces the partial-revert class.
   const { error: updateError } = await supabase

--- a/scripts/batch-operations/complete-children.mjs
+++ b/scripts/batch-operations/complete-children.mjs
@@ -69,10 +69,15 @@ export default {
       }
 
       try {
+        // SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001: do not write `progress` here.
+        // enforce_progress_on_completion() (database/migrations/20251211_fix_progress_trigger_rls_access.sql:334-356)
+        // is a BEFORE-UPDATE trigger that unconditionally overwrites progress_percentage on this exact
+        // status transition, so an explicit progress_percentage write in this same statement would
+        // silently no-op. The trigger already sets progress_percentage correctly; writing the dead
+        // `progress` column here was the only remaining live writer of it.
         const updates = {
           status: 'completed',
           current_phase: 'COMPLETED',
-          progress: 100,
           updated_at: new Date().toISOString()
         };
 

--- a/scripts/eva-support/_internal/dispatcher.js
+++ b/scripts/eva-support/_internal/dispatcher.js
@@ -58,7 +58,7 @@ export function buildRelatedSDsPrefix({ sds = [], blockers = [] } = {}) {
   for (const sd of sds.slice(0, 5)) {
     if (seen.has(sd.sd_key)) continue;
     seen.add(sd.sd_key);
-    const progress = typeof sd.progress === 'number' ? `${sd.progress}%` : '—';
+    const progress = typeof sd.progress_percentage === 'number' ? `${sd.progress_percentage}%` : '—';
     lines.push(`  ${sd.sd_key} | ${sd.status} | ${progress}`);
   }
   for (const b of blockers.slice(0, 3)) {

--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -1049,7 +1049,7 @@ async function cmdStatus() {
   // Active corrective SDs
   const { data: correctives } = await supabase
     .from('strategic_directives_v2')
-    .select('sd_key, title, status, progress')
+    .select('sd_key, title, status, progress_percentage')
     .not('vision_origin_score_id', 'is', null)
     .not('status', 'in', '("completed","cancelled")')
     .order('created_at', { ascending: false })
@@ -1058,7 +1058,7 @@ async function cmdStatus() {
   if (correctives?.length > 0) {
     console.log(`\n  Active Corrective SDs (${correctives.length}):`);
     for (const sd of correctives) {
-      console.log(`    ${sd.sd_key} [${sd.status}] ${sd.progress || 0}% \u2014 ${sd.title?.substring(0, 55)}`);
+      console.log(`    ${sd.sd_key} [${sd.status}] ${sd.progress_percentage || 0}% \u2014 ${sd.title?.substring(0, 55)}`);
     }
   }
 

--- a/scripts/eva/vision-heal.js
+++ b/scripts/eva/vision-heal.js
@@ -297,7 +297,7 @@ async function cmdStatus() {
   // Active corrective SDs
   const { data: correctives } = await supabase
     .from('strategic_directives_v2')
-    .select('sd_key, title, status, progress')
+    .select('sd_key, title, status, progress_percentage')
     .not('vision_origin_score_id', 'is', null)
     .not('status', 'in', '("completed","cancelled")')
     .order('created_at', { ascending: false })
@@ -306,7 +306,7 @@ async function cmdStatus() {
   if (correctives?.length > 0) {
     console.log(`\n   Active Corrective SDs (${correctives.length}):`);
     for (const sd of correctives) {
-      console.log(`      ${sd.sd_key} [${sd.status}] ${sd.progress || 0}% — ${sd.title?.substring(0, 60)}`);
+      console.log(`      ${sd.sd_key} [${sd.status}] ${sd.progress_percentage || 0}% — ${sd.title?.substring(0, 60)}`);
     }
   }
 

--- a/scripts/examples/efficient-database-queries.js
+++ b/scripts/examples/efficient-database-queries.js
@@ -57,12 +57,12 @@ async function example1_selectColumns() {
 
   const { data: sdGood } = await supabase
     .from('strategic_directives_v2')
-    .select('id, title, status, priority, progress')
+    .select('id, title, status, priority, progress_percentage')
     .order('created_at', { ascending: false })
     .limit(1)
     .single();
 
-  const goodOutput = `${sdGood.id}: ${sdGood.title} (status: ${sdGood.status}, priority: ${sdGood.priority}, progress: ${sdGood.progress}%)`;
+  const goodOutput = `${sdGood.id}: ${sdGood.title} (status: ${sdGood.status}, priority: ${sdGood.priority}, progress: ${sdGood.progress_percentage}%)`;
   console.log('Output:', goodOutput);
   console.log(`Tokens: ~${estimateTokens(goodOutput)}`);
   console.log();

--- a/scripts/gates/integration-verification-gate.js
+++ b/scripts/gates/integration-verification-gate.js
@@ -3,7 +3,7 @@
  * SD-MAN-ORCH-SCOPE-COMPLEXITY-ANALYSIS-001-B
  *
  * Runs at orchestrator EXEC-COMPLETE boundary. Verifies:
- * 1. All children are completed (status + progress)
+ * 1. All children are completed (status + progress_percentage)
  * 2. Deliverables cross-reference correctly between children
  * 3. Capabilities have consumers (no orphans)
  *
@@ -55,7 +55,7 @@ async function verifyChildrenCompleted(parentId, parentSdKey, supabase) {
 
   const { data: children, error: childErr } = await supabase
     .from('strategic_directives_v2')
-    .select('sd_key, title, status, progress, current_phase')
+    .select('sd_key, title, status, progress_percentage, current_phase')
     .eq('parent_sd_id', parentId);
 
   if (childErr || !children || children.length === 0) {
@@ -70,8 +70,8 @@ async function verifyChildrenCompleted(parentId, parentSdKey, supabase) {
       warnings.push(`Child ${child.sd_key} status is '${child.status}' (expected 'completed')`);
       allComplete = false;
     }
-    if (child.progress !== 100) {
-      warnings.push(`Child ${child.sd_key} progress is ${child.progress}% (expected 100%)`);
+    if (child.progress_percentage !== 100) {
+      warnings.push(`Child ${child.sd_key} progress is ${child.progress_percentage}% (expected 100%)`);
       allComplete = false;
     }
   }

--- a/scripts/generate-comprehensive-retrospective.js
+++ b/scripts/generate-comprehensive-retrospective.js
@@ -282,7 +282,7 @@ function calculateQualityScore(insights, prdAnalysis, subAgents, sd) {
   let score = 70; // Base score (UPDATED from 60 to ensure minimum threshold)
 
   // Progress contribution (30 points)
-  score += (sd.progress || 0) * 0.3;
+  score += (sd.progress_percentage || 0) * 0.3;
 
   // Sub-agent verification (10 points)
   if (subAgents.consulted >= 3) score += 10;
@@ -376,7 +376,7 @@ async function generateComprehensiveRetrospective(sdId) {
   }
 
   console.log(`SD: ${sd.sd_key} - ${sd.title}`);
-  console.log(`Status: ${sd.status}, Progress: ${sd.progress}%`);
+  console.log(`Status: ${sd.status}, Progress: ${sd.progress_percentage}%`);
 
   // Check if an SD_COMPLETION retrospective already exists.
   // Scope the dedup to retro_type so typed rows (e.g. a LEAD_TO_PLAN handoff
@@ -442,7 +442,7 @@ async function generateComprehensiveRetrospective(sdId) {
   // Build comprehensive retrospective - ensure quality thresholds met (trigger scoring)
   const baseAchievements = [
     ...handoffInsights.achievements.slice(0, 10),
-    sd.progress >= 100 ? `SD completed at ${sd.progress}% progress` : `Progress achieved: ${sd.progress}%`,
+    sd.progress_percentage >= 100 ? `SD completed at ${sd.progress_percentage}% progress` : `Progress achieved: ${sd.progress_percentage}%`,
     subAgentAnalysis.consulted > 0 ? `${subAgentAnalysis.consulted} sub-agent(s) consulted for verification` : 'Implementation completed with quality verification',
     prdAnalysis ? `PRD created with ${prdAnalysis.acceptance_criteria} acceptance criteria` : 'Requirements documented comprehensively',
     'Database-first architecture maintained throughout',
@@ -649,7 +649,7 @@ async function generateComprehensiveRetrospective(sdId) {
     bugs_found: 0,
     bugs_resolved: 0,
     tests_added: handoffInsights.patterns.some(p => p.toLowerCase().includes('test')) ? 1 : 0,
-    objectives_met: sd.progress >= 100,
+    objectives_met: sd.progress_percentage >= 100,
     on_schedule: true,
     within_scope: true,
     success_patterns: successPatterns,

--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -65,7 +65,7 @@ async function generateRetrospective(sdInput) {
   const { sdId, sd } = await resolveSdInput(sdInput, supabase);
 
   console.log(`SD: ${sd.sd_key} - ${sd.title}`);
-  console.log(`Status: ${sd.status}, Progress: ${sd.progress}%`);
+  console.log(`Status: ${sd.status}, Progress: ${sd.progress_percentage}%`);
 
   // QF-20260526-904: route through getFilteredRetrospective so the writer
   // sees the same row the LEAD-FINAL-APPROVAL gate and PLAN-TO-LEAD
@@ -130,7 +130,7 @@ async function generateRetrospective(sdInput) {
 
   // High-quality content arrays (will be converted to JSONB)
   const what_went_well_array = [
-    `${sd.sd_key} completed successfully with ${sd.progress}% progress achieved`,
+    `${sd.sd_key} completed successfully with ${sd.progress_percentage}% progress achieved`,
     'LEO Protocol validation gates passed with comprehensive testing coverage',
     'Clear handoffs maintained between LEAD→PLAN→EXEC phases with proper documentation',
     'Database schema changes validated through Database Architect sub-agent review',
@@ -180,7 +180,7 @@ async function generateRetrospective(sdInput) {
     // omitting the key also yields NULL — this explicit null is kept as defense-in-depth.
     retrospective_type: null,
     title: `${sd.sd_key} Retrospective`,
-    description: `Retrospective analysis for ${sd.title} - completed at ${sd.progress}% with ${sd.status} status`,
+    description: `Retrospective analysis for ${sd.title} - completed at ${sd.progress_percentage}% with ${sd.status} status`,
     conducted_date: new Date().toISOString(),
     agents_involved: ['LEAD', 'PLAN', 'EXEC'],
     sub_agents_involved: prd ? ['Database Architect', 'QA Director', 'Code Reviewer'] : [],
@@ -216,7 +216,7 @@ async function generateRetrospective(sdInput) {
     // satisfy the >= 70 publish gate on its own. Omitting the key makes the stored score solely
     // what the evaluation produced.
 
-    team_satisfaction: Math.min(10, Math.max(1, Math.floor(sd.progress / 10))),
+    team_satisfaction: Math.min(10, Math.max(1, Math.floor(sd.progress_percentage / 10))),
     business_value_delivered: sd.priority >= 70 ? 'HIGH' : sd.priority >= 40 ? 'MEDIUM' : 'LOW',
     customer_impact: 'MEDIUM',
     technical_debt_addressed: true,
@@ -224,7 +224,7 @@ async function generateRetrospective(sdInput) {
     bugs_found: 0,
     bugs_resolved: 0,
     tests_added: prd ? 2 : 0, // Assume unit + E2E if PRD exists
-    objectives_met: sd.progress >= 100,
+    objectives_met: sd.progress_percentage >= 100,
     on_schedule: true,
     within_scope: true,
     success_patterns: ['Quality-first approach', 'Database-driven validation', 'Automated testing'],

--- a/scripts/get-working-on-sd.js
+++ b/scripts/get-working-on-sd.js
@@ -103,7 +103,7 @@ async function checkResumeEligibility(sdUuid, currentPhase) {
   };
 }
 
-const SD_COLUMNS = 'id, sd_key, title, status, priority, is_working_on, claiming_session_id, created_at, current_phase, progress, description';
+const SD_COLUMNS = 'id, sd_key, title, status, priority, is_working_on, claiming_session_id, created_at, current_phase, progress_percentage, description';
 
 async function getWorkingOnSD() {
   try {
@@ -119,7 +119,7 @@ async function getWorkingOnSD() {
         .from('strategic_directives_v2')
         .select(SD_COLUMNS)
         .eq('claiming_session_id', sessionId)
-        .lt('progress', 100);
+        .lt('progress_percentage', 100);
       if (!ownError && ownClaim && ownClaim.length > 0) {
         workingOn = ownClaim;
       }
@@ -146,7 +146,7 @@ async function getWorkingOnSD() {
         .from('strategic_directives_v2')
         .select(SD_COLUMNS)
         .or('claiming_session_id.not.is.null,is_working_on.eq.true')
-        .lt('progress', 100);  // Less than 100% complete
+        .lt('progress_percentage', 100);  // Less than 100% complete
 
       if (workingError) {
         console.error('Error querying working_on SD:', workingError);
@@ -167,7 +167,7 @@ async function getWorkingOnSD() {
    Status: ${sd.status}
    Priority: ${sd.priority || 'not set'}
    Current Phase: ${sd.current_phase || 'not set'}
-   Progress: ${sd.progress || 0}%
+   Progress: ${sd.progress_percentage || 0}%
    Claimed by: ${sd.claiming_session_id || 'unknown (legacy is_working_on)'}
    Created: ${new Date(sd.created_at).toLocaleDateString()}
 
@@ -211,14 +211,14 @@ async function getWorkingOnSD() {
       // Also check if there's a completed SD still marked
       const { data: completedWorking } = await supabase
         .from('strategic_directives_v2')
-        .select('id, title, progress, claiming_session_id')
+        .select('id, title, progress_percentage, claiming_session_id')
         .or('claiming_session_id.not.is.null,is_working_on.eq.true')
-        .gte('progress', 100);
+        .gte('progress_percentage', 100);
 
       if (completedWorking && completedWorking.length > 0) {
         console.log('⚠️  Note: The following completed SD still has working_on flag:');
         completedWorking.forEach(sd => {
-          console.log(`   - ${sd.id}: ${sd.title} (${sd.progress}% complete)`);
+          console.log(`   - ${sd.id}: ${sd.title} (${sd.progress_percentage}% complete)`);
         });
         console.log('   This SD is being ignored since it\'s 100% complete.\n');
       }

--- a/scripts/leo-resume.js
+++ b/scripts/leo-resume.js
@@ -50,11 +50,15 @@ try {
   if (state.sd && state.sd.id) {
     console.log('[SD] Working on: ' + state.sd.id);
     if (state.sd.phase) console.log('[SD] Phase: ' + state.sd.phase);
-    // Note (SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001): state.sd.progress_percentage depends on the
-    // writer (lib/context/unified-state-manager.js) selecting the correct DB column, which it does
-    // not today (separate bug logged: feedback 05a14092, selects a nonexistent progress_pct column).
-    if (state.sd.progress_percentage !== null && state.sd.progress_percentage !== undefined) {
-      console.log('[SD] Progress: ' + state.sd.progress_percentage + '%');
+    // NOT part of SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001's scope: this reads a JSON snapshot
+    // key from .claude/unified-session-state.json, not the strategic_directives_v2 DB column
+    // directly. The producer (lib/context/unified-state-manager.js) always writes this field as
+    // `progress` (see its STATE_SCHEMA and every getSDState() return path) -- reading
+    // `progress_percentage` here would always be undefined and silently drop this line. (The
+    // producer's own separate bug, selecting a nonexistent progress_pct DB column, is logged as
+    // feedback 05a14092 and is unrelated to this JS key name.)
+    if (state.sd.progress !== null && state.sd.progress !== undefined) {
+      console.log('[SD] Progress: ' + state.sd.progress + '%');
     }
   }
 

--- a/scripts/leo-resume.js
+++ b/scripts/leo-resume.js
@@ -50,8 +50,11 @@ try {
   if (state.sd && state.sd.id) {
     console.log('[SD] Working on: ' + state.sd.id);
     if (state.sd.phase) console.log('[SD] Phase: ' + state.sd.phase);
-    if (state.sd.progress !== null && state.sd.progress !== undefined) {
-      console.log('[SD] Progress: ' + state.sd.progress + '%');
+    // Note (SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001): state.sd.progress_percentage depends on the
+    // writer (lib/context/unified-state-manager.js) selecting the correct DB column, which it does
+    // not today (separate bug logged: feedback 05a14092, selects a nonexistent progress_pct column).
+    if (state.sd.progress_percentage !== null && state.sd.progress_percentage !== undefined) {
+      console.log('[SD] Progress: ' + state.sd.progress_percentage + '%');
     }
   }
 

--- a/scripts/modules/audit/audit-runner.js
+++ b/scripts/modules/audit/audit-runner.js
@@ -212,25 +212,25 @@ const DETECTION_RULES = {
     name: 'Progress Status Mismatch',
     severity: 'medium',
     evaluate: (sd, _config) => {
-      if (sd.status === 'completed' && sd.progress < 100) {
+      if (sd.status === 'completed' && sd.progress_percentage < 100) {
         return {
           triggered: true,
-          message: `SD marked completed but progress is only ${sd.progress}%`,
+          message: `SD marked completed but progress is only ${sd.progress_percentage}%`,
           evidence: {
             timestamps: {
-              progress: sd.progress,
+              progress: sd.progress_percentage,
               expected_progress: 100
             }
           }
         };
       }
-      if (sd.progress === 100 && sd.status !== 'completed' && sd.status !== 'on_hold' && sd.status !== 'cancelled') {
+      if (sd.progress_percentage === 100 && sd.status !== 'completed' && sd.status !== 'on_hold' && sd.status !== 'cancelled') {
         return {
           triggered: true,
           message: `SD has 100% progress but status is "${sd.status}" (expected: completed)`,
           evidence: {
             timestamps: {
-              progress: sd.progress,
+              progress: sd.progress_percentage,
               status: sd.status
             }
           }

--- a/tests/unit/eva-support/dispatcher.test.js
+++ b/tests/unit/eva-support/dispatcher.test.js
@@ -82,7 +82,7 @@ describe('dispatcher.js — buildRelatedSDsPrefix()', () => {
   it('composes prefix from sds only', async () => {
     const { buildRelatedSDsPrefix } = await import('../../../scripts/eva-support/_internal/dispatcher.js');
     const prefix = buildRelatedSDsPrefix({
-      sds: [{ sd_key: 'SD-FOO-001', status: 'draft', progress: 0 }],
+      sds: [{ sd_key: 'SD-FOO-001', status: 'draft', progress_percentage: 0 }],
       blockers: [],
     });
     expect(prefix).toContain('Related SDs:');
@@ -102,7 +102,7 @@ describe('dispatcher.js — buildRelatedSDsPrefix()', () => {
   it('de-duplicates an SD that appears in both sds and blockers (sds wins)', async () => {
     const { buildRelatedSDsPrefix } = await import('../../../scripts/eva-support/_internal/dispatcher.js');
     const prefix = buildRelatedSDsPrefix({
-      sds: [{ sd_key: 'SD-DUPE', status: 'in_progress', progress: 50 }],
+      sds: [{ sd_key: 'SD-DUPE', status: 'in_progress', progress_percentage: 50 }],
       blockers: [{ sd_key: 'SD-DUPE', blocker_reason: 'should be deduped' }],
     });
     const occurrences = (prefix.match(/SD-DUPE/g) || []).length;
@@ -154,7 +154,7 @@ describe('dispatcher.js — dispatch() middleware behavior', () => {
     vi.doMock('../../../lib/eva-support/sd-reader.js', () => ({
       getActiveSDs: async () => ({
         flag_enabled: true,
-        sds: [{ sd_key: 'SD-MATCH-001', status: 'draft', current_phase: 'LEAD', priority: 'high', progress: 25, target_application: 'EHG_Engineer', title: 'demo' }],
+        sds: [{ sd_key: 'SD-MATCH-001', status: 'draft', current_phase: 'LEAD', priority: 'high', progress_percentage: 25, target_application: 'EHG_Engineer', title: 'demo' }],
         audit_row_id: null,
       }),
     }));

--- a/tests/unit/eva-support/sd-reader.test.js
+++ b/tests/unit/eva-support/sd-reader.test.js
@@ -40,7 +40,7 @@ describe('sd-reader.js — static source invariants', () => {
       'current_phase',
       'target_application',
       'priority',
-      'progress',
+      'progress_percentage',
     ]);
   });
 
@@ -91,7 +91,7 @@ describe('sd-reader.js — runtime behavior', () => {
     mockSupabaseClient = {
       from: vi.fn((tableName) => {
         supabaseFromCalls.push(tableName);
-        return buildChain({ data: [{ sd_key: 'SD-DEMO-001', title: 'demo', status: 'draft', current_phase: 'LEAD', target_application: 'EHG_Engineer', priority: 'high', progress: 0 }], error: null });
+        return buildChain({ data: [{ sd_key: 'SD-DEMO-001', title: 'demo', status: 'draft', current_phase: 'LEAD', target_application: 'EHG_Engineer', priority: 'high', progress_percentage: 0 }], error: null });
       }),
     };
 

--- a/tests/unit/sd-revert.test.js
+++ b/tests/unit/sd-revert.test.js
@@ -24,11 +24,11 @@ describe('lib/sd/revert.js — static-pin (single-UPDATE shape)', () => {
     expect(updateMatches).toBe(1);
   });
 
-  it('references all 4 atomic columns (status, current_phase, progress, metadata) inside revertSD', () => {
+  it('references all 4 atomic columns (status, current_phase, progress_percentage, metadata) inside revertSD', () => {
     const body = sliceFunctionBody(REVERT_SRC, 'revertSD');
     expect(body).toContain('status:');
     expect(body).toContain('current_phase:');
-    expect(body).toContain('progress:');
+    expect(body).toContain('progress_percentage:');
     expect(body).toContain('metadata:');
   });
 
@@ -84,8 +84,8 @@ describe('lib/sd/revert.js — runtime behaviour', () => {
     };
   }
 
-  it('writes status/current_phase/progress/metadata atomically (single supabase.update call)', async () => {
-    const existing = { id: 'sd-test-1', metadata: { foo: 'bar' }, status: 'completed', current_phase: 'COMPLETED', progress: 100 };
+  it('writes status/current_phase/progress_percentage/metadata atomically (single supabase.update call)', async () => {
+    const existing = { id: 'sd-test-1', metadata: { foo: 'bar' }, status: 'completed', current_phase: 'COMPLETED', progress_percentage: 100 };
     const supabase = buildMock(existing);
 
     const res = await revertSD('sd-test-1', 'test', { supabase });
@@ -94,7 +94,7 @@ describe('lib/sd/revert.js — runtime behaviour', () => {
     expect(res.was_idempotent).toBe(false);
     expect(res.payload.status).toBe('draft');
     expect(res.payload.current_phase).toBe('LEAD');
-    expect(res.payload.progress).toBe(0);
+    expect(res.payload.progress_percentage).toBe(0);
     expect(res.payload.metadata.foo).toBe('bar');
     expect(res.payload.metadata.reverted_reason).toBe('test');
     expect(res.payload.metadata.reverted_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -107,7 +107,7 @@ describe('lib/sd/revert.js — runtime behaviour', () => {
       metadata: { reverted_at: '2026-04-28T12:02:44.918Z', reverted_reason: 'first' },
       status: 'draft',
       current_phase: 'LEAD',
-      progress: 0,
+      progress_percentage: 0,
     };
     const supabase = buildMock(existing);
 
@@ -119,7 +119,7 @@ describe('lib/sd/revert.js — runtime behaviour', () => {
   });
 
   it('dry_run returns planned payload without invoking update', async () => {
-    const existing = { id: 'sd-test-3', metadata: {}, status: 'completed', current_phase: 'COMPLETED', progress: 100 };
+    const existing = { id: 'sd-test-3', metadata: {}, status: 'completed', current_phase: 'COMPLETED', progress_percentage: 100 };
     const updateSpy = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }));
     const supabase = {
       from: vi.fn(() => ({
@@ -136,7 +136,7 @@ describe('lib/sd/revert.js — runtime behaviour', () => {
   });
 
   it('throws bracket-tokenized [SD_REVERT_FAILED] on update error', async () => {
-    const existing = { id: 'sd-test-4', metadata: {}, status: 'completed', current_phase: 'COMPLETED', progress: 100 };
+    const existing = { id: 'sd-test-4', metadata: {}, status: 'completed', current_phase: 'COMPLETED', progress_percentage: 100 };
     const supabase = buildMock(existing, { message: 'permission denied' });
 
     await expect(revertSD('sd-test-4', 'fail', { supabase })).rejects.toThrow(/\[SD_REVERT_FAILED\]/);
@@ -157,7 +157,7 @@ describe('lib/sd/revert.js — runtime behaviour', () => {
   });
 
   it('preserve_metadata option merges extra fields into metadata', async () => {
-    const existing = { id: 'sd-test-5', metadata: { foo: 'bar' }, status: 'completed', current_phase: 'COMPLETED', progress: 100 };
+    const existing = { id: 'sd-test-5', metadata: { foo: 'bar' }, status: 'completed', current_phase: 'COMPLETED', progress_percentage: 100 };
     const supabase = buildMock(existing);
 
     const res = await revertSD('sd-test-5', 'with-preserve', { supabase, preserve_metadata: { audit_token: 'X-123' } });


### PR DESCRIPTION
## Summary
- `strategic_directives_v2.progress` is a stale dead-twin column: measured 75.8% of completed SDs (3,404/4,492) read 0 there while `progress_percentage` is correct. `enforce_progress_on_completion()` (BEFORE-UPDATE trigger) only ever maintains `progress_percentage`.
- Repoints readers/writers to the live column across: the orchestrator-completion gate (`integration-verification-gate.js`), `/heal` + vision-heal renders, the EVA-support dispatcher + its two producers (`sd-reader.js`, `sd-blocker-surface.js`), retrospective scoring (`generate-retrospective.js`, `generate-comprehensive-retrospective.js`), and remaining display/audit consumers (`get-working-on-sd.js`, `leo-resume.js`, `audit-runner.js`, `efficient-database-queries.js`).
- `complete-children.mjs`'s writer is **dropped**, not repointed: it sets `status='completed'` in the same `UPDATE`, so the completion trigger would silently overwrite an explicit `progress_percentage` write on that exact path — the trigger already owns the column there.
- `lib/sd/revert.js`'s writer **is** safely repointed: it transitions status to `'draft'`, so the completion trigger never fires on that path (verified against the trigger's own `NEW.status='completed' AND OLD.status!='completed'` condition).
- Updates the two pre-existing pinned regression tests (`sd-reader.test.js`, `sd-revert.test.js`) and `dispatcher.test.js`'s mock fixtures to match.

## Test plan
- [x] `npx vitest run` on every touched file's dedicated test file — 110 passed, 10 skipped (DB-tier, no live target configured)
- [x] Full unit tier (`npm run test:unit`, 3220 files / 39644 tests): 39436 passed. The 4 unrelated failures (singleton-relaunch-restore, heal-vision `--target-path` smoke, stop-loop-wakeup-reminder timing) are pre-existing spawn/timing flakiness in unrelated subsystems — logged as harness bugs (feedback `a21203a6`, `20868eb3`), not touched here.
- [x] Direct verification that neither writer repoint is silently overwritten by `enforce_progress_on_completion()` (checked each writer's own `status` transition against the trigger's firing condition)

Follow-up PR adds the FR-7 ratchet guard (AST-based static-analysis lint + frozen baseline) preventing regression back to the dead column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)