### PR TITLE
test(SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001): FR-7 ratchet guard against progress-column regressions

### DIFF
--- a/scripts/audit/control-seed-specs.json
+++ b/scripts/audit/control-seed-specs.json
@@ -368,5 +368,27 @@
       "input": "migration SQL file TEXT under database/migrations/, supabase/migrations/, database/chairman-gated/ (paren-balance-scanned for CREATE [OR REPLACE] FUNCTION ... SECURITY DEFINER, then regex-matched for a same-function REVOKE naming PUBLIC and each of anon/authenticated addressed). Consumes no DB columns and no live catalog state -- that axis is the separate scripts/audit-rpc-execute-grants.mjs completeness gate, declared as this control's own KNOWN LIMITATION.",
       "seen": "live --all sweep against this repo's real database/migrations/, supabase/migrations/, database/chairman-gated/ at HEAD (session 642532a6, 2026-08-16): 1517 files scanned, 326 real pre-existing violations by exact file+function name -- a genuine positive in the deployment environment, not a fixture. The migration this SD authored (database/chairman-gated/20260816_close_remaining_secdef_execute_exposure.sql) was independently confirmed to score ZERO findings against the same live sweep."
     }
+  },
+  {
+    "name": "progress-column-lint",
+    "script": "scripts/lint/progress-column-lint.mjs",
+    "rootFlag": null,
+    "cwdScope": true,
+    "extraArgs": [],
+    "note": "SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001 FR-7. Scans via git ls-files (inherits cwd, so it IS aimable at a scratch git repo like no-connection-string-literals-lint and secdef-execute-revoke-lint above -- cwdScope:true, no --root flag needed). Reporting-only CLI (always exits 0 by design; the tests/unit/hygiene/no-bare-progress-column.test.js ratchet check, not this CLI's exit code, is what enforces pass/fail against the frozen baseline), so detection is by output text, not exit code -- matches the harness's DETECTS verdict path.",
+    "fixtures": [
+      {
+        "path": "lib/seeded-progress-column-defect.js",
+        "content": "// SEEDED DEFECT: writes the dead-twin `progress` column instead of `progress_percentage`\n// on the same UPDATE that sets status to 'completed' -- the exact class of bug\n// complete-children.mjs originally shipped.\nexport async function markComplete(supabase, sdId) {\n  return supabase.from('strategic_directives_v2').update({ status: 'completed', progress: 100 }).eq('id', sdId);\n}\n"
+      }
+    ],
+    "detectTokens": [
+      "seeded-progress-column-defect",
+      "RULE B"
+    ],
+    "observability_proof": {
+      "input": "git ls-files output (tracked .js/.mjs/.cjs/.ts/.tsx paths, filtered by PATH_EXCLUDE_PREFIXES) with each file's source TEXT AST-parsed via @babel/parser -- RULE A/B/C all require the same call or binding chain to also contain .from('strategic_directives_v2'); consumes no DB columns and no environment variables.",
+      "seen": "Live scan against this repo's real tracked tree at HEAD (session 642532a6-bd77-485d-9717-aa034628319c, 2026-08-16): 4621 files scanned, 37 real pre-existing bare-progress-column sites found across 20 files by exact file+line+rule (frozen into tests/unit/hygiene/progress-column-baseline.json) -- a genuine positive in the deployment tree, not a fixture. Every file this SD itself repointed (sd-reader.js, sd-blocker-surface.js, dispatcher.js, revert.js, integration-verification-gate.js, complete-children.mjs, heal-command.mjs, vision-heal.js, generate-retrospective.js, generate-comprehensive-retrospective.js, get-working-on-sd.js, leo-resume.js, audit-runner.js, efficient-database-queries.js) was independently confirmed to score ZERO findings against the same live scan."
+    }
   }
 ]

--- a/scripts/lint/progress-column-lint.mjs
+++ b/scripts/lint/progress-column-lint.mjs
@@ -4,7 +4,7 @@
 // the enforce_progress_on_completion() BEFORE-UPDATE trigger only maintains the latter — see
 // database/migrations/20251211_fix_progress_trigger_rls_access.sql:334-356). The column is not
 // dropped (no DDL in this SD's scope), so it still silently accepts reads and writes. This is a
-// RATCHET guard, not a zero-tolerance one: a fresh census at authoring time found 32 pre-existing
+// RATCHET guard, not a zero-tolerance one: a fresh census at authoring time found 37 pre-existing
 // bare-`progress` sites outside this SD's own repointed files (frozen in
 // tests/unit/hygiene/progress-column-baseline.json). The guard blocks any NEW site beyond that
 // baseline; the baseline may only shrink over time as future SDs clean up the remainder.
@@ -13,30 +13,53 @@
 // .from('strategic_directives_v2') (single-chain, syntactic — same precedent as
 // lib/static-analysis/consumer-index.js, no deep taint tracking):
 //   RULE A (readers) — a PostgREST query-builder method (.select/.order/.eq/.neq/.gt/.gte/.lt/
-//           .lte/.is) whose column-name string argument is EXACTLY "progress" (.select splits
-//           its comma-separated argument first; the rest take a single column name). Exact-token
-//           matching, not substring, so progress_percentage and progress_pct never match.
-//   RULE B (writers) — .update({...}) / .insert({...}) object literal with a top-level key
-//           exactly named "progress".
+//           .lte/.is/.in/.filter/.like/.ilike/.contains) whose column-name string argument is
+//           EXACTLY "progress" (.select splits its comma-separated argument first; the rest
+//           take a single column name). Exact-token matching, not substring, so
+//           progress_percentage and progress_pct never match.
+//   RULE B (writers) — .update({...}) / .insert({...}) / .upsert({...}) object literal (or
+//           array-of-objects batch form) with a top-level key exactly named "progress".
 //   RULE C (readers, partial coverage) — a bare `x.progress` property read where `x` is a
-//           SAME-SCOPE, SAME-STATEMENT variable directly initialized from a chain containing
-//           .from('strategic_directives_v2') (e.g. `const { data: sd } = await supabase.from(...)
-//           .select(...); ...sd.progress`).
+//           SAME-SCOPE variable directly (and only ever, see reassignment note below)
+//           initialized from a chain containing .from('strategic_directives_v2') (e.g.
+//           `const { data: sd } = await supabase.from(...).select(...); ...sd.progress`).
 //
