### PR TITLE
fix(SD-LEO-INFRA-EVIDENCE-WRITER-VERDICT-FAIL-LOUD-001): evidence writer fails loud on unrecognised verdict

### DIFF
--- a/scripts/store-sub-agent-repo-evidence.js
+++ b/scripts/store-sub-agent-repo-evidence.js
@@ -34,6 +34,34 @@ import { VERDICT_VALUES } from '../lib/sub-agents/verdict-chain.js';
 export const LIKELY_VERDICT_FIELDS = ['status', 'overall_status', 'overall_verdict', 'result', 'outcome', 'passed'];
 
 /**
+ * SD-LEO-INFRA-EVIDENCE-WRITER-VERDICT-FAIL-LOUD-001 (SECURITY, EXEC-TO-PLAN evidence 52cd374f,
+ * SEC-1/SEC-2/SEC-3): this is the first place a caller-supplied field VALUE (not just structural
+ * metadata) reaches an output stream in this writer's history, so every value routed into the
+ * guard message goes through here first: never throws (a hostile toString/valueOf shadowing the
+ * default -- e.g. {toString:1,valueOf:2}, JSON-reachable via --content -- makes a bare String(x)
+ * throw AFTER storeSubAgentResults() already persisted the row, per SEC-2 -- the exact
+ * "diagnostic that could break a write" class results-storage.js's own doctrine warns against,
+ * one layer over); bounded (SEC-3: an unbounded echo widens the AUDIENCE and RETENTION of
+ * whatever a payload legitimately or accidentally carries -- e.g. a connection string leaked into
+ * a `result` field -- into CI logs/terminal scrollback/agent transcripts, even though the same
+ * value already reached the DB either way).
+ *
+ * @param {*} value
+ * @param {number} [max]
+ * @returns {string}
+ */
+function safeValue(value, max = 200) {
+  let s;
+  try {
+    s = String(value);
+  } catch {
+    return '(unstringifiable)';
+  }
+  if (s.length > max) s = `${s.slice(0, max)}[+${s.length - max} chars]`;
+  return s;
+}
+
+/**
  * SD-LEO-INFRA-EVIDENCE-WRITER-VERDICT-FAIL-LOUD-001 (FR-1/FR-2/FR-3): pure predicate deciding
  * whether the row storeSubAgentResults() just wrote reflects writer MISUSE (an absent/unrecognised
  * input verdict) rather than a legitimate verdict='ERROR' crash report.
@@ -53,6 +81,12 @@ export const LIKELY_VERDICT_FIELDS = ['status', 'overall_status', 'overall_verdi
  * derived from originalVerdictFor()/metadata.verdict_chain, both of which a payload can forge
  * (verdict-chain.js's own docblock documents this exact pre-seeding attack one layer up).
  *
+ * SECURITY (SEC-1, evidence 52cd374f): every caller-controlled value interpolated into the
+ * returned message is routed through safeValue() then JSON.stringify() -- never raw. A raw
+ * newline in a field value could otherwise forge a second physical line matching this script's
+ * own `Stored ... id=...` success format, and a raw ANSI escape sequence could erase the warning
+ * from a human's terminal. JSON.stringify escapes both and supplies its own quoting.
+ *
  * @param {object} rawPayload - the loaded --content payload, as the caller supplied it
  * @param {string|null|undefined} storedVerdict - the verdict column storeSubAgentResults() wrote
  * @param {boolean} [storageTimeout] - true when the row is storeSubAgentResults' synthetic,
@@ -62,18 +96,21 @@ export const LIKELY_VERDICT_FIELDS = ['status', 'overall_status', 'overall_verdi
 export function verdictMisuseMessage(rawPayload, storedVerdict, storageTimeout) {
   if (storedVerdict !== 'ERROR') return null;
   const rawVerdict = rawPayload?.verdict;
-  const normalized = String(rawVerdict ?? '').trim().toUpperCase();
+  const safeRawVerdict = safeValue(rawVerdict ?? '');
+  const normalized = safeRawVerdict.trim().toUpperCase();
   if (VERDICT_VALUES.includes(normalized)) return null;
 
-  const display = rawVerdict === undefined || rawVerdict === null || String(rawVerdict).trim() === '' ? '(absent)' : String(rawVerdict);
+  const isAbsent = rawVerdict === undefined || rawVerdict === null || safeRawVerdict.trim() === '';
+  const display = isAbsent ? '(absent)' : JSON.stringify(safeRawVerdict);
   let message = `[VERDICT_UNRECOGNISED] input verdict=${display} stored=ERROR accepted=${VERDICT_VALUES.join('|')} -- pass a top-level verdict`;
 
   for (const field of LIKELY_VERDICT_FIELDS) {
-    const value = rawPayload?.[field];
-    if (value !== undefined && value !== null && String(value).trim() !== '') {
-      message += ` (found "${field}": "${value}" -- pass "verdict", not "${field}")`;
-      break;
-    }
+    const rawFieldValue = rawPayload?.[field];
+    if (rawFieldValue === undefined || rawFieldValue === null) continue;
+    const safeFieldValue = safeValue(rawFieldValue);
+    if (safeFieldValue.trim() === '') continue;
+    message += ` (found "${field}": ${JSON.stringify(safeFieldValue)} -- pass "verdict", not "${field}")`;
+    break;
   }
 
   if (storageTimeout) message += ' (write timed out -- row not persisted)';

--- a/scripts/store-sub-agent-repo-evidence.js
+++ b/scripts/store-sub-agent-repo-evidence.js
@@ -22,14 +22,75 @@ import { getSupabaseClient } from '../lib/sub-agent-executor/supabase-client.js'
 import { normalizeSDId } from './modules/sd-id-normalizer.js';
 import { loadContentPayload, extractContentArg } from './add-prd-to-database.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+import { VERDICT_VALUES } from '../lib/sub-agents/verdict-chain.js';
+
+/**
+ * SD-LEO-INFRA-EVIDENCE-WRITER-VERDICT-FAIL-LOUD-001 (FR-3): the most plausible non-verdict
+ * top-level field names a caller might mistakenly send instead of `verdict`, ordered by how
+ * often each shape actually appears in this codebase's real sub-agent payloads (lib/sub-agents/
+ * design/*.js, regression.js, uat.js, testing/phases/*.js, etc). First present, non-empty match
+ * wins -- never auto-mapped to verdict, only named in the guard message (FR-3 DOES-NOT).
+ */
+export const LIKELY_VERDICT_FIELDS = ['status', 'overall_status', 'overall_verdict', 'result', 'outcome', 'passed'];
+
+/**
+ * SD-LEO-INFRA-EVIDENCE-WRITER-VERDICT-FAIL-LOUD-001 (FR-1/FR-2/FR-3): pure predicate deciding
+ * whether the row storeSubAgentResults() just wrote reflects writer MISUSE (an absent/unrecognised
+ * input verdict) rather than a legitimate verdict='ERROR' crash report.
+ *
+ * BOTH conjuncts are independently load-bearing, measured via a live probe against the real
+ * chain (PLAN-phase testing-agent, evidence 4387c4c7) -- not assumed:
+ *   - storedVerdict === 'ERROR' alone is NOT sufficient: a genuine {verdict:'ERROR', ...} crash
+ *     report also stores as 'ERROR' (~77% of the table's historical ERROR population, from the
+ *     exact agent types this CLI names as its intended callers) and must never fire here.
+ *   - rawPayload.verdict not being a VERDICT_VALUES member alone is NOT sufficient: prefix-family
+ *     tokens like 'CONCERNS'/'BLOCK'/'UNKNOWN' are not literal members either, but mapVerdict's
+ *     own classification resolves them to non-ERROR verdicts (CONDITIONAL_PASS/BLOCKED/BLOCKED) --
+ *     this predicate never re-derives that classification itself (TR-1/TR-4: reuse, never
+ *     duplicate mapVerdict), it simply never fires for them because storedVerdict is never 'ERROR'
+ *     for that input in the first place.
+ * rawPayload MUST be the raw, caller-supplied payload (or a shallow copy of it) -- never
+ * derived from originalVerdictFor()/metadata.verdict_chain, both of which a payload can forge
+ * (verdict-chain.js's own docblock documents this exact pre-seeding attack one layer up).
+ *
+ * @param {object} rawPayload - the loaded --content payload, as the caller supplied it
+ * @param {string|null|undefined} storedVerdict - the verdict column storeSubAgentResults() wrote
+ * @param {boolean} [storageTimeout] - true when the row is storeSubAgentResults' synthetic,
+ *   never-actually-persisted statement-timeout fallback (result.storage_timeout === true)
+ * @returns {string|null} the stderr message to emit, or null if this is not a misuse case
+ */
+export function verdictMisuseMessage(rawPayload, storedVerdict, storageTimeout) {
+  if (storedVerdict !== 'ERROR') return null;
+  const rawVerdict = rawPayload?.verdict;
+  const normalized = String(rawVerdict ?? '').trim().toUpperCase();
+  if (VERDICT_VALUES.includes(normalized)) return null;
+
+  const display = rawVerdict === undefined || rawVerdict === null || String(rawVerdict).trim() === '' ? '(absent)' : String(rawVerdict);
+  let message = `[VERDICT_UNRECOGNISED] input verdict=${display} stored=ERROR accepted=${VERDICT_VALUES.join('|')} -- pass a top-level verdict`;
+
+  for (const field of LIKELY_VERDICT_FIELDS) {
+    const value = rawPayload?.[field];
+    if (value !== undefined && value !== null && String(value).trim() !== '') {
+      message += ` (found "${field}": "${value}" -- pass "verdict", not "${field}")`;
+      break;
+    }
+  }
+
+  if (storageTimeout) message += ' (write timed out -- row not persisted)';
+  return message;
+}
 
 export async function main(argv) {
   const [sdId, subAgentCode, ...rest] = argv;
   if (!sdId || !subAgentCode) {
-    throw new Error('Usage: store-sub-agent-repo-evidence.js <SD-ID> <SUB-AGENT-CODE> --content @results.json [--target-application <app>] [--phase <phase>]');
+    throw new Error(
+      'Usage: store-sub-agent-repo-evidence.js <SD-ID> <SUB-AGENT-CODE> --content @results.json [--target-application <app>] [--phase <phase>]\n' +
+      `Accepted verdicts: ${VERDICT_VALUES.join('|')}`
+    );
   }
   const { value: contentArg, remaining } = extractContentArg(rest);
   const results = loadContentPayload(contentArg);
+  const rawPayload = { ...results };
 
   const phaseIdx = remaining.indexOf('--phase');
   const phase = phaseIdx >= 0 ? remaining[phaseIdx + 1] : undefined;
@@ -46,6 +107,13 @@ export async function main(argv) {
   const resolution = await resolveSubAgentRepo({ sdId, targetApplication, subAgentCode, supabase });
   const withEvidence = applySubAgentRepoVerdict(results, resolution);
   const stored = await storeSubAgentResults(subAgentCode, sdId, null, withEvidence, phase ? { phase } : {});
+
+  const misuseMessage = verdictMisuseMessage(rawPayload, stored.verdict, stored.storage_timeout === true);
+  if (misuseMessage) {
+    console.error(misuseMessage);
+    process.exitCode = 1;
+  }
+
   console.log(`Stored ${subAgentCode} evidence for ${sdId}: id=${stored.id}, repo_path=${withEvidence.metadata.repo_path}`);
   return stored;
 }

--- a/tests/unit/store-sub-agent-repo-evidence.test.js
+++ b/tests/unit/store-sub-agent-repo-evidence.test.js
@@ -3,13 +3,25 @@
  * write path for Task-tool-invoked sub-agents. This exercises `main()` end-to-end (content
  * loaded from a real temp file, matching --content @<path> usage, never inline shell JSON)
  * against the same stubbed-network-only supabase pattern as the other results-storage tests.
+ *
+ * SD-LEO-INFRA-EVIDENCE-WRITER-VERDICT-FAIL-LOUD-001: adds coverage for the verdictMisuseMessage
+ * guard -- main() now fails loud (stderr token + process.exitCode=1) when the stored row lands
+ * verdict='ERROR' from an absent/unrecognised input verdict, without false-flagging a genuine
+ * verdict='ERROR' crash report.
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { VERDICT_VALUES } from '../../lib/sub-agents/verdict-chain.js';
 
-function makeMockSupabase(captureTarget) {
+// FR-5/TR-3: save/restore process.exitCode around EVERY test in this file so a guard-fire in
+// one test can never leak into the real test-runner exit code (or into a later test).
+let savedExitCode;
+beforeEach(() => { savedExitCode = process.exitCode; });
+afterEach(() => { process.exitCode = savedExitCode; });
+
+function makeMockSupabase(captureTarget, opts = {}) {
   return {
     from(table) {
       return {
@@ -30,6 +42,13 @@ function makeMockSupabase(captureTarget) {
         insert(record) {
           captureTarget.insertedTable = table;
           captureTarget.inserted = record;
+          if (opts.forceTimeoutError) {
+            return {
+              select() {
+                return { single: async () => ({ data: null, error: { message: 'canceling statement due to statement timeout' } }) };
+              },
+            };
+          }
           const inserted = { id: 'mock-row-id', ...record };
           return {
             select() {
@@ -42,6 +61,85 @@ function makeMockSupabase(captureTarget) {
   };
 }
 
+// TS-1 through TS-4, TS-14, TS-15: pure predicate, zero Supabase mocking. Own describe block,
+// dynamic import scoped to beforeAll/afterAll -- NOT a top-level static import: statically
+// importing store-sub-agent-repo-evidence.js at file-parse time resolves its live
+// getSupabaseClient dependency BEFORE any vi.doMock() call can intercept it, poisoning the
+// module cache for the first main()-integration test below (measured: a real network attempt
+// via UNIT_TIER_NETWORK_REFUSED). afterAll's vi.resetModules() clears that cache before the
+// main()-integration describe's own doMock/import cycle runs (PLAN-phase testing-agent guidance
+// on isolation, refined during EXEC after reproducing the exact failure).
+describe('verdictMisuseMessage() (pure predicate)', () => {
+  let verdictMisuseMessage, LIKELY_VERDICT_FIELDS;
+
+  beforeAll(async () => {
+    const mod = await import('../../scripts/store-sub-agent-repo-evidence.js');
+    verdictMisuseMessage = mod.verdictMisuseMessage;
+    LIKELY_VERDICT_FIELDS = mod.LIKELY_VERDICT_FIELDS;
+  });
+
+  afterAll(() => {
+    vi.resetModules();
+  });
+
+  it('TS-1: does not fire for any VERDICT_VALUES member, storedVerdict paired to the measured-consistent value', () => {
+    for (const v of VERDICT_VALUES) {
+      expect(verdictMisuseMessage({ verdict: v }, v, false)).toBeNull();
+      expect(verdictMisuseMessage({ verdict: v.toLowerCase() }, v, false)).toBeNull();
+      expect(verdictMisuseMessage({ verdict: `  ${v}  ` }, v, false)).toBeNull();
+    }
+  });
+
+  it('TS-2: fires for undefined/null/empty/whitespace-only input verdict (storedVerdict=ERROR, the only value these can measurably produce)', () => {
+    expect(verdictMisuseMessage({}, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(verdictMisuseMessage({ verdict: undefined }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(verdictMisuseMessage({ verdict: null }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(verdictMisuseMessage({ verdict: '' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(verdictMisuseMessage({ verdict: '   ' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+  });
+
+  it('TS-4: fires for genuine garbage and non-string types (storedVerdict=ERROR), never throws', () => {
+    expect(verdictMisuseMessage({ verdict: 'HIGH' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(verdictMisuseMessage({ verdict: 'a prose findings dump, not a verdict' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    for (const bad of [0, false, {}]) {
+      expect(() => verdictMisuseMessage({ verdict: bad }, 'ERROR', false)).not.toThrow();
+      expect(verdictMisuseMessage({ verdict: bad }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    }
+  });
+
+  it('TS-3/TS-11 pointer: does NOT independently classify prefix-family tokens -- that is main()\'s real-chain job, not this predicate\'s', () => {
+    // Given the (unreachable-in-production) pair storedVerdict='ERROR' + a prefix-family token,
+    // the predicate correctly fires -- it never re-derives mapVerdict's classification (TR-1/TR-4).
+    // The claim "CONCERNS/BLOCK/UNKNOWN never cause a real guard fire" is proven at the main()
+    // integration level only, because main()'s real chain never actually produces
+    // storedVerdict='ERROR' for those inputs -- see TS-11 below.
+    expect(verdictMisuseMessage({ verdict: 'CONCERNS' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+  });
+
+  it('TS-14: array-order precedence -- first present field wins, not object key order', () => {
+    const msg = verdictMisuseMessage({ overall_status: 'PASS', status: 'PASS' }, 'ERROR', false);
+    expect(msg).toContain('"status"');
+    expect(msg).not.toContain('"overall_status"');
+  });
+
+  it('TS-15: an empty-string candidate field does not count as present -- scan continues', () => {
+    const msg = verdictMisuseMessage({ status: '', overall_status: 'PASS' }, 'ERROR', false);
+    expect(msg).not.toContain('"status"');
+    expect(msg).toContain('"overall_status"');
+  });
+
+  it('a payload with none of LIKELY_VERDICT_FIELDS omits the naming clause entirely', () => {
+    const msg = verdictMisuseMessage({}, 'ERROR', false);
+    expect(msg).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    for (const field of LIKELY_VERDICT_FIELDS) expect(msg).not.toContain(`"${field}"`);
+  });
+
+  it('the storage_timeout clause is appended when the row was never actually persisted', () => {
+    const msg = verdictMisuseMessage({}, 'ERROR', true);
+    expect(msg).toContain('(write timed out -- row not persisted)');
+  });
+});
+
 describe('store-sub-agent-repo-evidence.js main() (QF-20260702-679)', () => {
   const capture = {};
   let tmpFile;
@@ -53,6 +151,36 @@ describe('store-sub-agent-repo-evidence.js main() (QF-20260702-679)', () => {
     vi.doUnmock('../../lib/sub-agents/resolve-repo.js');
     if (tmpFile && fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
   });
+
+  async function runMain(payload, opts = {}) {
+    capture.inserted = null;
+    tmpFile = path.join(os.tmpdir(), `qf-679-results-${Date.now()}-${Math.floor(Math.random() * 1e6)}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(payload));
+
+    vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeMockSupabase(capture, opts),
+    }));
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => v,
+    }));
+    vi.doMock('../../lib/sub-agents/resolve-repo.js', async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        resolveSubAgentRepo: async () => ({ repoPath: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer', repoResolved: true, registrySource: 'db' }),
+      };
+    });
+
+    const { main } = await import('../../scripts/store-sub-agent-repo-evidence.js');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stored = await main(['SD-TEST-001', 'VALIDATION', '--content', `@${tmpFile}`, '--phase', 'PLAN_VERIFICATION']);
+    const stderrText = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const stdoutText = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+    return { stored, stderrText, stdoutText };
+  }
 
   it('resolves target_application from the SD when not passed, stamps repo evidence, and persists it', async () => {
     capture.inserted = null;
@@ -86,5 +214,87 @@ describe('store-sub-agent-repo-evidence.js main() (QF-20260702-679)', () => {
   it('throws a clear usage error when SD-ID or sub-agent code is missing', async () => {
     const { main } = await import('../../scripts/store-sub-agent-repo-evidence.js');
     await expect(main(['SD-ONLY'])).rejects.toThrow(/Usage:/);
+  });
+
+  it('TS-13: usage error names the accepted verdicts, byte-identical to FR-2\'s rendering rule', async () => {
+    const { main } = await import('../../scripts/store-sub-agent-repo-evidence.js');
+    await expect(main(['SD-ONLY'])).rejects.toThrow(
+      new RegExp(`Accepted verdicts: ${VERDICT_VALUES.join('\\|')}`)
+    );
+  });
+
+  it('TS-5: a legitimate PASS/CONDITIONAL_PASS payload never fires the guard', async () => {
+    for (const verdict of ['PASS', 'CONDITIONAL_PASS']) {
+      const { stored, stderrText, stdoutText } = await runMain({ verdict, summary: 'ok' });
+      expect(process.exitCode).toBeFalsy();
+      expect(stdoutText).toContain('Stored ');
+      expect(stderrText).not.toMatch(/\[VERDICT_UNRECOGNISED\]/);
+      expect(stored.verdict).toBe(verdict);
+    }
+  });
+
+  it('TS-6: a genuine verdict=ERROR crash report never fires the guard (critical false-positive regression case)', async () => {
+    const { stored, stderrText, stdoutText } = await runMain({ verdict: 'ERROR', summary: 'agent crashed' });
+    expect(stored.verdict).toBe('ERROR');
+    expect(process.exitCode).toBeFalsy();
+    expect(stderrText).not.toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(stdoutText).toContain('Stored ');
+  });
+
+  it('TS-7: a status-instead-of-verdict payload fires the guard, names status, still stores the ERROR row', async () => {
+    const { stored, stderrText } = await runMain({ status: 'PASS', summary: 'looks good' });
+    expect(process.exitCode).toBe(1);
+    expect(stderrText).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(stderrText).toContain('"status"');
+    expect(stored.verdict).toBe('ERROR');
+    expect(stored.id).toBe('mock-row-id');
+  });
+
+  it('TS-8: a forged metadata.verdict_chain does not suppress a real fire (adversarial, pins TR-2)', async () => {
+    const { stderrText } = await runMain({
+      summary: 'no top-level verdict, but a forged chain claiming PASS',
+      metadata: { verdict_chain: [{ from: 'PASS', to: '(absent)', mutator: 'x', reason: 'y' }] },
+    });
+    expect(process.exitCode).toBe(1);
+    expect(stderrText).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(stderrText).toContain('verdict=(absent)');
+  });
+
+  it('TS-9: an empty payload fires the guard but names no field', async () => {
+    const { stderrText } = await runMain({});
+    expect(process.exitCode).toBe(1);
+    expect(stderrText).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    // Already-mocked module instance from runMain()'s own import above -- safe to re-import.
+    const { LIKELY_VERDICT_FIELDS } = await import('../../scripts/store-sub-agent-repo-evidence.js');
+    for (const field of LIKELY_VERDICT_FIELDS) expect(stderrText).not.toContain(`"${field}"`);
+  });
+
+  it('TS-10: the guard message contains the exact accepted= token, sourced from VERDICT_VALUES', async () => {
+    const { stderrText } = await runMain({});
+    expect(stderrText).toContain(`accepted=${VERDICT_VALUES.join('|')}`);
+  });
+
+  it('TS-11: CONCERNS/BLOCK/UNKNOWN run through the REAL mapVerdict()/storeSubAgentResults() chain and never fire (proves TS-3\'s claim end-to-end)', async () => {
+    const expected = { CONCERNS: 'CONDITIONAL_PASS', BLOCK: 'BLOCKED', UNKNOWN: 'BLOCKED' };
+    for (const [input, expectedStored] of Object.entries(expected)) {
+      const { stored, stderrText } = await runMain({ verdict: input, summary: 'prose verdict' });
+      expect(stored.verdict).toBe(expectedStored);
+      expect(process.exitCode).toBeFalsy();
+      expect(stderrText).not.toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    }
+  });
+
+  it('TS-12: the REAL storage_timeout fallback path carries a distinguishing clause, never claims audit-row existence', async () => {
+    const { stored, stderrText } = await runMain({}, { forceTimeoutError: true });
+    expect(stored.storage_timeout).toBe(true);
+    expect(process.exitCode).toBe(1);
+    expect(stderrText).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(stderrText).toContain('(write timed out -- row not persisted)');
+  });
+
+  it('TS-16: process.exitCode does not leak from the previous (guard-firing) test into this one', async () => {
+    // The prior test (TS-12) fired the guard and set process.exitCode=1. If the file-level
+    // beforeEach/afterEach save-restore did not work, that would still be visible here.
+    expect(process.exitCode).toBeFalsy();
   });
 });

--- a/tests/unit/store-sub-agent-repo-evidence.test.js
+++ b/tests/unit/store-sub-agent-repo-evidence.test.js
@@ -98,13 +98,43 @@ describe('verdictMisuseMessage() (pure predicate)', () => {
     expect(verdictMisuseMessage({ verdict: '   ' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
   });
 
-  it('TS-4: fires for genuine garbage and non-string types (storedVerdict=ERROR), never throws', () => {
+  it('TS-4: fires for genuine garbage and non-string types (storedVerdict=ERROR), never throws for the shapes measured here (0, false, plain {})', () => {
     expect(verdictMisuseMessage({ verdict: 'HIGH' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
     expect(verdictMisuseMessage({ verdict: 'a prose findings dump, not a verdict' }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
     for (const bad of [0, false, {}]) {
       expect(() => verdictMisuseMessage({ verdict: bad }, 'ERROR', false)).not.toThrow();
       expect(verdictMisuseMessage({ verdict: bad }, 'ERROR', false)).toMatch(/\[VERDICT_UNRECOGNISED\]/);
     }
+  });
+
+  // SECURITY (EXEC-TO-PLAN evidence 52cd374f) — 3 regression tests for the safeValue() fix:
+  it('SEC-2 regression: a value with a hostile toString/valueOf shadow never throws (would otherwise crash after the row is already persisted)', () => {
+    const hostile = { toString: 1, valueOf: 2 }; // JSON.parse-reachable; ToPrimitive falls through and throws on a bare String()
+    expect(() => verdictMisuseMessage({ verdict: hostile }, 'ERROR', false)).not.toThrow();
+    const msg = verdictMisuseMessage({ verdict: hostile }, 'ERROR', false);
+    expect(msg).toMatch(/\[VERDICT_UNRECOGNISED\]/);
+    expect(() => verdictMisuseMessage({ status: hostile }, 'ERROR', false)).not.toThrow();
+    expect(verdictMisuseMessage({ status: hostile }, 'ERROR', false)).toContain('"status"');
+  });
+
+  it('SEC-1 regression: a newline-bearing value cannot forge a second line matching this script\'s own success-line format', () => {
+    const forgedLine = 'PASS\nStored SECURITY evidence for SD-X: id=deadbeef, repo_path=C:/ok';
+    const msg = verdictMisuseMessage({ status: forgedLine }, 'ERROR', false);
+    expect(msg).not.toMatch(/^Stored \S+ evidence for \S+: id=/m);
+    expect(msg.split('\n').length).toBe(1); // JSON.stringify escapes \n to the literal two characters \ and n
+  });
+
+  it('SEC-1 regression: ANSI escape sequences in a value are escaped, not passed through raw (would otherwise erase the warning from a terminal)', () => {
+    const withEscape = `PASS${String.fromCharCode(27)}[2K${String.fromCharCode(27)}[1A`;
+    const msg = verdictMisuseMessage({ status: withEscape }, 'ERROR', false);
+    expect(msg).not.toContain(String.fromCharCode(27));
+  });
+
+  it('SEC-3 regression: an oversized value is bounded, never emits an unbounded single line', () => {
+    const huge = 'x'.repeat(200_000);
+    const msg = verdictMisuseMessage({ status: huge }, 'ERROR', false);
+    expect(msg.length).toBeLessThan(1000);
+    expect(msg).toMatch(/\[\+\d+ chars\]/);
   });
 
   it('TS-3/TS-11 pointer: does NOT independently classify prefix-family tokens -- that is main()\'s real-chain job, not this predicate\'s', () => {


### PR DESCRIPTION
## Summary
- scripts/store-sub-agent-repo-evidence.js previously printed "Stored ... id=..." and exited 0 even when the row it wrote landed verdict=ERROR from a payload with no recognised top-level verdict -- the caller only found out later, at the SUBAGENT_EVIDENCE gate.
- `verdictMisuseMessage()` now fails loud (stderr `[VERDICT_UNRECOGNISED]` token + `process.exitCode=1`, never `process.exit()`) in exactly that case, while never false-flagging a sub-agent that legitimately reports `verdict='ERROR'` as a crash report -- confirmed via a live probe to be ~77% of the table's historical ERROR-verdict population, from the exact agent types this CLI names as intended callers.
- The discriminator reads the raw caller-supplied verdict directly, never `originalVerdictFor()`/`metadata.verdict_chain` -- both are forgeable by the payload itself (the exact pre-seeding attack `verdict-chain.js` documents one layer up).
- SECURITY review (EXEC-TO-PLAN, evidence 52cd374f) found the change opens the first path in this writer where a caller-supplied field *value* reaches an output stream; fixed with a `safeValue()` helper (never throws on a hostile `toString`, bounds echoed values to 200 chars, routes every value through `JSON.stringify` so it can't forge a fake success line or hide behind ANSI escapes).

## Test plan
- [x] `npx vitest run tests/unit/store-sub-agent-repo-evidence.test.js` -- 24/24 passing (extended from 2 pre-existing)
- [x] 2 rounds of mutation testing (reverting either guard conjunct, and the security try/catch) confirmed to break the corresponding test
- [x] Zero regressions across 205 tests in 19 files importing `results-storage.js`/`verdict-chain.js`
- [x] LEAD-phase + PLAN-phase + EXEC-phase TESTING sub-agent review (3 independent rounds)
- [x] EXEC-phase SECURITY sub-agent review (CONDITIONAL_PASS, findings fixed same-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)