-// KNOWN LIMITATION (measured, not guessed): RULE C only resolves a single-hop direct
-// declarator-init binding. It does NOT trace through function parameters (e.g.
-// scripts/modules/audit/audit-runner.js's `evaluate: (sd, _config) => ...` — sd arrives from a
-// caller elsewhere in the file), array indexing after a reassignment (e.g.
-// scripts/get-working-on-sd.js's `workingOn = spotlight; ... sd = workingOn[0]`), or
-// cross-function resolver calls (e.g. scripts/generate-retrospective.js's sd argument, sourced
-// from a separate resolver). Full interprocedural dataflow tracing would close this but is out
-// of proportion to this SD's scope and inconsistent with the codebase's own single-hop static-
-// analysis precedent. COMPENSATING CONTROL for the files this SD actually touched: every
-// repointed read site was verified by direct grep + Read against its own select-clause during
-// EXEC (never repointed blind), and the two pinned regression tests
-// (tests/unit/eva-support/sd-reader.test.js, tests/unit/sd-revert.test.js) assert the exact
-// column name each source now selects. A future SD extending RULE C to trace parameters/
-// reassignment would close the remaining gap for files added after this one.
+// KNOWN LIMITATIONS (measured via adversarial review, not guessed):
+//   - RULE C only resolves a single-hop direct declarator-init binding, and only when the
+//     binding is never reassigned (binding.constant — a reassigned variable is skipped
+//     entirely rather than risk a false positive from a stale .init). It does NOT trace through
+//     function parameters (e.g. scripts/modules/audit/audit-runner.js's
+//     `evaluate: (sd, _config) => ...` — sd arrives from a caller elsewhere in the file), array
+//     indexing after a reassignment (e.g. scripts/get-working-on-sd.js's
+//     `workingOn = spotlight; ... sd = workingOn[0]`), destructuring a field back OUT of an
+//     already-resolved binding (`const { data: sd } = await ...; const { progress } = sd;`), or
+//     cross-function resolver calls (e.g. scripts/generate-retrospective.js's sd argument,
+//     sourced from a separate resolver). Full interprocedural dataflow tracing would close this
+//     but is out of proportion to this SD's scope and inconsistent with the codebase's own
+//     single-hop static-analysis precedent.
+//   - chainContainsFromTable requires .from(...)'s argument to be a literal string. A table
+//     name held in a constant/variable (e.g. `supabase.from(TABLE)`) defeats detection for all
+//     three rules. This module exports its own TABLE constant (below) that could in principle
+//     be imported and used this exact way -- not yet observed in this codebase, but plausible.
+//   - Optional chaining (`?.`) produces OptionalCallExpression/OptionalMemberExpression AST
+//     nodes, which none of the three visitors recognize (despite ast-parse.js enabling the
+//     optionalChaining parser plugin) -- `supabase?.from(...)`, `.select(...)?.eq(...)`, and
+//     `row?.progress` are all invisible to every rule. Not observed as a live pattern against
+//     strategic_directives_v2 in this codebase at authoring time.
+//   - RULE B's ObjectExpression/ArrayExpression handling only covers a LITERAL argument. A
+//     write payload built in a variable and passed by reference (e.g.
+//     `const insert = {...}; supabase.from(TABLE).upsert(insert)` -- a real, live pattern at
+//     scripts/pocock/weekly-deepening-report.mjs:117) is invisible; tracing it would need the
+//     same binding-resolution machinery as RULE C, applied to write arguments.
+//   - RULE A's column-list split does not parse PostgREST `alias:column` select syntax
+//     (`.select('foo:progress')`), and neither RULE B nor RULE C recognizes computed/bracket
+//     property access (`row['progress']`, `update({ ['progress']: 0 })`).
+// COMPENSATING CONTROL for the files this SD actually touched: every repointed read/write site
+// was verified by direct grep + Read against its own select/update clause during EXEC (never
+// repointed blind), and the pinned regression tests (tests/unit/eva-support/sd-reader.test.js,
+// tests/unit/sd-revert.test.js, tests/unit/eva-support/dispatcher.test.js) assert the exact
+// column name each source now uses. A future SD closing any of the gaps above would tighten the
+// ratchet for files added after this one; none of them affect files this SD already fixed.
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -52,7 +75,10 @@ export const DEAD_COLUMN = 'progress';
 
 // PostgREST query-builder methods whose first argument is a single column-name string.
 // `select` is comma-separated and handled specially, not included here.
-const SINGLE_COLUMN_FILTER_METHODS = new Set(['order', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'is']);
+const SINGLE_COLUMN_FILTER_METHODS = new Set(['order', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'is', 'in', 'filter', 'like', 'ilike', 'contains']);
+
+// Write methods whose object-literal argument RULE B inspects for a `progress` key.
+const WRITE_METHODS = new Set(['update', 'insert', 'upsert']);
 
 export const SELF_PATHS = new Set([
   'scripts/lint/progress-column-lint.mjs',
@@ -144,18 +170,24 @@ export function scanSource(content, filePath) {
         if (arg.value === DEAD_COLUMN) {
           findings.push({ line: node.loc?.start?.line ?? 0, rule: 'A', method: methodName, snippet: `${methodName}('${arg.value}', ...)` });
         }
-      } else if (methodName === 'update' || methodName === 'insert') {
+      } else if (WRITE_METHODS.has(methodName)) {
         if (!chainContainsFromTable(callee.object, TABLE)) return;
         const arg = node.arguments[0];
-        if (!arg || arg.type !== 'ObjectExpression') return;
-        for (const prop of arg.properties) {
-          if (
-            prop.type === 'ObjectProperty' &&
-            !prop.computed &&
-            ((prop.key.type === 'Identifier' && prop.key.name === DEAD_COLUMN) ||
-              (prop.key.type === 'StringLiteral' && prop.key.value === DEAD_COLUMN))
-          ) {
-            findings.push({ line: node.loc?.start?.line ?? 0, rule: 'B', method: methodName, snippet: `${methodName}({ ${DEAD_COLUMN}: ... })` });
+        if (!arg) return;
+        // .insert([{...}, {...}]) / .upsert([{...}, {...}]) batch form: check every element.
+        const objectArgs = arg.type === 'ObjectExpression' ? [arg]
+          : arg.type === 'ArrayExpression' ? arg.elements.filter((e) => e && e.type === 'ObjectExpression')
+          : [];
+        for (const objArg of objectArgs) {
+          for (const prop of objArg.properties) {
+            if (
+              prop.type === 'ObjectProperty' &&
+              !prop.computed &&
+              ((prop.key.type === 'Identifier' && prop.key.name === DEAD_COLUMN) ||
+                (prop.key.type === 'StringLiteral' && prop.key.value === DEAD_COLUMN))
+            ) {
+              findings.push({ line: node.loc?.start?.line ?? 0, rule: 'B', method: methodName, snippet: `${methodName}({ ${DEAD_COLUMN}: ... })` });
+            }
           }
         }
       }
@@ -169,6 +201,12 @@ export function scanSource(content, filePath) {
 
       const binding = nodePath.scope.getBinding(node.object.name);
       if (!binding) return;
+      // Adversarial review of PR #7141: a binding that is REASSIGNED after its declaration
+      // (`row = { progress: 42 }` after `let row = supabase.from(...).select(...)`) must not
+      // be trusted -- the declarator's .init reflects only the FIRST assignment, not the value
+      // at the actual read site. binding.constant is false whenever any constantViolations
+      // exist (Babel resolves this without needing our own control-flow analysis).
+      if (!binding.constant) return;
 
       let declaratorPath = binding.path;
       while (declaratorPath && declaratorPath.node.type !== 'VariableDeclarator') {

--- a/scripts/lint/progress-column-lint.mjs
+++ b/scripts/lint/progress-column-lint.mjs
@@ -1,0 +1,266 @@
+// SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001, FR-7.
+//
+// strategic_directives_v2.progress is a dead-twin column (superseded by progress_percentage;
+// the enforce_progress_on_completion() BEFORE-UPDATE trigger only maintains the latter — see
+// database/migrations/20251211_fix_progress_trigger_rls_access.sql:334-356). The column is not
+// dropped (no DDL in this SD's scope), so it still silently accepts reads and writes. This is a
+// RATCHET guard, not a zero-tolerance one: a fresh census at authoring time found 32 pre-existing
+// bare-`progress` sites outside this SD's own repointed files (frozen in
+// tests/unit/hygiene/progress-column-baseline.json). The guard blocks any NEW site beyond that
+// baseline; the baseline may only shrink over time as future SDs clean up the remainder.
+//
+// Three AST-scoped rule shapes, all requiring the call chain to also contain
+// .from('strategic_directives_v2') (single-chain, syntactic — same precedent as
+// lib/static-analysis/consumer-index.js, no deep taint tracking):
+//   RULE A (readers) — a PostgREST query-builder method (.select/.order/.eq/.neq/.gt/.gte/.lt/
+//           .lte/.is) whose column-name string argument is EXACTLY "progress" (.select splits
+//           its comma-separated argument first; the rest take a single column name). Exact-token
+//           matching, not substring, so progress_percentage and progress_pct never match.
+//   RULE B (writers) — .update({...}) / .insert({...}) object literal with a top-level key
+//           exactly named "progress".
+//   RULE C (readers, partial coverage) — a bare `x.progress` property read where `x` is a
+//           SAME-SCOPE, SAME-STATEMENT variable directly initialized from a chain containing
+//           .from('strategic_directives_v2') (e.g. `const { data: sd } = await supabase.from(...)
+//           .select(...); ...sd.progress`).
+//
+// KNOWN LIMITATION (measured, not guessed): RULE C only resolves a single-hop direct
+// declarator-init binding. It does NOT trace through function parameters (e.g.
+// scripts/modules/audit/audit-runner.js's `evaluate: (sd, _config) => ...` — sd arrives from a
+// caller elsewhere in the file), array indexing after a reassignment (e.g.
+// scripts/get-working-on-sd.js's `workingOn = spotlight; ... sd = workingOn[0]`), or
+// cross-function resolver calls (e.g. scripts/generate-retrospective.js's sd argument, sourced
+// from a separate resolver). Full interprocedural dataflow tracing would close this but is out
+// of proportion to this SD's scope and inconsistent with the codebase's own single-hop static-
+// analysis precedent. COMPENSATING CONTROL for the files this SD actually touched: every
+// repointed read site was verified by direct grep + Read against its own select-clause during
+// EXEC (never repointed blind), and the two pinned regression tests
+// (tests/unit/eva-support/sd-reader.test.js, tests/unit/sd-revert.test.js) assert the exact
+// column name each source now selects. A future SD extending RULE C to trace parameters/
+// reassignment would close the remaining gap for files added after this one.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import traverseImport from '@babel/traverse';
+import { parseSource, MAX_ANALYZABLE_BYTES } from '../../lib/static-analysis/ast-parse.js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+// See lib/static-analysis/consumer-index.js for why this fallback is needed (ESM vs CJS interop).
+const traverse = traverseImport.default || traverseImport;
+
+export const TABLE = 'strategic_directives_v2';
+export const DEAD_COLUMN = 'progress';
+
+// PostgREST query-builder methods whose first argument is a single column-name string.
+// `select` is comma-separated and handled specially, not included here.
+const SINGLE_COLUMN_FILTER_METHODS = new Set(['order', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'is']);
+
+export const SELF_PATHS = new Set([
+  'scripts/lint/progress-column-lint.mjs',
+  'tests/unit/hygiene/no-bare-progress-column.test.js',
+]);
+
+// Tracked but not live production source for this guard's purposes: historical one-off/archive
+// scripts (already executed, not maintained), test files (synthetic fixtures legitimately use
+// arbitrary field names including "progress"), docs, and worktree checkouts of other SDs.
+export const PATH_EXCLUDE_PREFIXES = [
+  'tests/',
+  '.artifacts/',
+  'scripts/one-off/',
+  'scripts/archive/',
+  'scripts/temp/',
+  'docs/',
+  '.worktrees/',
+];
+
+export function isExcludedPath(filePath, prefixes = PATH_EXCLUDE_PREFIXES) {
+  return prefixes.some((p) => filePath.startsWith(p));
+}
+
+const INCLUDE_EXT = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx']);
+
+/** Walk leftward through a call/member chain looking for `.from(tableName)` anywhere in it. */
+function chainContainsFromTable(node, tableName) {
+  let current = node;
+  while (current) {
+    if (current.type === 'CallExpression') {
+      const callee = current.callee;
+      if (
+        callee.type === 'MemberExpression' &&
+        !callee.computed &&
+        callee.property.type === 'Identifier' &&
+        callee.property.name === 'from' &&
+        current.arguments.length > 0 &&
+        current.arguments[0].type === 'StringLiteral' &&
+        current.arguments[0].value === tableName
+      ) {
+        return true;
+      }
+      current = callee.type === 'MemberExpression' ? callee.object : null;
+    } else if (current.type === 'MemberExpression') {
+      current = current.object;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
+/**
+ * Scan one file's source text for RULE A / RULE B / RULE C violations.
+ *
+ * @param {string} content
+ * @param {string} filePath - used only to decide jsx/ts parser plugins
+ * @returns {Array<{line: number, rule: 'A'|'B'|'C', method: string, snippet: string}>}
+ */
+export function scanSource(content, filePath) {
+  const findings = [];
+  let ast;
+  try {
+    ast = parseSource(content, filePath);
+  } catch {
+    return findings; // unparsable file — per-file isolation, not this guard's concern
+  }
+
+  traverse(ast, {
+    CallExpression(nodePath) {
+      const { node } = nodePath;
+      const callee = node.callee;
+      if (callee.type !== 'MemberExpression' || callee.computed) return;
+      if (callee.property.type !== 'Identifier') return;
+      const methodName = callee.property.name;
+
+      if (methodName === 'select') {
+        if (!chainContainsFromTable(callee.object, TABLE)) return;
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== 'StringLiteral') return;
+        const cols = arg.value.split(',').map((s) => s.trim());
+        if (cols.includes(DEAD_COLUMN)) {
+          findings.push({ line: node.loc?.start?.line ?? 0, rule: 'A', method: 'select', snippet: arg.value });
+        }
+      } else if (SINGLE_COLUMN_FILTER_METHODS.has(methodName)) {
+        if (!chainContainsFromTable(callee.object, TABLE)) return;
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== 'StringLiteral') return;
+        if (arg.value === DEAD_COLUMN) {
+          findings.push({ line: node.loc?.start?.line ?? 0, rule: 'A', method: methodName, snippet: `${methodName}('${arg.value}', ...)` });
+        }
+      } else if (methodName === 'update' || methodName === 'insert') {
+        if (!chainContainsFromTable(callee.object, TABLE)) return;
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== 'ObjectExpression') return;
+        for (const prop of arg.properties) {
+          if (
+            prop.type === 'ObjectProperty' &&
+            !prop.computed &&
+            ((prop.key.type === 'Identifier' && prop.key.name === DEAD_COLUMN) ||
+              (prop.key.type === 'StringLiteral' && prop.key.value === DEAD_COLUMN))
+          ) {
+            findings.push({ line: node.loc?.start?.line ?? 0, rule: 'B', method: methodName, snippet: `${methodName}({ ${DEAD_COLUMN}: ... })` });
+          }
+        }
+      }
+    },
+
+    MemberExpression(nodePath) {
+      const { node } = nodePath;
+      if (node.computed) return;
+      if (node.property.type !== 'Identifier' || node.property.name !== DEAD_COLUMN) return;
+      if (node.object.type !== 'Identifier') return;
+
+      const binding = nodePath.scope.getBinding(node.object.name);
+      if (!binding) return;
+
+      let declaratorPath = binding.path;
+      while (declaratorPath && declaratorPath.node.type !== 'VariableDeclarator') {
+        declaratorPath = declaratorPath.parentPath;
+      }
+      if (!declaratorPath) return;
+      let init = declaratorPath.node.init;
+      if (!init) return;
+      if (init.type === 'AwaitExpression') init = init.argument;
+      if (!chainContainsFromTable(init, TABLE)) return;
+
+      findings.push({ line: node.loc?.start?.line ?? 0, rule: 'C', method: 'property-read', snippet: `${node.object.name}.${DEAD_COLUMN}` });
+    },
+  });
+
+  return findings;
+}
+
+/**
+ * Pure evaluator over already-loaded {path, content} pairs, so tests can exercise rule-shape
+ * detection without depending on live repo state or git (matches
+ * scripts/lint/no-connection-string-literals-lint.mjs's evaluateFiles precedent).
+ */
+export function evaluateFiles(files, { selfPaths = SELF_PATHS, excludePrefixes = PATH_EXCLUDE_PREFIXES } = {}) {
+  const findings = [];
+  for (const { path: filePath, content } of files) {
+    if (selfPaths.has(filePath)) continue;
+    if (isExcludedPath(filePath, excludePrefixes)) continue;
+    for (const finding of scanSource(content, filePath)) {
+      findings.push({ file: filePath, ...finding });
+    }
+  }
+  findings.sort((a, b) => (a.file === b.file ? a.line - b.line : a.file.localeCompare(b.file)));
+  return { findings, ok: findings.length === 0 };
+}
+
+export function loadTrackedFiles() {
+  // -z: NUL-delimited, sidesteps core.quotePath escaping of non-ASCII paths (same rationale as
+  // scripts/lint/no-connection-string-literals-lint.mjs's loadTrackedFiles).
+  const raw = execFileSync('git', ['ls-files', '-z'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  const paths = raw.split('\0').filter(Boolean)
+    .filter((p) => INCLUDE_EXT.has(p.slice(p.lastIndexOf('.'))))
+    .filter((p) => !isExcludedPath(p) && !SELF_PATHS.has(p));
+  const files = [];
+  const skippedFiles = [];
+  for (const p of paths) {
+    try {
+      const buf = readFileSync(p);
+      if (buf.length > MAX_ANALYZABLE_BYTES) {
+        skippedFiles.push({ path: p, bytes: buf.length });
+        continue;
+      }
+      files.push({ path: p, content: buf.toString('utf8') });
+    } catch {
+      continue; // binary/deleted-since-ls-files/permission error — not a violation
+    }
+  }
+  return { files, skippedFiles };
+}
+
+function main() {
+  const { files, skippedFiles } = loadTrackedFiles();
+  const result = evaluateFiles(files);
+
+  console.log(`[progress-column-lint] scanned ${files.length} tracked source file(s)`);
+  if (skippedFiles.length > 0) {
+    console.log(`⚠ skipped ${skippedFiles.length} file(s) over the ${MAX_ANALYZABLE_BYTES}-byte cap (not scanned):`);
+    for (const s of skippedFiles) console.log(`   ${s.path} (${s.bytes} bytes)`);
+  }
+  console.log(`Found ${result.findings.length} bare-"${DEAD_COLUMN}"-column site(s) on ${TABLE} chains.`);
+  for (const f of result.findings) {
+    console.log(`   [RULE ${f.rule}] ${f.file}:${f.line} (${f.method}) — ${f.snippet}`);
+  }
+
+  const writeIdx = process.argv.indexOf('--write-baseline');
+  if (writeIdx !== -1 && process.argv[writeIdx + 1]) {
+    const baselinePath = process.argv[writeIdx + 1];
+    const baseline = {
+      generated_note: 'Frozen allowlist for SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001 FR-7 ratchet guard. Regenerate via: node scripts/lint/progress-column-lint.mjs --write-baseline tests/unit/hygiene/progress-column-baseline.json. Must only shrink over time (see tests/unit/hygiene/no-bare-progress-column.test.js).',
+      table: TABLE,
+      dead_column: DEAD_COLUMN,
+      count: result.findings.length,
+      sites: result.findings,
+    };
+    mkdirSync(dirname(baselinePath), { recursive: true });
+    writeFileSync(baselinePath, JSON.stringify(baseline, null, 2) + '\n');
+    console.log(`\nWrote baseline: ${baselinePath}`);
+  }
+
+  process.exitCode = 0; // reporting tool; the baseline-subset check (not this CLI) enforces pass/fail
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/tests/unit/hygiene/no-bare-progress-column.test.js
+++ b/tests/unit/hygiene/no-bare-progress-column.test.js
@@ -60,7 +60,7 @@ describe('RULE A — reader string-literal membership', () => {
     expect(scanSource(src, 'f.js')).toEqual([]);
   });
 
-  it.each(['order', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'is'])(
+  it.each(['order', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'is', 'in', 'filter', 'like', 'ilike', 'contains'])(
     'flags .%s("progress", ...) as a single-column filter/order call',
     (method) => {
       const src = `supabase.from('strategic_directives_v2').select('id').${method}('progress', 100);`;
@@ -118,6 +118,29 @@ describe('RULE B — writer object-literal key check', () => {
     `;
     expect(scanSource(src, 'f.js')).toEqual([]);
   });
+
+  // Adversarial review of PR #7141: .upsert() was entirely uncovered (real precedent:
+  // scripts/pocock/weekly-deepening-report.mjs:117), and batch array-of-objects .insert()/
+  // .upsert() calls (not just a single object literal) were also uncovered.
+  it('flags upsert({ progress: ... }) on strategic_directives_v2', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').upsert({ id: x, progress: 0 }, { onConflict: \'id\' });';
+    const findings = scanSource(src, 'f.js');
+    expect(findings).toEqual([{ line: 1, rule: 'B', method: 'upsert', snippet: 'upsert({ progress: ... })' }]);
+  });
+
+  it('flags a violation inside a batch array-of-objects .insert([...]) call', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').insert([{ sd_key: \'a\' }, { sd_key: \'b\', progress: 10 }]);';
+    const findings = scanSource(src, 'f.js');
+    expect(findings).toEqual([{ line: 1, rule: 'B', method: 'insert', snippet: 'insert({ progress: ... })' }]);
+  });
+
+  it('does NOT flag .upsert(insert) where the payload is a variable reference (documented limitation)', () => {
+    const src = `
+      const insert = { id: x, progress: 0 };
+      supabase.from('strategic_directives_v2').upsert(insert, { onConflict: 'id' });
+    `;
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
 });
 
 describe('RULE C — same-scope property-read (partial coverage, documented limitation)', () => {
@@ -162,6 +185,20 @@ describe('RULE C — same-scope property-read (partial coverage, documented limi
       function evaluate(sd, _config) {
         if (sd.status === 'completed' && sd.progress < 100) return true;
         return false;
+      }
+    `;
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  // Adversarial review of PR #7141: a binding resolved from a strategic_directives_v2 chain
+  // but then REASSIGNED before the .progress read must not be flagged -- the declarator's
+  // .init reflects the FIRST assignment only, not the value at the actual read site.
+  it('does NOT flag row.progress when row is reassigned to an unrelated value first (false-positive guard)', () => {
+    const src = `
+      function run(supabase) {
+        let row = supabase.from('strategic_directives_v2').select('id');
+        row = { progress: 42 };
+        return row.progress;
       }
     `;
     expect(scanSource(src, 'f.js')).toEqual([]);
@@ -243,7 +280,15 @@ describe('evaluateFiles — mutation/red-green meta-test', () => {
 
 describe('live ratchet — ok:true only while every live finding is already in the frozen baseline', () => {
   const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
-  const baselineKeys = new Set(baseline.sites.map((s) => `${s.file}:${s.line}:${s.rule}`));
+  // Adversarial review of PR #7141 (SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001): a
+  // file:line:rule key is NOT unique -- Babel's node.loc.start.line for a chained
+  // CallExpression is the start of the WHOLE fluent chain, so two DIFFERENT findings on the
+  // same table/rule (e.g. .lt('progress',...) and .select('...progress...') both starting at
+  // scripts/handoff-export.cjs:89) collide onto one key. Verified against the live baseline:
+  // 37 sites, only 36 unique file:line:rule keys before `method` was added here. Without
+  // `method` in the key, a genuinely NEW violation landing on an already-baselined line would
+  // silently pass the subset check instead of failing it.
+  const baselineKeys = new Set(baseline.sites.map((s) => `${s.file}:${s.line}:${s.rule}:${s.method}`));
 
   it('baseline file has the expected shape', () => {
     expect(baseline.table).toBe('strategic_directives_v2');
@@ -252,10 +297,14 @@ describe('live ratchet — ok:true only while every live finding is already in t
     expect(baseline.count).toBe(baseline.sites.length);
   });
 
+  it('the baseline dedup key (file:line:rule:method) has no collisions (regression guard for the PR #7141 review finding)', () => {
+    expect(baselineKeys.size).toBe(baseline.sites.length);
+  });
+
   it('every LIVE finding is already present in the frozen baseline (no NEW site)', () => {
     const { files } = loadTrackedFiles();
     const { findings } = evaluateFiles(files);
-    const newFindings = findings.filter((f) => !baselineKeys.has(`${f.file}:${f.line}:${f.rule}`));
+    const newFindings = findings.filter((f) => !baselineKeys.has(`${f.file}:${f.line}:${f.rule}:${f.method}`));
     expect(newFindings).toEqual([]);
   }, 60000);
 

--- a/tests/unit/hygiene/no-bare-progress-column.test.js
+++ b/tests/unit/hygiene/no-bare-progress-column.test.js
@@ -26,6 +26,12 @@ const ROOT = path.resolve(__dirname, '../../..');
 const BASELINE_PATH = path.join(ROOT, 'tests/unit/hygiene/progress-column-baseline.json');
 
 describe('constants', () => {
+  it('PATH_EXCLUDE_PREFIXES is a non-empty array of string prefixes', () => {
+    expect(Array.isArray(PATH_EXCLUDE_PREFIXES)).toBe(true);
+    expect(PATH_EXCLUDE_PREFIXES.length).toBeGreaterThan(0);
+    for (const p of PATH_EXCLUDE_PREFIXES) expect(typeof p).toBe('string');
+  });
+
   it('targets strategic_directives_v2 and the "progress" column', () => {
     expect(TABLE).toBe('strategic_directives_v2');
     expect(DEAD_COLUMN).toBe('progress');

--- a/tests/unit/hygiene/no-bare-progress-column.test.js
+++ b/tests/unit/hygiene/no-bare-progress-column.test.js
@@ -1,0 +1,289 @@
+// SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001, FR-7/FR-8.
+//
+// Two test styles, deliberately:
+//  - Sections 1-4 exercise scanSource/evaluateFiles on SYNTHETIC in-memory fixtures (no disk,
+//    no git) -- matches tests/unit/hygiene/no-connection-string-literals.test.js's precedent.
+//  - Section 5 is a genuine exception to that precedent: a ratchet guard's entire point is
+//    comparing today's live repo state against a frozen baseline, so it necessarily reads the
+//    real tracked tree via loadTrackedFiles(). This is deliberate, not a drift from convention.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  TABLE,
+  DEAD_COLUMN,
+  SELF_PATHS,
+  PATH_EXCLUDE_PREFIXES,
+  isExcludedPath,
+  scanSource,
+  evaluateFiles,
+  loadTrackedFiles,
+} from '../../../scripts/lint/progress-column-lint.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../../..');
+const BASELINE_PATH = path.join(ROOT, 'tests/unit/hygiene/progress-column-baseline.json');
+
+describe('constants', () => {
+  it('targets strategic_directives_v2 and the "progress" column', () => {
+    expect(TABLE).toBe('strategic_directives_v2');
+    expect(DEAD_COLUMN).toBe('progress');
+  });
+});
+
+describe('RULE A — reader string-literal membership', () => {
+  it('flags an exact "progress" token inside a .select() comma list', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').select(\'id, sd_key, progress\').eq(\'id\', x);';
+    const findings = scanSource(src, 'f.js');
+    expect(findings).toEqual([{ line: 1, rule: 'A', method: 'select', snippet: 'id, sd_key, progress' }]);
+  });
+
+  it('does NOT flag progress_percentage (exact-equality, not substring)', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').select(\'id, progress_percentage\');';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag progress_pct either', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').select(\'id, progress_pct\');';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag a .select("progress") on an unrelated table', () => {
+    const src = 'supabase.from(\'some_other_table\').select(\'id, progress\');';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  it.each(['order', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'is'])(
+    'flags .%s("progress", ...) as a single-column filter/order call',
+    (method) => {
+      const src = `supabase.from('strategic_directives_v2').select('id').${method}('progress', 100);`;
+      const findings = scanSource(src, 'f.js');
+      expect(findings.some((f) => f.rule === 'A' && f.method === method)).toBe(true);
+    },
+  );
+
+  it('does NOT flag .lt("progress_percentage", ...) (this SD\'s own repointed shape)', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').select(\'id\').lt(\'progress_percentage\', 100);';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag a non-string-literal .select() argument (e.g. a joined constant)', () => {
+    // Known blind spot (documented): array-built select clauses like
+    // ALLOWED_COLUMNS.join(',') are not resolved back to a literal by this rule.
+    const src = 'supabase.from(\'strategic_directives_v2\').select(SELECT_CLAUSE);';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+});
+
+describe('RULE B — writer object-literal key check', () => {
+  it('flags update({ progress: ... }) on strategic_directives_v2', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').update({ status: \'draft\', progress: 0 }).eq(\'id\', x);';
+    const findings = scanSource(src, 'f.js');
+    expect(findings).toEqual([{ line: 1, rule: 'B', method: 'update', snippet: 'update({ progress: ... })' }]);
+  });
+
+  it('flags insert({ progress: ... }) on strategic_directives_v2', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').insert({ progress: 0 });';
+    const findings = scanSource(src, 'f.js');
+    expect(findings[0].rule).toBe('B');
+    expect(findings[0].method).toBe('insert');
+  });
+
+  it('does NOT flag update({ progress_percentage: ... }) (already-correct code)', () => {
+    const src = 'supabase.from(\'strategic_directives_v2\').update({ progress_percentage: 0 });';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag update({ progress: ... }) on an unrelated table', () => {
+    const src = 'supabase.from(\'other_table\').update({ progress: 5 });';
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  // WARN-5 from the LEAD-phase prospective TESTING review: a key-name-only (non-AST-scoped)
+  // guard would flag DTO construction like `progress: sd.progress_percentage || 0` -- the
+  // DESIRED end state, not a bug. RULE B is scoped to .update()/.insert() call arguments only,
+  // so a bare object literal built elsewhere (never passed to .update/.insert on this table) is
+  // structurally invisible to it, by construction, without needing a value-shape exemption.
+  it('does NOT flag a DTO object literal with a "progress" key reading progress_percentage', () => {
+    const src = `
+      const dto = { progress: sd.progress_percentage || 0, status: sd.status };
+      return dto;
+    `;
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+});
+
+describe('RULE C — same-scope property-read (partial coverage, documented limitation)', () => {
+  it('flags sd.progress where sd is destructured directly from a strategic_directives_v2 select', () => {
+    const src = `
+      async function run(supabase) {
+        const { data: sd } = await supabase.from('strategic_directives_v2').select('id, progress_percentage').single();
+        return sd.progress;
+      }
+    `;
+    const findings = scanSource(src, 'f.js');
+    expect(findings).toEqual([{ line: 4, rule: 'C', method: 'property-read', snippet: 'sd.progress' }]);
+  });
+
+  it('flags row.progress for a plain (non-destructured, non-awaited) direct binding', () => {
+    const src = `
+      function run(supabase) {
+        const row = supabase.from('strategic_directives_v2').select('id');
+        return row.progress;
+      }
+    `;
+    const findings = scanSource(src, 'f.js');
+    expect(findings.some((f) => f.rule === 'C' && f.snippet === 'row.progress')).toBe(true);
+  });
+
+  it('never flags .progress_percentage reads (exact property-name match only)', () => {
+    const src = `
+      async function run(supabase) {
+        const { data: sd } = await supabase.from('strategic_directives_v2').select('*').single();
+        return sd.progress_percentage;
+      }
+    `;
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  // Documented KNOWN LIMITATION (see the lint script's own header comment): RULE C only
+  // resolves a single-hop direct declarator-init binding. A function PARAMETER's true origin
+  // (the caller's argument) is out of reach for single-file, single-hop static analysis --
+  // this mirrors lib/static-analysis/consumer-index.js's own no-deep-taint-tracking precedent.
+  it('does NOT flag sd.progress when sd arrives as a function parameter (documented gap)', () => {
+    const src = `
+      function evaluate(sd, _config) {
+        if (sd.status === 'completed' && sd.progress < 100) return true;
+        return false;
+      }
+    `;
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag .progress on an object unrelated to strategic_directives_v2', () => {
+    const src = `
+      async function run() {
+        const video = await encoder.getStatus();
+        return video.progress;
+      }
+    `;
+    expect(scanSource(src, 'f.js')).toEqual([]);
+  });
+});
+
+describe('self-path and exclude-prefix handling', () => {
+  it('SELF_PATHS contains exactly this guard file and its own test', () => {
+    expect(SELF_PATHS).toEqual(new Set([
+      'scripts/lint/progress-column-lint.mjs',
+      'tests/unit/hygiene/no-bare-progress-column.test.js',
+    ]));
+  });
+
+  it('evaluateFiles never reports findings for a self-path, even with a real violation', () => {
+    const files = [{
+      path: 'scripts/lint/progress-column-lint.mjs',
+      content: 'supabase.from(\'strategic_directives_v2\').update({ progress: 0 });',
+    }];
+    expect(evaluateFiles(files).ok).toBe(true);
+  });
+
+  it.each(['tests/unit/example.test.js', '.artifacts/scratch.mjs', 'scripts/one-off/x.mjs', 'scripts/archive/y.js', 'docs/notes.js', '.worktrees/other-sd/z.js'])(
+    'isExcludedPath excludes %s',
+    (p) => {
+      expect(isExcludedPath(p)).toBe(true);
+    },
+  );
+
+  it('isExcludedPath does not exclude ordinary production paths', () => {
+    expect(isExcludedPath('lib/eva-support/sd-reader.js')).toBe(false);
+    expect(isExcludedPath('scripts/modules/audit/audit-runner.js')).toBe(false);
+  });
+
+  it('evaluateFiles skips excluded-prefix findings', () => {
+    const files = [{
+      path: 'scripts/one-off/scratch.mjs',
+      content: 'supabase.from(\'strategic_directives_v2\').update({ progress: 0 });',
+    }];
+    expect(evaluateFiles(files).ok).toBe(true);
+  });
+});
+
+describe('evaluateFiles — mutation/red-green meta-test', () => {
+  it('reports ok:true for an all-clean synthetic file set', () => {
+    const files = [
+      { path: 'a.js', content: 'supabase.from(\'strategic_directives_v2\').select(\'id, progress_percentage\');' },
+      { path: 'b.js', content: 'supabase.from(\'strategic_directives_v2\').update({ progress_percentage: 100 });' },
+    ];
+    expect(evaluateFiles(files)).toEqual({ findings: [], ok: true });
+  });
+
+  // Red-green: this is the guard's own proof that it can fail, not just pass -- a scanner that
+  // always returns ok:true would trivially satisfy the Section 5 subset check below without
+  // actually checking anything (same discipline as tests/unit/sd-revert.test.js's
+  // "static-pin meta-test: synthetic two-update body fails the assertion").
+  it('reports ok:false with one finding per injected violation across multiple files', () => {
+    const files = [
+      { path: 'a.js', content: 'supabase.from(\'strategic_directives_v2\').select(\'id, progress\');' },
+      { path: 'b.js', content: 'supabase.from(\'strategic_directives_v2\').update({ progress: 5 });' },
+      { path: 'c.js', content: 'supabase.from(\'strategic_directives_v2\').select(\'id, progress_percentage\');' }, // clean
+    ];
+    const result = evaluateFiles(files);
+    expect(result.ok).toBe(false);
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((f) => f.file).sort()).toEqual(['a.js', 'b.js']);
+  });
+});
+
+describe('live ratchet — ok:true only while every live finding is already in the frozen baseline', () => {
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  const baselineKeys = new Set(baseline.sites.map((s) => `${s.file}:${s.line}:${s.rule}`));
+
+  it('baseline file has the expected shape', () => {
+    expect(baseline.table).toBe('strategic_directives_v2');
+    expect(baseline.dead_column).toBe('progress');
+    expect(Array.isArray(baseline.sites)).toBe(true);
+    expect(baseline.count).toBe(baseline.sites.length);
+  });
+
+  it('every LIVE finding is already present in the frozen baseline (no NEW site)', () => {
+    const { files } = loadTrackedFiles();
+    const { findings } = evaluateFiles(files);
+    const newFindings = findings.filter((f) => !baselineKeys.has(`${f.file}:${f.line}:${f.rule}`));
+    expect(newFindings).toEqual([]);
+  }, 60000);
+
+  // Not a hard requirement (the baseline is allowed to still equal the live count if nothing
+  // has shrunk yet), but flags accidental growth going the other direction too, independent of
+  // the per-site subset check above.
+  it('live finding count does not exceed the frozen baseline count', () => {
+    const { files } = loadTrackedFiles();
+    const { findings } = evaluateFiles(files);
+    expect(findings.length).toBeLessThanOrEqual(baseline.count);
+  }, 60000);
+
+  // Direct regression proof for this SD's own FR-1 through FR-6 repoints: none of the files
+  // this SD explicitly fixed may reappear in the live scan, under any rule.
+  const FIXED_FILES = [
+    'lib/eva-support/sd-reader.js',
+    'lib/eva-support/sd-blocker-surface.js',
+    'scripts/eva-support/_internal/dispatcher.js',
+    'lib/sd/revert.js',
+    'scripts/gates/integration-verification-gate.js',
+    'scripts/batch-operations/complete-children.mjs',
+    'scripts/eva/heal-command.mjs',
+    'scripts/eva/vision-heal.js',
+    'scripts/generate-retrospective.js',
+    'scripts/generate-comprehensive-retrospective.js',
+    'scripts/get-working-on-sd.js',
+    'scripts/leo-resume.js',
+    'scripts/modules/audit/audit-runner.js',
+    'scripts/examples/efficient-database-queries.js',
+  ];
+
+  it.each(FIXED_FILES)('%s produces zero live findings', (relFile) => {
+    const absPath = path.join(ROOT, relFile);
+    const content = readFileSync(absPath, 'utf8');
+    expect(scanSource(content, absPath)).toEqual([]);
+  });
+});

--- a/tests/unit/hygiene/progress-column-baseline.json
+++ b/tests/unit/hygiene/progress-column-baseline.json
@@ -1,0 +1,267 @@
+{
+  "generated_note": "Frozen allowlist for SD-LEO-INFRA-PROGRESS-COLUMN-DEAD-TWIN-001 FR-7 ratchet guard. Regenerate via: node scripts/lint/progress-column-lint.mjs --write-baseline tests/unit/hygiene/progress-column-baseline.json. Must only shrink over time (see tests/unit/hygiene/no-bare-progress-column.test.js).",
+  "table": "strategic_directives_v2",
+  "dead_column": "progress",
+  "count": 37,
+  "sites": [
+    {
+      "file": "lib/eva/adapters/real-data-adapter.js",
+      "line": 91,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, sd_type, progress, completion_date"
+    },
+    {
+      "file": "lib/eva/bridge/verification-sd-generator.js",
+      "line": 87,
+      "rule": "B",
+      "method": "insert",
+      "snippet": "insert({ progress: ... })"
+    },
+    {
+      "file": "lib/eva/chairman-governance-panels.js",
+      "line": 39,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, sd_type, priority, venture_id, current_phase, progress"
+    },
+    {
+      "file": "lib/eva/chairman-governance-panels.js",
+      "line": 173,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, status, current_phase, progress, created_at, completion_date"
+    },
+    {
+      "file": "lib/eva/event-bus/handlers/sd-completed.js",
+      "line": 90,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, sd_type, progress"
+    },
+    {
+      "file": "lib/eva/friday-data-aggregator.js",
+      "line": 51,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, current_phase, progress"
+    },
+    {
+      "file": "lib/eva/quality-findings/sd-generator.js",
+      "line": 632,
+      "rule": "B",
+      "method": "insert",
+      "snippet": "insert({ progress: ... })"
+    },
+    {
+      "file": "lib/eva/rpc/get-s20-sd-progress.js",
+      "line": 41,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, current_phase, progress, parent_sd_id, created_at"
+    },
+    {
+      "file": "lib/eva/s20-pause-controller.js",
+      "line": 221,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, current_phase, progress"
+    },
+    {
+      "file": "lib/eva/s20-pause-controller.js",
+      "line": 341,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, current_phase, progress, parent_sd_id"
+    },
+    {
+      "file": "lib/eva/venture-context-manager.js",
+      "line": 191,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, sd_type, priority, current_phase, progress"
+    },
+    {
+      "file": "lib/eva/vision-governance-service.js",
+      "line": 124,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, progress, vision_origin_score_id"
+    },
+    {
+      "file": "lib/strategy/sd-proposal-generator.js",
+      "line": 196,
+      "rule": "B",
+      "method": "insert",
+      "snippet": "insert({ progress: ... })"
+    },
+    {
+      "file": "lib/sub-agents/validation.js",
+      "line": 390,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, title, status, priority, progress, current_phase, scope, category, target_application, sd_type"
+    },
+    {
+      "file": "lib/utils/dependency-chain-validator.js",
+      "line": 40,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, dependency_chain, dependencies, parent_sd_id, status, progress"
+    },
+    {
+      "file": "lib/utils/dependency-chain-validator.js",
+      "line": 72,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, progress"
+    },
+    {
+      "file": "lib/utils/dependency-chain-validator.js",
+      "line": 159,
+      "rule": "A",
+      "method": "select",
+      "snippet": "status, progress"
+    },
+    {
+      "file": "lib/utils/dependency-chain-validator.js",
+      "line": 171,
+      "rule": "C",
+      "method": "property-read",
+      "snippet": "dep.progress"
+    },
+    {
+      "file": "lib/utils/dependency-chain-validator.js",
+      "line": 177,
+      "rule": "C",
+      "method": "property-read",
+      "snippet": "dep.progress"
+    },
+    {
+      "file": "lib/utils/orchestrator-child-completion.js",
+      "line": 82,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, sd_type, status, progress"
+    },
+    {
+      "file": "lib/utils/orchestrator-child-completion.js",
+      "line": 178,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, status, progress"
+    },
+    {
+      "file": "lib/utils/orchestrator-child-completion.js",
+      "line": 215,
+      "rule": "B",
+      "method": "update",
+      "snippet": "update({ progress: ... })"
+    },
+    {
+      "file": "scripts/handoff-export.cjs",
+      "line": 89,
+      "rule": "A",
+      "method": "lt",
+      "snippet": "lt('progress', ...)"
+    },
+    {
+      "file": "scripts/handoff-export.cjs",
+      "line": 89,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, priority, current_phase, progress, description"
+    },
+    {
+      "file": "scripts/handoff-export.cjs",
+      "line": 108,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, priority, current_phase, progress, description"
+    },
+    {
+      "file": "scripts/hooks/session-init.cjs",
+      "line": 80,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, sd_type, status, current_phase, progress"
+    },
+    {
+      "file": "scripts/hooks/session-init.cjs",
+      "line": 102,
+      "rule": "C",
+      "method": "property-read",
+      "snippet": "sd.progress"
+    },
+    {
+      "file": "scripts/hooks/session-init.cjs",
+      "line": 156,
+      "rule": "C",
+      "method": "property-read",
+      "snippet": "sd.progress"
+    },
+    {
+      "file": "scripts/leo-orchestrator-enforced.js",
+      "line": 171,
+      "rule": "B",
+      "method": "update",
+      "snippet": "update({ progress: ... })"
+    },
+    {
+      "file": "scripts/modules/child-progression-gate.js",
+      "line": 84,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, completion_date, progress"
+    },
+    {
+      "file": "scripts/modules/handoff/blocker-resolution.js",
+      "line": 77,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, status, progress"
+    },
+    {
+      "file": "scripts/modules/handoff/blocker-resolution.js",
+      "line": 166,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, sd_key, title, status, progress, current_phase, parent_sd_id, dependencies, metadata"
+    },
+    {
+      "file": "scripts/modules/handoff/blocker-resolution.js",
+      "line": 178,
+      "rule": "C",
+      "method": "property-read",
+      "snippet": "blockerSD.progress"
+    },
+    {
+      "file": "scripts/modules/handoff/orchestrator-completion-guardian.js",
+      "line": 127,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, title, status, progress"
+    },
+    {
+      "file": "scripts/modules/qa/dependency-checker.js",
+      "line": 43,
+      "rule": "A",
+      "method": "select",
+      "snippet": "id, title, progress, status, metadata"
+    },
+    {
+      "file": "scripts/sd-query.js",
+      "line": 109,
+      "rule": "A",
+      "method": "select",
+      "snippet": "sd_key, title, status, current_phase, progress, sd_type, priority, created_at, completion_date"
+    },
+    {
+      "file": "templates/execute-phase/phase-utils.js",
+      "line": 84,
+      "rule": "B",
+      "method": "update",
+      "snippet": "update({ progress: ... })"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Follow-up to #7139. Adds an AST-based static-analysis guard (`scripts/lint/progress-column-lint.mjs`) preventing new bare-`progress` reads/writes against `strategic_directives_v2` from being reintroduced now that #7139 repointed the live call sites to `progress_percentage`.
- Three rule shapes, all chain-scoped to `.from('strategic_directives_v2')` (no deep taint tracking — matches `lib/static-analysis/consumer-index.js`'s own precedent):
  - **RULE A**: exact-equality string-literal membership on `.select()`/`.order()`/`.eq()`/`.neq()`/`.gt()`/`.gte()`/`.lt()`/`.lte()`/`.is()` column-name arguments (exact match, not substring — immune to `progress_percentage`/`progress_pct`)
  - **RULE B**: `.update()`/`.insert()` object-literal key check
  - **RULE C** (partial coverage, documented limitation): same-scope direct-binding property reads. Does not trace through function parameters or multi-hop reassignment — documented explicitly rather than overclaimed.
- A **fresh** census (not the stale LEAD-phase count) found 37 pre-existing bare-progress sites across 20 files outside this SD's own repointed scope, frozen into `tests/unit/hygiene/progress-column-baseline.json`. This is a **ratchet**, not zero-tolerance: the guard test asserts every live finding is already in the frozen baseline (no NEW site), and the baseline may only shrink over time.
- Registers the control in `scripts/audit/control-seed-specs.json` (the repo's existing control-about-controls meta-test registry) with a fixture proving it fires on a seeded defect, verified locally via a direct `runTrial()` call (`verdict: DETECTS`).

## Test plan
- [x] `npx vitest run tests/unit/hygiene/no-bare-progress-column.test.js` — 55/55 passing, including:
  - Synthetic-fixture unit tests for all 3 rules (positive + negative cases, including the DTO-false-positive and function-parameter-gap cases)
  - A mutation/red-green meta-test proving the scanner can fail, not just pass
  - A live scan against the real (post-#7139-merge) tracked tree asserting no finding falls outside the frozen baseline
  - 14 direct regression checks — one per file #7139 repointed — confirming each is clean under all three rules
- [x] Directly verified the control-seed-specs.json entry fires correctly (`runTrial()` returns `verdict: DETECTS`, `treeClean: true`) and satisfies `hasObservabilityProof`/`KNOWN LIMITATION` checks before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)